### PR TITLE
feat: add basic SNVM arithmetic interpreter

### DIFF
--- a/cli/snvm.go
+++ b/cli/snvm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"synnergy/core"
@@ -14,18 +15,46 @@ func init() {
 		Use:   "snvm",
 		Short: "Interact with the Synnergy VM",
 	}
+
 	execCmd := &cobra.Command{
-		Use:   "exec",
-		Short: "Execute a no-op transaction",
+		Use:   "exec [add|sub|mul|div] <a> <b>",
+		Short: "Execute a simple arithmetic program",
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opStr, aStr, bStr := args[0], args[1], args[2]
+			a, err := strconv.ParseInt(aStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid operand a: %w", err)
+			}
+			b, err := strconv.ParseInt(bStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid operand b: %w", err)
+			}
+			var op core.Opcode
+			switch opStr {
+			case "add":
+				op = core.OpAdd
+			case "sub":
+				op = core.OpSub
+			case "mul":
+				op = core.OpMul
+			case "div":
+				op = core.OpDiv
+			default:
+				return fmt.Errorf("unknown opcode %s", opStr)
+			}
+
 			tx := core.NewTransaction("", "", 0, 0, 0)
-			if err := vm.Execute(tx); err != nil {
+			tx.Program = []core.Instruction{{Op: core.OpPush, Value: a}, {Op: core.OpPush, Value: b}, {Op: op}}
+			res, err := vm.Execute(tx)
+			if err != nil {
 				return err
 			}
-			fmt.Println("executed")
+			fmt.Println(res)
 			return nil
 		},
 	}
+
 	snvmCmd.AddCommand(execCmd)
 	rootCmd.AddCommand(snvmCmd)
 }

--- a/core/instruction.go
+++ b/core/instruction.go
@@ -1,0 +1,9 @@
+package core
+
+// Instruction represents a single operation and optional value for the
+// Synnergy Virtual Machine.  Only OpPush utilises the Value field.
+// Other opcodes operate purely on the VM stack.
+type Instruction struct {
+	Op    Opcode
+	Value int64
+}

--- a/core/opcode.go
+++ b/core/opcode.go
@@ -1,9 +1,25 @@
 package core
 
 // Opcode defines the set of operations understood by the SNVM.
+//
+// The opcodes below provide a very small but functional instruction set for
+// demonstration and testing of the virtual machine.  They intentionally mirror
+// common arithmetic instructions one might find in a typical stack based VM.
+// Additional instructions can be added over time as the SNVM grows.
 type Opcode byte
 
 const (
-	OpNoop Opcode = iota
+	OpNoop Opcode = iota // no operation
+
+	// Stack / arithmetic operations
+	OpPush // push literal onto the stack
+	OpAdd  // pop two values, push a + b
+	OpSub  // pop two values, push a - b
+	OpMul  // pop two values, push a * b
+	OpDiv  // pop two values, push a / b
+
+	// Application level operation used elsewhere in the codebase.  It is
+	// retained to maintain compatibility with existing modules such as the
+	// gas accounting logic.
 	OpTransfer
 )

--- a/core/snvm.go
+++ b/core/snvm.go
@@ -1,13 +1,58 @@
 package core
 
+import "fmt"
+
 // SNVM represents the Synnergy Network Virtual Machine.
+// Currently it operates as a very small stack machine used for executing
+// arithmetic instructions contained within a Transaction's Program field.
+// The structure is intentionally lightweight but can be extended with state or
+// configuration as the VM evolves.
 type SNVM struct{}
 
 // NewSNVM creates a new virtual machine instance.
 func NewSNVM() *SNVM { return &SNVM{} }
 
-// Execute runs the opcodes associated with a transaction.
-func (vm *SNVM) Execute(tx *Transaction) error {
-	// TODO: implement opcode execution
-	return nil
+// Execute runs the opcodes associated with a transaction.  The function returns
+// the top of the VM stack after execution or zero if the program produced no
+// result.  Errors are returned for invalid programs such as stack underflows or
+// division by zero.
+func (vm *SNVM) Execute(tx *Transaction) (int64, error) {
+	var stack []int64
+	for _, ins := range tx.Program {
+		switch ins.Op {
+		case OpNoop:
+			// do nothing
+		case OpPush:
+			stack = append(stack, ins.Value)
+		case OpAdd, OpSub, OpMul, OpDiv:
+			if len(stack) < 2 {
+				return 0, fmt.Errorf("stack underflow")
+			}
+			b := stack[len(stack)-1]
+			a := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			var res int64
+			switch ins.Op {
+			case OpAdd:
+				res = a + b
+			case OpSub:
+				res = a - b
+			case OpMul:
+				res = a * b
+			case OpDiv:
+				if b == 0 {
+					return 0, fmt.Errorf("division by zero")
+				}
+				res = a / b
+			}
+			stack = append(stack, res)
+		default:
+			return 0, fmt.Errorf("unknown opcode %d", ins.Op)
+		}
+	}
+
+	if len(stack) == 0 {
+		return 0, nil
+	}
+	return stack[len(stack)-1], nil
 }

--- a/core/snvm_test.go
+++ b/core/snvm_test.go
@@ -1,0 +1,31 @@
+package core
+
+import "testing"
+
+func TestSNVMArithmetic(t *testing.T) {
+	vm := NewSNVM()
+	tx := &Transaction{Program: []Instruction{
+		{Op: OpPush, Value: 2},
+		{Op: OpPush, Value: 3},
+		{Op: OpAdd},
+	}}
+	res, err := vm.Execute(tx)
+	if err != nil {
+		t.Fatalf("execution error: %v", err)
+	}
+	if res != 5 {
+		t.Fatalf("expected 5, got %d", res)
+	}
+}
+
+func TestSNVMDivideByZero(t *testing.T) {
+	vm := NewSNVM()
+	tx := &Transaction{Program: []Instruction{
+		{Op: OpPush, Value: 10},
+		{Op: OpPush, Value: 0},
+		{Op: OpDiv},
+	}}
+	if _, err := vm.Execute(tx); err == nil {
+		t.Fatalf("expected division by zero error")
+	}
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -23,6 +23,11 @@ type Transaction struct {
 	Timestamp int64
 	Signature []byte
 	Type      TransactionType
+
+	// Program holds optional bytecode instructions to be executed by the
+	// Synnergy Virtual Machine.  Traditional transfer transactions will
+	// leave this field nil.
+	Program []Instruction
 }
 
 // NewTransaction creates a new unsigned transaction with the provided


### PR DESCRIPTION
## Summary
- extend SNVM opcode set with stack-based arithmetic operations
- add transaction program field and VM interpreter for arithmetic execution
- expose arithmetic execution via CLI `snvm exec`

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900f3f09e0832087cd043e882c0485