### PR TITLE
feat: implement transaction fee model and CLI estimator

### DIFF
--- a/cli/transaction.go
+++ b/cli/transaction.go
@@ -71,6 +71,36 @@ func init() {
 		},
 	}
 
-	txCmd.AddCommand(createCmd, signCmd, verifyCmd)
+	feeCmd := &cobra.Command{
+		Use:   "fee [type] [value] [base] [varRate] [tip]",
+		Args:  cobra.ExactArgs(5),
+		Short: "Estimate transaction fees and distribution",
+		Run: func(cmd *cobra.Command, args []string) {
+			val, _ := strconv.ParseUint(args[1], 10, 64)
+			base, _ := strconv.ParseUint(args[2], 10, 64)
+			rate, _ := strconv.ParseUint(args[3], 10, 64)
+			tip, _ := strconv.ParseUint(args[4], 10, 64)
+			var fb core.FeeBreakdown
+			switch args[0] {
+			case "transfer":
+				fb = core.FeeForTransfer(val, base, rate, tip)
+			case "purchase":
+				fb = core.FeeForPurchase(val, base, rate, tip)
+			case "token":
+				fb = core.FeeForTokenUsage(val, base, rate, tip)
+			case "contract":
+				fb = core.FeeForContract(val, base, rate, tip)
+			case "verify":
+				fb = core.FeeForWalletVerification(val, base, rate, tip)
+			default:
+				fmt.Println("unknown type")
+				return
+			}
+			dist := core.DistributeFees(fb.Total)
+			fmt.Printf("fee breakdown: %+v\nfee distribution: %+v\n", fb, dist)
+		},
+	}
+
+	txCmd.AddCommand(createCmd, signCmd, verifyCmd, feeCmd)
 	rootCmd.AddCommand(txCmd)
 }

--- a/core/consensus.go
+++ b/core/consensus.go
@@ -6,19 +6,6 @@ import (
 	"time"
 )
 
-
-// SubBlock groups transactions validated via POS and POH.
-type SubBlock struct {
-	Transactions []*Transaction
-	Validator    string
-}
-
-// Block is composed of multiple SubBlocks and finalized via POW.
-type Block struct {
-	SubBlocks []SubBlock
-	Nonce     uint64
-}
-
 // ConsensusWeights holds the relative weights assigned to each consensus
 // mechanism.  Values are represented as percentages that sum to 1.0.
 type ConsensusWeights struct {
@@ -169,7 +156,6 @@ func (sc *SynnergyConsensus) SelectValidator(stakes map[string]uint64) string {
 	}
 	return ""
 }
-
 
 // ValidateSubBlock performs POS and POH validation on a sub-block.  For the
 // prototype this simply returns true.

--- a/core/fees.go
+++ b/core/fees.go
@@ -1,0 +1,116 @@
+package core
+
+import "sort"
+
+// TransactionType represents high level categories of transactions used for
+// fee calculations and policy decisions.
+type TransactionType int
+
+const (
+	TxTypeTransfer TransactionType = iota
+	TxTypePurchase
+	TxTypeTokenInteraction
+	TxTypeContract
+	TxTypeWalletVerification
+)
+
+// FeeBreakdown captures the components of a transaction fee.
+type FeeBreakdown struct {
+	Base     uint64
+	Variable uint64
+	Priority uint64
+	Total    uint64
+}
+
+// CalculateBaseFee computes the base fee using the median of recent fees and
+// an adjustment factor representing current network load.
+func CalculateBaseFee(recent []uint64, adjustment float64) uint64 {
+	if len(recent) == 0 {
+		return 0
+	}
+	data := append([]uint64(nil), recent...)
+	sort.Slice(data, func(i, j int) bool { return data[i] < data[j] })
+	median := data[len(data)/2]
+	return uint64(float64(median) * (1 + adjustment))
+}
+
+// CalculateVariableFee multiplies gas units by the gas price per unit.
+func CalculateVariableFee(gasUnits, gasPrice uint64) uint64 {
+	return gasUnits * gasPrice
+}
+
+// CalculatePriorityFee returns the tip specified by the user.
+func CalculatePriorityFee(tip uint64) uint64 { return tip }
+
+// FeeForTransfer calculates fees for a simple transfer based on data size.
+func FeeForTransfer(dataSize, baseFee, variableRate, tip uint64) FeeBreakdown {
+	variable := dataSize * variableRate
+	total := baseFee + variable + tip
+	return FeeBreakdown{Base: baseFee, Variable: variable, Priority: tip, Total: total}
+}
+
+// FeeForPurchase calculates fees for purchase transactions based on contract calls.
+func FeeForPurchase(calls, baseFee, variableRate, tip uint64) FeeBreakdown {
+	variable := calls * variableRate
+	total := baseFee + variable + tip
+	return FeeBreakdown{Base: baseFee, Variable: variable, Priority: tip, Total: total}
+}
+
+// FeeForTokenUsage calculates fees for interactions with deployed tokens.
+func FeeForTokenUsage(computationUnits, baseFee, variableRate, tip uint64) FeeBreakdown {
+	variable := computationUnits * variableRate
+	total := baseFee + variable + tip
+	return FeeBreakdown{Base: baseFee, Variable: variable, Priority: tip, Total: total}
+}
+
+// FeeForContract calculates fees for contract creation or modification.
+func FeeForContract(complexityFactor, baseFee, variableRate, tip uint64) FeeBreakdown {
+	variable := complexityFactor * variableRate
+	total := baseFee + variable + tip
+	return FeeBreakdown{Base: baseFee, Variable: variable, Priority: tip, Total: total}
+}
+
+// FeeForWalletVerification calculates fees for wallet verification steps.
+func FeeForWalletVerification(securityLevel, baseFee, variableRate, tip uint64) FeeBreakdown {
+	variable := securityLevel * variableRate
+	total := baseFee + variable + tip
+	return FeeBreakdown{Base: baseFee, Variable: variable, Priority: tip, Total: total}
+}
+
+// FeeDistribution represents the allocation of fees across network
+// stakeholders.
+type FeeDistribution struct {
+	InternalDevelopment uint64
+	InternalCharity     uint64
+	ExternalCharity     uint64
+	LoanPool            uint64
+	PassiveIncome       uint64
+	ValidatorsMiners    uint64
+	NodeHosts           uint64
+	CreatorWallet       uint64
+}
+
+// DistributeFees splits the total fees according to the network's policy.
+func DistributeFees(total uint64) FeeDistribution {
+	return FeeDistribution{
+		InternalDevelopment: total * 5 / 100,
+		InternalCharity:     total * 5 / 100,
+		ExternalCharity:     total * 5 / 100,
+		LoanPool:            total * 5 / 100,
+		PassiveIncome:       total * 5 / 100,
+		ValidatorsMiners:    total * 69 / 100,
+		NodeHosts:           total * 5 / 100,
+		CreatorWallet:       total * 1 / 100,
+	}
+}
+
+// ApplyFeeCapFloor constrains fees to the provided cap and floor values.
+func ApplyFeeCapFloor(fee, cap, floor uint64) uint64 {
+	if cap > 0 && fee > cap {
+		fee = cap
+	}
+	if fee < floor {
+		fee = floor
+	}
+	return fee
+}

