### PR TITLE
feat: add dynamic fee adjustment and estimator

### DIFF
--- a/cli/fees.go
+++ b/cli/fees.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	feesCmd := &cobra.Command{
+		Use:   "fees",
+		Short: "Estimate transaction fees and provide feedback",
+	}
+
+	estimateCmd := &cobra.Command{
+		Use:   "estimate",
+		Short: "Estimate fees for a transaction",
+		Run: func(cmd *cobra.Command, args []string) {
+			txTypeStr, _ := cmd.Flags().GetString("type")
+			units, _ := cmd.Flags().GetUint64("units")
+			tip, _ := cmd.Flags().GetUint64("tip")
+			load, _ := cmd.Flags().GetFloat64("load")
+
+			var txType core.TransactionType
+			switch txTypeStr {
+			case "transfer":
+				txType = core.TxTypeTransfer
+			case "purchase":
+				txType = core.TxTypePurchase
+			case "token":
+				txType = core.TxTypeTokenInteraction
+			case "contract":
+				txType = core.TxTypeContract
+			case "wallet":
+				txType = core.TxTypeWalletVerification
+			default:
+				fmt.Printf("unknown type %s\n", txTypeStr)
+				return
+			}
+
+			// Placeholder for recent fee data which would be synced from the network.
+			recent := []uint64{1, 2, 1, 2, 1}
+			base := core.CalculateBaseFee(recent, load)
+			base, variable := core.AdjustFeeRates(base, 1, load)
+			fb := core.EstimateFee(txType, units, base, variable, tip)
+			fmt.Printf("Base: %d\nVariable: %d\nPriority: %d\nTotal: %d\n", fb.Base, fb.Variable, fb.Priority, fb.Total)
+		},
+	}
+	estimateCmd.Flags().String("type", "transfer", "transaction type (transfer,purchase,token,contract,wallet)")
+	estimateCmd.Flags().Uint64("units", 1, "units for fee calculation")
+	estimateCmd.Flags().Uint64("tip", 0, "priority fee")
+	estimateCmd.Flags().Float64("load", 0, "network load factor")
+	feesCmd.AddCommand(estimateCmd)
+
+	feedbackCmd := &cobra.Command{
+		Use:   "feedback",
+		Short: "Submit feedback about fee estimates",
+		Run: func(cmd *cobra.Command, args []string) {
+			message, _ := cmd.Flags().GetString("message")
+			fmt.Printf("feedback received: %s\n", message)
+		},
+	}
+	feedbackCmd.Flags().String("message", "", "feedback message")
+	feesCmd.AddCommand(feedbackCmd)
+
+	rootCmd.AddCommand(feesCmd)
+}

--- a/core/fees_test.go
+++ b/core/fees_test.go
@@ -28,3 +28,17 @@ func TestApplyFeeCapFloor(t *testing.T) {
 		t.Fatalf("floor not applied, got %d", got)
 	}
 }
+
+func TestAdjustFeeRates(t *testing.T) {
+	base, variable := AdjustFeeRates(100, 10, 0.5)
+	if base != 150 || variable != 15 {
+		t.Fatalf("unexpected adjusted rates: base=%d variable=%d", base, variable)
+	}
+}
+
+func TestEstimateFee(t *testing.T) {
+	fb := EstimateFee(TxTypePurchase, 2, 1, 3, 1)
+	if fb.Base != 1 || fb.Variable != 6 || fb.Priority != 1 || fb.Total != 8 {
+		t.Fatalf("unexpected estimate: %+v", fb)
+	}
+}


### PR DESCRIPTION
## Summary
- implement dynamic fee adjustment and generic estimation utilities
- expose fee estimation and feedback via CLI
- cover new logic with unit tests

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900ea19a9c8320a86106bc9bf138af