### PR TITLE
Add comprehensive core tests

### DIFF
--- a/core/block_test.go
+++ b/core/block_test.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+    "crypto/sha256"
+    "encoding/hex"
+    "fmt"
+    "testing"
+)
+
+func TestSubBlockCreationAndVerification(t *testing.T) {
+    tx := NewTransaction("a", "b", 1, 0, 0)
+    sb := NewSubBlock([]*Transaction{tx}, "val")
+    if sb.PohHash != sb.Hash() {
+        t.Fatalf("poh hash not set correctly")
+    }
+    if !sb.VerifySignature() {
+        t.Fatalf("signature verification failed")
+    }
+}
+
+func TestBlockHeaderHash(t *testing.T) {
+    tx := NewTransaction("a", "b", 1, 0, 0)
+    sb := NewSubBlock([]*Transaction{tx}, "v1")
+    b := NewBlock([]*SubBlock{sb}, "prevhash")
+    nonce := uint64(7)
+    got := b.HeaderHash(nonce)
+    h := sha256.New()
+    h.Write([]byte("prevhash"))
+    h.Write([]byte(sb.PohHash))
+    h.Write([]byte(fmt.Sprintf("%d%d", b.Timestamp, nonce)))
+    expected := hex.EncodeToString(h.Sum(nil))
+    if got != expected {
+        t.Fatalf("header hash mismatch")
+    }
+}
+

--- a/core/coin_test.go
+++ b/core/coin_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+    "math"
+    "testing"
+)
+
+func TestBlockRewardHalving(t *testing.T) {
+    if BlockReward(0) != InitialBlockReward {
+        t.Fatalf("unexpected reward at height 0")
+    }
+    if BlockReward(HalvingInterval) != InitialBlockReward/2 {
+        t.Fatalf("reward not halved at interval")
+    }
+}
+
+func TestCirculatingAndRemainingSupply(t *testing.T) {
+    height := uint64(2)
+    expected := GenesisAllocation + BlockReward(0) + BlockReward(1)
+    if got := CirculatingSupply(height); got != expected {
+        t.Fatalf("circulating supply %d != %d", got, expected)
+    }
+    if rem := RemainingSupply(height); rem != MaxSupply-expected {
+        t.Fatalf("remaining supply %d != %d", rem, MaxSupply-expected)
+    }
+}
+
+func TestEconomicHelpers(t *testing.T) {
+    if v := InitialPrice(1, 2, 3, 4, 5, 6); math.Abs(v-(1.0+2.0+(3.0*4.0)/5.0)*6.0) > 1e-9 {
+        t.Fatalf("initial price mismatch")
+    }
+    if v := AlphaFactor(1, 2, 3, 4); math.Abs(v-(3.0*1.0+2.0+3.0)/4.0) > 1e-9 {
+        t.Fatalf("alpha factor mismatch")
+    }
+    if v := MinimumStake(100, 10, 5, 2); math.Abs(v-(100.0/(10.0*5.0))*2.0) > 1e-9 {
+        t.Fatalf("minimum stake mismatch")
+    }
+    if MinimumStake(100, 0, 5, 2) != 0 {
+        t.Fatalf("minimum stake should be zero when reward or supply zero")
+    }
+    if v := LockupDuration(10, 2, 4, 0.5); math.Abs(v-(10.0*(2.0/4.0*10.0)+0.5*20.0)) > 1e-9 {
+        t.Fatalf("lockup duration mismatch")
+    }
+    if LockupDuration(10, 2, 0, 0.5) != 10 {
+        t.Fatalf("lockup duration should return base when threshold zero")
+    }
+    ratio := PriceToSupplyRatio(100, 0)
+    if math.Abs(ratio-100.0/float64(CirculatingSupply(0))) > 1e-9 {
+        t.Fatalf("price to supply ratio mismatch")
+    }
+}
+

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+    "math"
+    "testing"
+)
+
+func TestThreshold(t *testing.T) {
+    sc := NewSynnergyConsensus()
+    if sc.Threshold(2, 3) != sc.Alpha*2+sc.Beta*3 {
+        t.Fatalf("threshold calculation incorrect")
+    }
+}
+
+func TestAdjustWeightsAndAvailability(t *testing.T) {
+    sc := NewSynnergyConsensus()
+    sc.SetAvailability(true, false, true)
+    sc.AdjustWeights(0.5, 0.5)
+    if sc.Weights.PoS != 0 {
+        t.Fatalf("PoS weight should be zero when unavailable")
+    }
+    total := sc.Weights.PoW + sc.Weights.PoS + sc.Weights.PoH
+    if math.Abs(total-1) > 1e-9 {
+        t.Fatalf("weights not normalized")
+    }
+}
+
+func TestTransitionThreshold(t *testing.T) {
+    sc := NewSynnergyConsensus()
+    tt := sc.TransitionThreshold(1, 2, 3)
+    expected := sc.Tload(1) + sc.Tsecurity(2) + sc.Tstake(3)
+    if tt != expected {
+        t.Fatalf("transition threshold mismatch")
+    }
+}
+
+func TestDifficultyAdjust(t *testing.T) {
+    sc := NewSynnergyConsensus()
+    if sc.DifficultyAdjust(1, 20, 10) != 2 {
+        t.Fatalf("difficulty adjust incorrect")
+    }
+}
+
+func TestSelectValidator(t *testing.T) {
+    sc := NewSynnergyConsensus()
+    stakes := map[string]uint64{"a": 1, "b": 2}
+    addr := sc.SelectValidator(stakes)
+    if addr != "a" && addr != "b" {
+        t.Fatalf("unexpected validator: %s", addr)
+    }
+    if sc.SelectValidator(map[string]uint64{}) != "" {
+        t.Fatalf("expected empty string when no stakes")
+    }
+}
+

