### PR TITLE
Implement validator security measures

### DIFF
--- a/cli/node.go
+++ b/cli/node.go
@@ -28,7 +28,30 @@ func init() {
 		Short: "Assign stake to an address",
 		Run: func(cmd *cobra.Command, args []string) {
 			amt, _ := strconv.ParseUint(args[1], 10, 64)
-			currentNode.SetStake(args[0], amt)
+			if err := currentNode.SetStake(args[0], amt); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+	slashCmd := &cobra.Command{
+		Use:   "slash [address] [reason]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Slash a validator (reason: double|downtime)",
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[1] {
+			case "double":
+				currentNode.ReportDoubleSign(args[0])
+			case "downtime":
+				currentNode.ReportDowntime(args[0])
+			}
+		},
+	}
+	rehabCmd := &cobra.Command{
+		Use:   "rehab [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Rehabilitate a slashed validator",
+		Run: func(cmd *cobra.Command, args []string) {
+			currentNode.Rehabilitate(args[0])
 		},
 	}
 	addTxCmd := &cobra.Command{
@@ -64,6 +87,6 @@ func init() {
 			fmt.Printf("mined block %s with nonce %d\n", block.Hash, block.Nonce)
 		},
 	}
-	nodeCmd.AddCommand(infoCmd, stakeCmd, addTxCmd, mempoolCmd, mineCmd)
+	nodeCmd.AddCommand(infoCmd, stakeCmd, slashCmd, rehabCmd, addTxCmd, mempoolCmd, mineCmd)
 	rootCmd.AddCommand(nodeCmd)
 }

--- a/core/security_test.go
+++ b/core/security_test.go
@@ -1,0 +1,54 @@
+package core
+
+import "testing"
+
+func TestSetStakeEnforcesMinimum(t *testing.T) {
+	ledger := NewLedger()
+	node := NewNode("n1", "addr", ledger)
+	if err := node.SetStake("v1", MinStake-1); err == nil {
+		t.Fatalf("expected error for stake below minimum")
+	}
+	if err := node.SetStake("v1", MinStake); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSlashingAndRehabilitation(t *testing.T) {
+	ledger := NewLedger()
+	node := NewNode("n1", "addr", ledger)
+	_ = node.SetStake("v1", MinStake*2)
+	node.ReportDoubleSign("v1")
+	if !node.Slashed["v1"] {
+		t.Fatalf("validator should be slashed")
+	}
+	if node.Stakes["v1"] >= MinStake*2 {
+		t.Fatalf("stake not reduced")
+	}
+	node.Rehabilitate("v1")
+	if node.Slashed["v1"] {
+		t.Fatalf("validator should be rehabilitated")
+	}
+}
+
+func TestEligibleStakesExcludesSlashed(t *testing.T) {
+	ledger := NewLedger()
+	node := NewNode("n1", "addr", ledger)
+	_ = node.SetStake("v1", MinStake)
+	_ = node.SetStake("v2", MinStake)
+	node.ReportDowntime("v1")
+	elig := node.eligibleStakes()
+	if _, ok := elig["v1"]; ok {
+		t.Fatalf("slashed validator should not be eligible")
+	}
+	if _, ok := elig["v2"]; !ok {
+		t.Fatalf("validator v2 should be eligible")
+	}
+}
+
+func TestSubBlockSignature(t *testing.T) {
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "val")
+	if !sb.VerifySignature() {
+		t.Fatalf("signature verification failed")
+	}
+}


### PR DESCRIPTION
## Summary
- Enforce validator minimum stake and track slashed validators
- Sign sub-blocks and verify signatures during block production
- Add CLI commands for staking, slashing, and rehabilitation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900e8a6aac8320b07597eed87ac8e8