### PR TITLE
Add forensic and historical node modules

### DIFF
--- a/Nodes/forensic_node.go
+++ b/Nodes/forensic_node.go
@@ -1,0 +1,38 @@
+package nodes
+
+import "time"
+
+// TransactionLite represents the minimal transaction data required for
+// forensic analysis without pulling full ledger state.
+type TransactionLite struct {
+	Hash      string
+	From      string
+	To        string
+	Value     uint64
+	Timestamp time.Time
+}
+
+// NetworkTrace captures a single network level event or message for
+// later inspection by forensic tools.
+type NetworkTrace struct {
+	PeerID    string
+	Event     string
+	Timestamp time.Time
+}
+
+// ForensicNodeInterface defines behaviour for nodes that capture
+// lightweight transaction information and network traces for analysis.
+type ForensicNodeInterface interface {
+	// RecordTransaction stores a minimal representation of a transaction for
+	// later inspection.
+	RecordTransaction(tx TransactionLite) error
+
+	// RecordNetworkTrace stores a network trace or event for later analysis.
+	RecordNetworkTrace(trace NetworkTrace) error
+
+	// Transactions returns the list of recorded transactions.
+	Transactions() []TransactionLite
+
+	// NetworkTraces returns the list of captured network traces.
+	NetworkTraces() []NetworkTrace
+}

--- a/Nodes/historical_node.go
+++ b/Nodes/historical_node.go
@@ -1,0 +1,27 @@
+package nodes
+
+import "time"
+
+// BlockSummary provides the minimal metadata required to reference a
+// block in archival storage.
+type BlockSummary struct {
+	Height    uint64
+	Hash      string
+	Timestamp time.Time
+}
+
+// HistoricalNodeInterface extends NodeInterface with archival
+// functionality for serving historical chain data.
+type HistoricalNodeInterface interface {
+	// ArchiveBlock stores a block summary for long term retrieval.
+	ArchiveBlock(summary BlockSummary) error
+
+	// GetBlockByHeight retrieves a stored block by its height.
+	GetBlockByHeight(height uint64) (BlockSummary, bool)
+
+	// GetBlockByHash retrieves a stored block by its hash.
+	GetBlockByHash(hash string) (BlockSummary, bool)
+
+	// TotalBlocks returns the number of archived blocks.
+	TotalBlocks() int
+}

--- a/core/audit_management.go
+++ b/core/audit_management.go
@@ -1,0 +1,51 @@
+package core
+
+import (
+	"sync"
+	"time"
+)
+
+// AuditEntry records a single audit log event.
+type AuditEntry struct {
+	Address   string
+	Event     string
+	Metadata  map[string]string
+	Timestamp time.Time
+}
+
+// AuditManager coordinates persistent audit logs stored in-memory. In a
+// full implementation entries would be persisted to the ledger.
+type AuditManager struct {
+	mu      sync.RWMutex
+	records map[string][]AuditEntry
+}
+
+// NewAuditManager creates a new AuditManager instance.
+func NewAuditManager() *AuditManager {
+	return &AuditManager{records: make(map[string][]AuditEntry)}
+}
+
+// Log records an audit event for the given address.
+func (m *AuditManager) Log(address, event string, metadata map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry := AuditEntry{
+		Address:   address,
+		Event:     event,
+		Metadata:  metadata,
+		Timestamp: time.Now(),
+	}
+	m.records[address] = append(m.records[address], entry)
+	return nil
+}
+
+// List returns all audit events for the given address.
+func (m *AuditManager) List(address string) []AuditEntry {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entries := m.records[address]
+	// return copy to prevent external mutation
+	out := make([]AuditEntry, len(entries))
+	copy(out, entries)
+	return out
+}

--- a/core/audit_management_test.go
+++ b/core/audit_management_test.go
@@ -1,0 +1,21 @@
+package core
+
+import "testing"
+
+func TestAuditManager_LogAndList(t *testing.T) {
+	m := NewAuditManager()
+	meta := map[string]string{"foo": "bar"}
+	if err := m.Log("addr1", "event1", meta); err != nil {
+		t.Fatalf("log failed: %v", err)
+	}
+	events := m.List("addr1")
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Event != "event1" {
+		t.Fatalf("unexpected event: %s", events[0].Event)
+	}
+	if events[0].Metadata["foo"] != "bar" {
+		t.Fatalf("metadata not stored")
+	}
+}

--- a/core/audit_node.go
+++ b/core/audit_node.go
@@ -1,0 +1,46 @@
+package core
+
+import "errors"
+
+// BootstrapNode defines the minimal behaviour required from a bootstrap
+// node. The concrete implementation is expected to handle network
+// initialisation for peers.
+type BootstrapNode interface {
+	Start() error
+}
+
+// AuditNode ties a BootstrapNode with the AuditManager to provide
+// on-chain audit logging capabilities.
+type AuditNode struct {
+	Bootstrap BootstrapNode
+	Manager   *AuditManager
+}
+
+// NewAuditNode constructs a new AuditNode instance.
+func NewAuditNode(b BootstrapNode, m *AuditManager) *AuditNode {
+	return &AuditNode{Bootstrap: b, Manager: m}
+}
+
+// Start launches the underlying bootstrap node.
+func (n *AuditNode) Start() error {
+	if n.Bootstrap == nil {
+		return errors.New("bootstrap node not configured")
+	}
+	return n.Bootstrap.Start()
+}
+
+// LogEvent records an audit event through the underlying manager.
+func (n *AuditNode) LogEvent(address, event string, metadata map[string]string) error {
+	if n.Manager == nil {
+		return errors.New("audit manager not configured")
+	}
+	return n.Manager.Log(address, event, metadata)
+}
+
+// ListEvents retrieves audit events for an address.
+func (n *AuditNode) ListEvents(address string) []AuditEntry {
+	if n.Manager == nil {
+		return nil
+	}
+	return n.Manager.List(address)
+}