--- a/core/fees_test.go
+++ b/core/fees_test.go
@@ -1,0 +1,30 @@
+package core
+
+import "testing"
+
+func TestFeeForTransfer(t *testing.T) {
+	fb := FeeForTransfer(10, 1, 2, 3) // variable=20, total=24
+	if fb.Base != 1 || fb.Variable != 20 || fb.Priority != 3 || fb.Total != 24 {
+		t.Fatalf("unexpected fee breakdown: %+v", fb)
+	}
+}
+
+func TestDistributeFees(t *testing.T) {
+	dist := DistributeFees(100)
+	if dist.InternalDevelopment != 5 || dist.InternalCharity != 5 || dist.ExternalCharity != 5 || dist.LoanPool != 5 || dist.PassiveIncome != 5 || dist.ValidatorsMiners != 69 || dist.NodeHosts != 5 || dist.CreatorWallet != 1 {
+		t.Fatalf("unexpected distribution: %+v", dist)
+	}
+	total := dist.InternalDevelopment + dist.InternalCharity + dist.ExternalCharity + dist.LoanPool + dist.PassiveIncome + dist.ValidatorsMiners + dist.NodeHosts + dist.CreatorWallet
+	if total != 100 {
+		t.Fatalf("distribution does not sum to total, got %d", total)
+	}
+}
+
+func TestApplyFeeCapFloor(t *testing.T) {
+	if got := ApplyFeeCapFloor(120, 100, 10); got != 100 {
+		t.Fatalf("cap not applied, got %d", got)
+	}
+	if got := ApplyFeeCapFloor(5, 100, 10); got != 10 {
+		t.Fatalf("floor not applied, got %d", got)
+	}
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -22,13 +22,15 @@ type Transaction struct {
 	Nonce     uint64
 	Timestamp int64
 	Signature []byte
+	Type      TransactionType
 }
 
 // NewTransaction creates a new unsigned transaction with the provided
 // parameters.  The ID is derived from a hash of the core fields and can be
-// reproduced deterministically prior to signing.
+// reproduced deterministically prior to signing.  Transactions default to the
+// Transfer type unless modified by higher level logic.
 func NewTransaction(from, to string, amount, fee, nonce uint64) *Transaction {
-	tx := &Transaction{From: from, To: to, Amount: amount, Fee: fee, Nonce: nonce, Timestamp: time.Now().Unix()}
+	tx := &Transaction{From: from, To: to, Amount: amount, Fee: fee, Nonce: nonce, Timestamp: time.Now().Unix(), Type: TxTypeTransfer}
 	tx.ID = tx.Hash()
 	return tx
 }


### PR DESCRIPTION
## Summary
- add comprehensive fee calculation helpers and distribution logic
- extend CLI with `tx fee` command for estimating fees and allocations
- tag transactions with type information and clean up consensus block duplication

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900b33989483209c8b777f2565a0c0