### PR TITLE
Add fee cap/floor policy with CLI flags (stage 6)

### DIFF
--- a/cli/transaction.go
+++ b/cli/transaction.go
@@ -11,6 +11,11 @@ import (
 	"synnergy/core"
 )
 
+var (
+	feeCap   uint64
+	feeFloor uint64
+)
+
 func init() {
 	txCmd := &cobra.Command{
 		Use:   "tx",
@@ -96,10 +101,18 @@ func init() {
 				fmt.Println("unknown type")
 				return
 			}
+			policy := core.FeePolicy{Cap: feeCap, Floor: feeFloor}
+			adj, note := policy.Enforce(fb.Total)
+			fb.Total = adj
+			if note != "" {
+				fmt.Println("note:", note)
+			}
 			dist := core.DistributeFees(fb.Total)
 			fmt.Printf("fee breakdown: %+v\nfee distribution: %+v\n", fb, dist)
 		},
 	}
+	feeCmd.Flags().Uint64Var(&feeCap, "cap", 0, "fee cap")
+	feeCmd.Flags().Uint64Var(&feeFloor, "floor", 0, "fee floor")
 
 	txCmd.AddCommand(createCmd, signCmd, verifyCmd, feeCmd)
 	rootCmd.AddCommand(txCmd)

--- a/core/fees.go
+++ b/core/fees.go
@@ -1,6 +1,9 @@
 package core
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // TransactionType represents high level categories of transactions used for
 // fee calculations and policy decisions.
@@ -113,4 +116,23 @@ func ApplyFeeCapFloor(fee, cap, floor uint64) uint64 {
 		fee = floor
 	}
 	return fee
+}
+
+// FeePolicy defines network-wide fee limits.
+type FeePolicy struct {
+	Cap   uint64
+	Floor uint64
+}
+
+// Enforce applies the cap and floor and returns the adjusted fee along with a
+// message if a threshold was triggered.
+func (p FeePolicy) Enforce(fee uint64) (uint64, string) {
+	adjusted := ApplyFeeCapFloor(fee, p.Cap, p.Floor)
+	var note string
+	if p.Cap > 0 && fee > p.Cap {
+		note = fmt.Sprintf("fee capped at %d", p.Cap)
+	} else if fee < p.Floor {
+		note = fmt.Sprintf("fee raised to floor %d", p.Floor)
+	}
+	return adjusted, note
 }

--- a/core/fees_test.go
+++ b/core/fees_test.go
@@ -28,3 +28,16 @@ func TestApplyFeeCapFloor(t *testing.T) {
 		t.Fatalf("floor not applied, got %d", got)
 	}
 }
+
+func TestFeePolicyEnforce(t *testing.T) {
+	p := FeePolicy{Cap: 100, Floor: 10}
+	if fee, note := p.Enforce(120); fee != 100 || note == "" {
+		t.Fatalf("expected cap enforcement, got %d %q", fee, note)
+	}
+	if fee, note := p.Enforce(5); fee != 10 || note == "" {
+		t.Fatalf("expected floor enforcement, got %d %q", fee, note)
+	}
+	if fee, note := p.Enforce(50); fee != 50 || note != "" {
+		t.Fatalf("unexpected change %d %q", fee, note)
+	}
+}


### PR DESCRIPTION
## Summary
- add `FeePolicy` to apply fee caps and floors with monitoring notes
- expose fee cap/floor flags in `tx fee` CLI command for transparent enforcement
- test fee policy and ensure distribution remains validated

## Testing
- `go test -v ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900eacc0ac832086a8e75cd206e2be