--- a/core/audit_node_test.go
+++ b/core/audit_node_test.go
@@ -1,0 +1,29 @@
+package core
+
+import "testing"
+
+type mockBootstrap struct{ started bool }
+
+func (m *mockBootstrap) Start() error {
+	m.started = true
+	return nil
+}
+
+func TestAuditNode_StartAndLog(t *testing.T) {
+	mgr := NewAuditManager()
+	bs := &mockBootstrap{}
+	node := NewAuditNode(bs, mgr)
+	if err := node.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	if !bs.started {
+		t.Fatalf("bootstrap not started")
+	}
+	if err := node.LogEvent("addr", "evt", nil); err != nil {
+		t.Fatalf("log event failed: %v", err)
+	}
+	events := node.ListEvents("addr")
+	if len(events) != 1 || events[0].Event != "evt" {
+		t.Fatalf("event not recorded")
+	}
+}

--- a/core/historical_node.go
+++ b/core/historical_node.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	nodes "synnergy/Nodes"
+)
+
+// HistoricalNode provides archival functionality for serving historical
+// chain data. It keeps block summaries in memory for quick lookup.
+type HistoricalNode struct {
+	mu       sync.RWMutex
+	byHeight map[uint64]nodes.BlockSummary
+	byHash   map[string]nodes.BlockSummary
+}
+
+// Ensure HistoricalNode implements nodes.HistoricalNodeInterface.
+var _ nodes.HistoricalNodeInterface = (*HistoricalNode)(nil)
+
+// NewHistoricalNode creates an empty HistoricalNode.
+func NewHistoricalNode() *HistoricalNode {
+	return &HistoricalNode{
+		byHeight: make(map[uint64]nodes.BlockSummary),
+		byHash:   make(map[string]nodes.BlockSummary),
+	}
+}
+
+// ArchiveBlock stores a block summary for long term retrieval.
+func (h *HistoricalNode) ArchiveBlock(summary nodes.BlockSummary) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, exists := h.byHeight[summary.Height]; exists {
+		return errors.New("block height already archived")
+	}
+	if _, exists := h.byHash[summary.Hash]; exists {
+		return errors.New("block hash already archived")
+	}
+	h.byHeight[summary.Height] = summary
+	h.byHash[summary.Hash] = summary
+	return nil
+}
+
+// GetBlockByHeight retrieves a stored block by its height.
+func (h *HistoricalNode) GetBlockByHeight(height uint64) (nodes.BlockSummary, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	summary, ok := h.byHeight[height]
+	return summary, ok
+}
+
+// GetBlockByHash retrieves a stored block by its hash.
+func (h *HistoricalNode) GetBlockByHash(hash string) (nodes.BlockSummary, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	summary, ok := h.byHash[hash]
+	return summary, ok
+}
+
+// TotalBlocks returns the number of archived blocks.
+func (h *HistoricalNode) TotalBlocks() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.byHeight)
+}

--- a/core/historical_node_test.go
+++ b/core/historical_node_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	nodes "synnergy/Nodes"
+	"testing"
+	"time"
+)
+
+func TestHistoricalNode_ArchiveAndRetrieve(t *testing.T) {
+	hn := NewHistoricalNode()
+	summary := nodes.BlockSummary{Height: 1, Hash: "abc", Timestamp: time.Now()}
+	if err := hn.ArchiveBlock(summary); err != nil {
+		t.Fatalf("archive failed: %v", err)
+	}
+	if hn.TotalBlocks() != 1 {
+		t.Fatalf("expected 1 block, got %d", hn.TotalBlocks())
+	}
+	if s, ok := hn.GetBlockByHeight(1); !ok || s.Hash != "abc" {
+		t.Fatalf("failed to get by height")
+	}
+	if s, ok := hn.GetBlockByHash("abc"); !ok || s.Height != 1 {
+		t.Fatalf("failed to get by hash")
+	}
+}
+
+func TestHistoricalNode_Duplicate(t *testing.T) {
+	hn := NewHistoricalNode()
+	summary := nodes.BlockSummary{Height: 1, Hash: "abc", Timestamp: time.Now()}
+	if err := hn.ArchiveBlock(summary); err != nil {
+		t.Fatalf("archive failed: %v", err)
+	}
+	if err := hn.ArchiveBlock(summary); err == nil {
+		t.Fatalf("expected duplicate error")
+	}
+}


### PR DESCRIPTION
## Summary
- define forensic and historical node interfaces for capturing minimal transaction and block data
- implement audit manager and node for on-chain audit logging
- add historical node implementation storing block summaries

## Testing
- `go test ./...` *(fails: no required module provides package github.com/sirupsen/logrus; core/gas_table.go:1:2: expected 'package', found 'EOF')*

------
https://chatgpt.com/codex/tasks/task_e_68902634158483208d0309d6ef232d46