### PR TITLE
Implement genesis wallet management and fee distribution CLI

### DIFF
--- a/cli/fees.go
+++ b/cli/fees.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	feeCmd := &cobra.Command{Use: "fees", Short: "Fee distribution utilities"}
+
+	distributeCmd := &cobra.Command{
+		Use:   "distribute [amount]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Distribute fees across genesis wallets",
+		Run: func(cmd *cobra.Command, args []string) {
+			total, _ := strconv.ParseUint(args[0], 10, 64)
+			wallets := core.DefaultGenesisWallets()
+			alloc := core.AllocateToGenesisWallets(total, wallets)
+			fmt.Printf("internal development: %d\n", alloc[wallets.InternalDevelopment])
+			fmt.Printf("internal charity: %d\n", alloc[wallets.InternalCharity])
+			fmt.Printf("external charity: %d\n", alloc[wallets.ExternalCharity])
+			fmt.Printf("loan pool: %d\n", alloc[wallets.LoanPool])
+			fmt.Printf("passive income: %d\n", alloc[wallets.PassiveIncome])
+			fmt.Printf("validators/miners: %d\n", alloc[wallets.ValidatorsMiners])
+			fmt.Printf("node hosts: %d\n", alloc[wallets.NodeHosts])
+			fmt.Printf("creator wallet: %d\n", alloc[wallets.CreatorWallet])
+		},
+	}
+
+	walletsCmd := &cobra.Command{
+		Use:   "wallets",
+		Short: "Display default genesis wallet addresses",
+		Run: func(cmd *cobra.Command, args []string) {
+			w := core.DefaultGenesisWallets()
+			fmt.Printf("genesis: %s\n", w.Genesis)
+			fmt.Printf("internal development: %s\n", w.InternalDevelopment)
+			fmt.Printf("internal charity: %s\n", w.InternalCharity)
+			fmt.Printf("external charity: %s\n", w.ExternalCharity)
+			fmt.Printf("loan pool: %s\n", w.LoanPool)
+			fmt.Printf("passive income: %s\n", w.PassiveIncome)
+			fmt.Printf("validators/miners: %s\n", w.ValidatorsMiners)
+			fmt.Printf("node hosts: %s\n", w.NodeHosts)
+			fmt.Printf("creator wallet: %s\n", w.CreatorWallet)
+		},
+	}
+
+	feeCmd.AddCommand(distributeCmd, walletsCmd)
+	rootCmd.AddCommand(feeCmd)
+}

--- a/core/genesis_wallets.go
+++ b/core/genesis_wallets.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// GenesisWallets holds addresses for initial ecosystem allocations.
+type GenesisWallets struct {
+	Genesis             string
+	InternalDevelopment string
+	InternalCharity     string
+	ExternalCharity     string
+	LoanPool            string
+	PassiveIncome       string
+	ValidatorsMiners    string
+	NodeHosts           string
+	CreatorWallet       string
+}
+
+// hashAddress returns a deterministic hex string for a given label.
+func hashAddress(label string) string {
+	h := sha256.Sum256([]byte(label))
+	return hex.EncodeToString(h[:])
+}
+
+// DefaultGenesisWallets provides the default set of genesis wallet addresses.
+func DefaultGenesisWallets() GenesisWallets {
+	return GenesisWallets{
+		Genesis:             hashAddress("genesis"),
+		InternalDevelopment: hashAddress("internal_development"),
+		InternalCharity:     hashAddress("internal_charity"),
+		ExternalCharity:     hashAddress("external_charity"),
+		LoanPool:            hashAddress("loan_pool"),
+		PassiveIncome:       hashAddress("passive_income"),
+		ValidatorsMiners:    hashAddress("validators_miners"),
+		NodeHosts:           hashAddress("node_hosts"),
+		CreatorWallet:       hashAddress("creator_wallet"),
+	}
+}
+
+// AllocateToGenesisWallets splits total fees across the genesis wallet
+// addresses according to the network's fee distribution policy.
+func AllocateToGenesisWallets(total uint64, wallets GenesisWallets) map[string]uint64 {
+	dist := DistributeFees(total)
+	return map[string]uint64{
+		wallets.InternalDevelopment: dist.InternalDevelopment,
+		wallets.InternalCharity:     dist.InternalCharity,
+		wallets.ExternalCharity:     dist.ExternalCharity,
+		wallets.LoanPool:            dist.LoanPool,
+		wallets.PassiveIncome:       dist.PassiveIncome,
+		wallets.ValidatorsMiners:    dist.ValidatorsMiners,
+		wallets.NodeHosts:           dist.NodeHosts,
+		wallets.CreatorWallet:       dist.CreatorWallet,
+	}
+}

--- a/core/genesis_wallets_test.go
+++ b/core/genesis_wallets_test.go
@@ -1,0 +1,47 @@
+package core
+
+import "testing"
+
+func TestDefaultGenesisWalletsDeterministic(t *testing.T) {
+	w1 := DefaultGenesisWallets()
+	w2 := DefaultGenesisWallets()
+	if w1 != w2 {
+		t.Fatalf("wallets not deterministic: %#v vs %#v", w1, w2)
+	}
+	if w1.Genesis == "" || w1.CreatorWallet == "" {
+		t.Fatalf("wallet addresses should not be empty: %#v", w1)
+	}
+}
+
+func TestAllocateToGenesisWallets(t *testing.T) {
+	wallets := DefaultGenesisWallets()
+	total := uint64(100)
+	alloc := AllocateToGenesisWallets(total, wallets)
+	dist := DistributeFees(total)
+
+	tests := []struct {
+		addr string
+		want uint64
+	}{
+		{wallets.InternalDevelopment, dist.InternalDevelopment},
+		{wallets.InternalCharity, dist.InternalCharity},
+		{wallets.ExternalCharity, dist.ExternalCharity},
+		{wallets.LoanPool, dist.LoanPool},
+		{wallets.PassiveIncome, dist.PassiveIncome},
+		{wallets.ValidatorsMiners, dist.ValidatorsMiners},
+		{wallets.NodeHosts, dist.NodeHosts},
+		{wallets.CreatorWallet, dist.CreatorWallet},
+	}
+
+	var sum uint64
+	for _, tt := range tests {
+		if got := alloc[tt.addr]; got != tt.want {
+			t.Fatalf("allocation mismatch for %s: got %d want %d", tt.addr, got, tt.want)
+		}
+		sum += alloc[tt.addr]
+	}
+	expected := dist.InternalDevelopment + dist.InternalCharity + dist.ExternalCharity + dist.LoanPool + dist.PassiveIncome + dist.ValidatorsMiners + dist.NodeHosts + dist.CreatorWallet
+	if sum != expected {
+		t.Fatalf("total allocation mismatch: got %d want %d", sum, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- add genesis wallet definitions and deterministic address generation
- provide fee allocation logic across genesis wallets
- introduce CLI utilities to view wallets and distribute fees

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900e96c0f88320bed3f5ecc044466c