--- a/core/gas_test.go
+++ b/core/gas_test.go
@@ -1,0 +1,17 @@
+package core
+
+import "testing"
+
+func TestDefaultGasTable(t *testing.T) {
+    g := DefaultGasTable()
+    if g[OpNoop] != 1 {
+        t.Fatalf("expected gas 1 for OpNoop")
+    }
+    if g[OpTransfer] != 10 {
+        t.Fatalf("expected gas 10 for OpTransfer")
+    }
+    if g[OpAdd] != 0 {
+        t.Fatalf("expected undefined ops to have zero gas cost")
+    }
+}
+

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -1,0 +1,44 @@
+package core
+
+import "testing"
+
+func TestNewTransactionAndHash(t *testing.T) {
+    tx := NewTransaction("alice", "bob", 10, 1, 0)
+    if tx.ID == "" {
+        t.Fatalf("expected ID to be set")
+    }
+    // ensure hash deterministic
+    fixed := &Transaction{From: "alice", To: "bob", Amount: 10, Fee: 1, Nonce: 0, Timestamp: 42}
+    h1 := fixed.Hash()
+    fixed2 := &Transaction{From: "alice", To: "bob", Amount: 10, Fee: 1, Nonce: 0, Timestamp: 42}
+    h2 := fixed2.Hash()
+    if h1 != h2 {
+        t.Fatalf("expected deterministic hash")
+    }
+}
+
+func TestAttachBiometric(t *testing.T) {
+    svc := NewBiometricService()
+    user := "u1"
+    bio := []byte("fingerprint")
+    svc.Enroll(user, bio)
+
+    tx := NewTransaction("a", "b", 1, 0, 0)
+    origID := tx.ID
+    if err := tx.AttachBiometric(user, bio, svc); err != nil {
+        t.Fatalf("attach biometric failed: %v", err)
+    }
+    if tx.ID == origID {
+        t.Fatalf("transaction ID should change after attaching biometric")
+    }
+    if len(tx.BiometricHash) == 0 {
+        t.Fatalf("biometric hash not set")
+    }
+    if err := tx.AttachBiometric(user, []byte("wrong"), svc); err == nil {
+        t.Fatalf("expected verification failure")
+    }
+    if err := tx.AttachBiometric(user, bio, nil); err == nil {
+        t.Fatalf("expected error when service nil")
+    }
+}
+

--- a/core/wallet_test.go
+++ b/core/wallet_test.go
@@ -1,0 +1,32 @@
+package core
+
+import "testing"
+
+func TestWalletSignAndVerify(t *testing.T) {
+    w1, err := NewWallet()
+    if err != nil {
+        t.Fatalf("failed to create wallet: %v", err)
+    }
+    w2, err := NewWallet()
+    if err != nil {
+        t.Fatalf("failed to create wallet: %v", err)
+    }
+    if w1.Address == w2.Address {
+        t.Fatalf("wallet addresses should be unique")
+    }
+    tx := NewTransaction("a", "b", 1, 0, 0)
+    sig, err := w1.Sign(tx)
+    if err != nil {
+        t.Fatalf("failed to sign transaction: %v", err)
+    }
+    if !VerifySignature(tx, sig, &w1.PrivateKey.PublicKey) {
+        t.Fatalf("signature verification failed")
+    }
+    if VerifySignature(tx, sig, &w2.PrivateKey.PublicKey) {
+        t.Fatalf("verification should fail with wrong public key")
+    }
+    if !tx.Verify(&w1.PrivateKey.PublicKey) {
+        t.Fatalf("tx.Verify should succeed with correct key")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add wallet tests for unique addresses and signature validation
- test transactions for deterministic hashes and biometric attachments
- cover block header hashing, coin economics, consensus weighting, and gas table defaults

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890153fdb688320b3f473a6a4ece163