### PR TITLE
feat: add transaction control and privacy

### DIFF
--- a/cli/transaction.go
+++ b/cli/transaction.go
@@ -11,11 +11,12 @@ import (
 	"synnergy/core"
 )
 
+var txCmd = &cobra.Command{
+	Use:   "tx",
+	Short: "Transaction utilities",
+}
+
 func init() {
-	txCmd := &cobra.Command{
-		Use:   "tx",
-		Short: "Transaction utilities",
-	}
 
 	createCmd := &cobra.Command{
 		Use:   "create [from] [to] [amount] [fee] [nonce]",

--- a/cli/tx_control.go
+++ b/cli/tx_control.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	controlCmd := &cobra.Command{
+		Use:   "control",
+		Short: "Advanced transaction controls",
+	}
+
+	scheduleCmd := &cobra.Command{
+		Use:   "schedule [from] [to] [amount] [fee] [nonce] [execUnix]",
+		Args:  cobra.ExactArgs(6),
+		Short: "Schedule a transaction for future execution",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[2], 10, 64)
+			fee, _ := strconv.ParseUint(args[3], 10, 64)
+			nonce, _ := strconv.ParseUint(args[4], 10, 64)
+			exec, _ := strconv.ParseInt(args[5], 10, 64)
+			tx := core.NewTransaction(args[0], args[1], amt, fee, nonce)
+			st := core.ScheduleTransaction(tx, time.Unix(exec, 0))
+			fmt.Printf("scheduled tx %s for %s\n", st.Tx.ID, st.ExecuteAt)
+		},
+	}
+
+	cancelCmd := &cobra.Command{
+		Use:   "cancel [from] [to] [amount] [fee] [nonce] [execUnix]",
+		Args:  cobra.ExactArgs(6),
+		Short: "Schedule and then cancel a transaction",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[2], 10, 64)
+			fee, _ := strconv.ParseUint(args[3], 10, 64)
+			nonce, _ := strconv.ParseUint(args[4], 10, 64)
+			exec, _ := strconv.ParseInt(args[5], 10, 64)
+			tx := core.NewTransaction(args[0], args[1], amt, fee, nonce)
+			st := core.ScheduleTransaction(tx, time.Unix(exec, 0))
+			canceled := core.CancelTransaction(st)
+			fmt.Printf("canceled: %v\n", canceled)
+		},
+	}
+
+	reverseCmd := &cobra.Command{
+		Use:   "reverse [from] [to] [amount] [fee] [nonce]",
+		Args:  cobra.ExactArgs(5),
+		Short: "Apply then reverse a transaction on a fresh ledger",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[2], 10, 64)
+			fee, _ := strconv.ParseUint(args[3], 10, 64)
+			nonce, _ := strconv.ParseUint(args[4], 10, 64)
+			l := core.NewLedger()
+			l.Credit(args[0], amt+fee)
+			tx := core.NewTransaction(args[0], args[1], amt, fee, nonce)
+			if err := l.ApplyTransaction(tx); err != nil {
+				fmt.Println("apply err:", err)
+				return
+			}
+			if err := core.ReverseTransaction(l, tx); err != nil {
+				fmt.Println("reverse err:", err)
+				return
+			}
+			fmt.Printf("balances after reverse: %s=%d %s=%d\n", args[0], l.GetBalance(args[0]), args[1], l.GetBalance(args[1]))
+		},
+	}
+
+	privateCmd := &cobra.Command{
+		Use:   "private [from] [to] [amount] [fee] [nonce] [keyhex]",
+		Args:  cobra.ExactArgs(6),
+		Short: "Convert a transaction to private and decrypt it",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[2], 10, 64)
+			fee, _ := strconv.ParseUint(args[3], 10, 64)
+			nonce, _ := strconv.ParseUint(args[4], 10, 64)
+			key, _ := hex.DecodeString(args[5])
+			tx := core.NewTransaction(args[0], args[1], amt, fee, nonce)
+			pt, err := core.ConvertToPrivate(tx, key)
+			if err != nil {
+				fmt.Println("private err:", err)
+				return
+			}
+			dec, err := pt.Decrypt(key)
+			if err != nil {
+				fmt.Println("decrypt err:", err)
+				return
+			}
+			fmt.Printf("private payload %x decrypted tx %s->%s\n", pt.Payload, dec.From, dec.To)
+		},
+	}
+
+	receiptCmd := &cobra.Command{
+		Use:   "receipt [txid] [status] [details]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Generate and store a transaction receipt",
+		Run: func(cmd *cobra.Command, args []string) {
+			r := core.GenerateReceipt(args[0], args[1], args[2])
+			store := core.NewReceiptStore()
+			store.Store(r)
+			got, _ := store.Get(args[0])
+			fmt.Printf("receipt: %+v\n", got)
+		},
+	}
+
+	controlCmd.AddCommand(scheduleCmd, cancelCmd, reverseCmd, privateCmd, receiptCmd)
+	txCmd.AddCommand(controlCmd)
+}

