### PR TITLE
feat: implement gas fee framework

### DIFF
--- a/cli/transaction.go
+++ b/cli/transaction.go
@@ -92,6 +92,8 @@ func init() {
 				fb = core.FeeForContract(val, base, rate, tip)
 			case "verify":
 				fb = core.FeeForWalletVerification(val, base, rate, tip)
+			case "feeless":
+				fb = core.FeeForValidatedTransfer(val, base, rate, tip, true)
 			default:
 				fmt.Println("unknown type")
 				return
@@ -101,6 +103,32 @@ func init() {
 		},
 	}
 
-	txCmd.AddCommand(createCmd, signCmd, verifyCmd, feeCmd)
+	baseFeeCmd := &cobra.Command{
+		Use:   "basefee [adjustment] [fees...]",
+		Args:  cobra.MinimumNArgs(2),
+		Short: "Calculate base fee from recent block fees",
+		Run: func(cmd *cobra.Command, args []string) {
+			adj, _ := strconv.ParseFloat(args[0], 64)
+			var fees []uint64
+			for _, a := range args[1:] {
+				v, _ := strconv.ParseUint(a, 10, 64)
+				fees = append(fees, v)
+			}
+			fmt.Println(core.CalculateBaseFee(fees, adj))
+		},
+	}
+
+	variableFeeCmd := &cobra.Command{
+		Use:   "variablefee [gasUnits] [gasPrice]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Calculate variable fee component",
+		Run: func(cmd *cobra.Command, args []string) {
+			units, _ := strconv.ParseUint(args[0], 10, 64)
+			price, _ := strconv.ParseUint(args[1], 10, 64)
+			fmt.Println(core.CalculateVariableFee(units, price))
+		},
+	}
+
+	txCmd.AddCommand(createCmd, signCmd, verifyCmd, feeCmd, baseFeeCmd, variableFeeCmd)
 	rootCmd.AddCommand(txCmd)
 }

--- a/core/fees_test.go
+++ b/core/fees_test.go
@@ -28,3 +28,49 @@ func TestApplyFeeCapFloor(t *testing.T) {
 		t.Fatalf("floor not applied, got %d", got)
 	}
 }
+
+func TestCalculateBaseFee(t *testing.T) {
+	recent := make([]uint64, 1100)
+	for i := range recent {
+		recent[i] = uint64(i + 1)
+	}
+	fee := CalculateBaseFee(recent, 0.1)
+	if fee != 661 {
+		t.Fatalf("unexpected base fee %d", fee)
+	}
+}
+
+func TestCalculateVariableAndPriorityFee(t *testing.T) {
+	if vf := CalculateVariableFee(10, 5); vf != 50 {
+		t.Fatalf("variable fee incorrect %d", vf)
+	}
+	if pf := CalculatePriorityFee(7); pf != 7 {
+		t.Fatalf("priority fee incorrect %d", pf)
+	}
+}
+
+func TestSpecificFeeCalculations(t *testing.T) {
+	if fb := FeeForPurchase(3, 1, 2, 4); fb.Total != 11 {
+		t.Fatalf("purchase fee incorrect %+v", fb)
+	}
+	if fb := FeeForTokenUsage(3, 1, 2, 4); fb.Total != 11 {
+		t.Fatalf("token fee incorrect %+v", fb)
+	}
+	if fb := FeeForContract(3, 1, 2, 4); fb.Total != 11 {
+		t.Fatalf("contract fee incorrect %+v", fb)
+	}
+	if fb := FeeForWalletVerification(3, 1, 2, 4); fb.Total != 11 {
+		t.Fatalf("verify fee incorrect %+v", fb)
+	}
+}
+
+func TestFeeForValidatedTransfer(t *testing.T) {
+	fb := FeeForValidatedTransfer(10, 1, 2, 3, true)
+	if fb.Total != 0 {
+		t.Fatalf("validated transfer should be free, got %+v", fb)
+	}
+	fb = FeeForValidatedTransfer(10, 1, 2, 3, false)
+	if fb.Total != 24 {
+		t.Fatalf("non-validated transfer fee incorrect %+v", fb)
+	}
+}


### PR DESCRIPTION
## Summary
- implement median-based base fee calculation with 1000 block history and priority/variable fee utilities
- add validated fee-less transfers and expose fee calculators in CLI
- expand unit tests for fee calculations and distribution

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900e791d28832094205cf14182fc69