--- a/core/transaction_control.go
+++ b/core/transaction_control.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ScheduledTransaction represents a transaction scheduled for future execution.
+// It can be cancelled prior to the ExecuteAt time.
+type ScheduledTransaction struct {
+	Tx        *Transaction
+	ExecuteAt time.Time
+	Canceled  bool
+}
+
+// ScheduleTransaction creates a scheduled transaction wrapper.
+func ScheduleTransaction(tx *Transaction, exec time.Time) *ScheduledTransaction {
+	return &ScheduledTransaction{Tx: tx, ExecuteAt: exec}
+}
+
+// CancelTransaction marks the scheduled transaction as cancelled if it
+// has not yet reached its execution time.
+func CancelTransaction(st *ScheduledTransaction) bool {
+	if time.Now().Before(st.ExecuteAt) && !st.Canceled {
+		st.Canceled = true
+		return true
+	}
+	return false
+}
+
+// ReverseTransaction reverses a previously applied transaction. It returns an
+// error if the recipient lacks sufficient funds.
+func ReverseTransaction(l *Ledger, tx *Transaction) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	total := tx.Amount + tx.Fee
+	if l.balances[tx.To] < tx.Amount {
+		return errors.New("insufficient recipient funds")
+	}
+	l.balances[tx.To] -= tx.Amount
+	l.balances[tx.From] += total
+	return nil
+}
+
+// PrivateTransaction contains encrypted transaction payload.
+type PrivateTransaction struct {
+	Payload []byte
+	Nonce   []byte
+}
+
+// ConvertToPrivate encrypts the transaction using AES-CTR with the provided key.
+func ConvertToPrivate(tx *Transaction, key []byte) (*PrivateTransaction, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(tx)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	stream := cipher.NewCTR(block, nonce)
+	payload := make([]byte, len(b))
+	stream.XORKeyStream(payload, b)
+	return &PrivateTransaction{Payload: payload, Nonce: nonce}, nil
+}
+
+// Decrypt decrypts the private transaction using the same key used for
+// encryption.
+func (pt *PrivateTransaction) Decrypt(key []byte) (*Transaction, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	stream := cipher.NewCTR(block, pt.Nonce)
+	b := make([]byte, len(pt.Payload))
+	stream.XORKeyStream(b, pt.Payload)
+	var tx Transaction
+	if err := json.Unmarshal(b, &tx); err != nil {
+		return nil, err
+	}
+	return &tx, nil
+}
+
+// Receipt captures the outcome of a transaction.
+type Receipt struct {
+	TxID      string
+	Status    string
+	Timestamp int64
+	Details   string
+}
+
+// GenerateReceipt creates a receipt for the given transaction ID and status.
+func GenerateReceipt(txID, status, details string) Receipt {
+	return Receipt{TxID: txID, Status: status, Timestamp: time.Now().Unix(), Details: details}
+}
+
+// ReceiptStore provides thread-safe storage for receipts.
+type ReceiptStore struct {
+	mu   sync.RWMutex
+	data map[string]Receipt
+}
+
+// NewReceiptStore constructs an empty receipt store.
+func NewReceiptStore() *ReceiptStore {
+	return &ReceiptStore{data: make(map[string]Receipt)}
+}
+
+// Store saves a receipt in the store.
+func (rs *ReceiptStore) Store(r Receipt) {
+	rs.mu.Lock()
+	rs.data[r.TxID] = r
+	rs.mu.Unlock()
+}
+
+// Get retrieves a receipt by transaction ID.
+func (rs *ReceiptStore) Get(id string) (Receipt, bool) {
+	rs.mu.RLock()
+	r, ok := rs.data[id]
+	rs.mu.RUnlock()
+	return r, ok
+}
+
+// Search returns all receipts containing the keyword in any field.
+func (rs *ReceiptStore) Search(keyword string) []Receipt {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	var res []Receipt
+	for _, r := range rs.data {
+		if strings.Contains(r.TxID, keyword) || strings.Contains(r.Status, keyword) || strings.Contains(r.Details, keyword) {
+			res = append(res, r)
+		}
+	}
+	return res
+}

--- a/core/transaction_control_test.go
+++ b/core/transaction_control_test.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestScheduleAndCancel(t *testing.T) {
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	exec := time.Now().Add(time.Hour)
+	st := ScheduleTransaction(tx, exec)
+	if !CancelTransaction(st) {
+		t.Fatal("expected cancel to succeed")
+	}
+	if !st.Canceled {
+		t.Fatal("scheduled transaction not marked canceled")
+	}
+}
+
+func TestReverseTransaction(t *testing.T) {
+	l := NewLedger()
+	l.Credit("a", 20)
+	tx := NewTransaction("a", "b", 10, 2, 0)
+	if err := l.ApplyTransaction(tx); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := ReverseTransaction(l, tx); err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if l.GetBalance("a") != 20 || l.GetBalance("b") != 0 {
+		t.Fatalf("unexpected balances: a=%d b=%d", l.GetBalance("a"), l.GetBalance("b"))
+	}
+}
+
+func TestConvertToPrivate(t *testing.T) {
+	key := []byte("example key 1234")
+	tx := NewTransaction("a", "b", 5, 1, 0)
+	pt, err := ConvertToPrivate(tx, key)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	dec, err := pt.Decrypt(key)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if dec.ID != tx.ID {
+		t.Fatalf("expected %s got %s", tx.ID, dec.ID)
+	}
+}
+
+func TestReceiptStore(t *testing.T) {
+	rs := NewReceiptStore()
+	r := GenerateReceipt("tx1", "ok", "details")
+	rs.Store(r)
+	if _, ok := rs.Get("tx1"); !ok {
+		t.Fatal("receipt not stored")
+	}
+	res := rs.Search("ok")
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result got %d", len(res))
+	}
+}


### PR DESCRIPTION
## Summary
- add transaction scheduling, cancellation, reversal, private encryption, and receipt storage utilities
- expose `tx` command and add CLI support for advanced transaction controls
- cover new functionality with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900ecdc0d48320b0646d513e9406cd