### PR TITLE
Add content and data node modules

### DIFF
--- a/content_node.go
+++ b/content_node.go
@@ -1,0 +1,49 @@
+package synnergy
+
+import "sync"
+
+// ContentNetworkNode mirrors basic information about a content node in the network.
+// It tracks which content items are hosted by this node so others can discover
+// available resources.
+type ContentNetworkNode struct {
+	ID      string
+	Address string
+
+	mu       sync.RWMutex
+	contents map[string]ContentMeta
+}
+
+// NewContentNetworkNode creates a registry entry for a content node.
+func NewContentNetworkNode(id, addr string) *ContentNetworkNode {
+	return &ContentNetworkNode{
+		ID:       id,
+		Address:  addr,
+		contents: make(map[string]ContentMeta),
+	}
+}
+
+// Register records the availability of a content item on this node.
+func (n *ContentNetworkNode) Register(meta ContentMeta) {
+	n.mu.Lock()
+	n.contents[meta.ID] = meta
+	n.mu.Unlock()
+}
+
+// Content returns metadata for a hosted content item.
+func (n *ContentNetworkNode) Content(id string) (ContentMeta, bool) {
+	n.mu.RLock()
+	meta, ok := n.contents[id]
+	n.mu.RUnlock()
+	return meta, ok
+}
+
+// List returns all content metadata stored on this node.
+func (n *ContentNetworkNode) List() []ContentMeta {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	out := make([]ContentMeta, 0, len(n.contents))
+	for _, m := range n.contents {
+		out = append(out, m)
+	}
+	return out
+}

--- a/content_node_impl.go
+++ b/content_node_impl.go
@@ -1,0 +1,98 @@
+package synnergy
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"sync"
+)
+
+// ContentNode handles storage of large encrypted content pieces.
+// Data is encrypted using AES-GCM before being persisted in memory.
+type ContentNode struct {
+	mu       sync.RWMutex
+	key      []byte
+	contents map[string][]byte
+	metas    map[string]ContentMeta
+}
+
+// NewContentNode creates a ContentNode using the provided 32-byte AES key.
+func NewContentNode(key []byte) (*ContentNode, error) {
+	if len(key) != 32 {
+		return nil, errors.New("key must be 32 bytes")
+	}
+	return &ContentNode{
+		key:      append([]byte(nil), key...),
+		contents: make(map[string][]byte),
+		metas:    make(map[string]ContentMeta),
+	}, nil
+}
+
+// StoreContent encrypts data, stores it and returns associated metadata.
+func (n *ContentNode) StoreContent(name string, data []byte) (ContentMeta, error) {
+	block, err := aes.NewCipher(n.key)
+	if err != nil {
+		return ContentMeta{}, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return ContentMeta{}, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return ContentMeta{}, err
+	}
+	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+
+	hash := sha256.Sum256(data)
+	id := hex.EncodeToString(hash[:])
+	meta := NewContentMeta(id, name, int64(len(data)), id)
+
+	n.mu.Lock()
+	n.contents[id] = ciphertext
+	n.metas[id] = meta
+	n.mu.Unlock()
+
+	return meta, nil
+}
+
+// RetrieveContent decrypts and returns the plaintext for the given id.
+func (n *ContentNode) RetrieveContent(id string) ([]byte, bool, error) {
+	n.mu.RLock()
+	enc, ok := n.contents[id]
+	n.mu.RUnlock()
+	if !ok {
+		return nil, false, nil
+	}
+
+	block, err := aes.NewCipher(n.key)
+	if err != nil {
+		return nil, false, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, false, err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(enc) < nonceSize {
+		return nil, false, errors.New("ciphertext too short")
+	}
+	nonce, cipherText := enc[:nonceSize], enc[nonceSize:]
+	plain, err := gcm.Open(nil, nonce, cipherText, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	return plain, true, nil
+}
+
+// Meta returns the ContentMeta for the provided id.
+func (n *ContentNode) Meta(id string) (ContentMeta, bool) {
+	n.mu.RLock()
+	meta, ok := n.metas[id]
+	n.mu.RUnlock()
+	return meta, ok
+}

--- a/content_types.go
+++ b/content_types.go
@@ -1,0 +1,31 @@
+package synnergy
+
+import "time"
+
+// ContentMeta describes a piece of content maintained by a ContentNode.
+// It mirrors metadata pinned on-chain allowing nodes to advertise and
+// validate content availability.
+type ContentMeta struct {
+	// ID is a unique identifier derived from the content payload.
+	ID string
+	// Name provides a human readable label for the content.
+	Name string
+	// Size reports the number of bytes in the original data.
+	Size int64
+	// Hash is a SHA-256 hash of the plaintext content encoded as hex.
+	Hash string
+	// Created indicates when the content was first stored.
+	Created time.Time
+}
+
+// NewContentMeta constructs a ContentMeta from basic fields and sets the
+// creation timestamp to the current UTC time.
+func NewContentMeta(id, name string, size int64, hash string) ContentMeta {
+	return ContentMeta{
+		ID:      id,
+		Name:    name,
+		Size:    size,
+		Hash:    hash,
+		Created: time.Now().UTC(),
+	}
+}

--- a/data.go
+++ b/data.go
@@ -1,0 +1,14 @@
+package synnergy
+
+// Opcode identifiers for the content distribution network (CDN) module.
+// These values are reserved for operations that manage large content blobs
+// referenced on-chain. They can be used by higher level components or the
+// virtual machine when encoding actions.
+const (
+	// OpDataAdd registers new content metadata with the network.
+	OpDataAdd uint8 = iota + 0x30
+	// OpDataRemove removes content from the distribution index.
+	OpDataRemove
+	// OpDataPin marks content as pinned so that nodes retain it locally.
+	OpDataPin
+)

--- a/data_distribution.go
+++ b/data_distribution.go
@@ -1,0 +1,48 @@
+package synnergy
+
+import "sync"
+
+// DataSet represents a piece of content offered through the network and the
+// nodes that host it.
+type DataSet struct {
+	Meta  ContentMeta
+	Nodes map[string]struct{}
+}
+
+// DataDistribution keeps track of which nodes serve specific datasets.
+type DataDistribution struct {
+	mu   sync.RWMutex
+	sets map[string]*DataSet
+}
+
+// NewDataDistribution creates an empty DataDistribution registry.
+func NewDataDistribution() *DataDistribution {
+	return &DataDistribution{sets: make(map[string]*DataSet)}
+}
+
+// Offer registers that a node hosts the given content dataset.
+func (d *DataDistribution) Offer(nodeID string, meta ContentMeta) {
+	d.mu.Lock()
+	ds, ok := d.sets[meta.ID]
+	if !ok {
+		ds = &DataSet{Meta: meta, Nodes: make(map[string]struct{})}
+		d.sets[meta.ID] = ds
+	}
+	ds.Nodes[nodeID] = struct{}{}
+	d.mu.Unlock()
+}
+
+// Locations returns the ids of nodes currently hosting the specified dataset.
+func (d *DataDistribution) Locations(contentID string) []string {
+	d.mu.RLock()
+	ds, ok := d.sets[contentID]
+	d.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	nodes := make([]string, 0, len(ds.Nodes))
+	for n := range ds.Nodes {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}

--- a/data_operations.go
+++ b/data_operations.go
@@ -1,0 +1,55 @@
+package synnergy
+
+import (
+	"sync"
+	"time"
+)
+
+// DataFeed holds structured data referenced on chain. It allows concurrent
+// updates and retrieval of key/value pairs representing external datasets.
+type DataFeed struct {
+	ID string
+
+	mu      sync.RWMutex
+	data    map[string]string
+	updated time.Time
+}
+
+// NewDataFeed creates a new DataFeed with the provided identifier.
+func NewDataFeed(id string) *DataFeed {
+	return &DataFeed{ID: id, data: make(map[string]string)}
+}
+
+// Update sets a key/value pair within the feed and records the update time.
+func (f *DataFeed) Update(key, value string) {
+	f.mu.Lock()
+	f.data[key] = value
+	f.updated = time.Now().UTC()
+	f.mu.Unlock()
+}
+
+// Get retrieves a value by key from the feed.
+func (f *DataFeed) Get(key string) (string, bool) {
+	f.mu.RLock()
+	val, ok := f.data[key]
+	f.mu.RUnlock()
+	return val, ok
+}
+
+// Snapshot returns a copy of the feed's current data map.
+func (f *DataFeed) Snapshot() map[string]string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	out := make(map[string]string, len(f.data))
+	for k, v := range f.data {
+		out[k] = v
+	}
+	return out
+}
+
+// LastUpdated returns the timestamp of the most recent update.
+func (f *DataFeed) LastUpdated() time.Time {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.updated
+}

--- a/data_resource_management.go
+++ b/data_resource_management.go
@@ -1,0 +1,59 @@
+package synnergy
+
+import "sync"
+
+// DataResourceManager provides simple key/value storage with byte usage
+// tracking. It is intended for managing content resources referenced by
+// other modules.
+type DataResourceManager struct {
+	mu    sync.RWMutex
+	store map[string][]byte
+	size  int64
+}
+
+// NewDataResourceManager constructs an empty manager instance.
+func NewDataResourceManager() *DataResourceManager {
+	return &DataResourceManager{store: make(map[string][]byte)}
+}
+
+// Put stores data under the given key, replacing any existing entry.
+func (m *DataResourceManager) Put(key string, data []byte) {
+	m.mu.Lock()
+	if old, ok := m.store[key]; ok {
+		m.size -= int64(len(old))
+	}
+	dup := append([]byte(nil), data...)
+	m.store[key] = dup
+	m.size += int64(len(dup))
+	m.mu.Unlock()
+}
+
+// Get retrieves a copy of the data for the specified key.
+func (m *DataResourceManager) Get(key string) ([]byte, bool) {
+	m.mu.RLock()
+	val, ok := m.store[key]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	out := make([]byte, len(val))
+	copy(out, val)
+	return out, true
+}
+
+// Delete removes the key and associated data from the manager.
+func (m *DataResourceManager) Delete(key string) {
+	m.mu.Lock()
+	if v, ok := m.store[key]; ok {
+		m.size -= int64(len(v))
+		delete(m.store, key)
+	}
+	m.mu.Unlock()
+}
+
+// Usage returns the total number of bytes currently stored.
+func (m *DataResourceManager) Usage() int64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.size
+}

--- a/indexing_node.go
+++ b/indexing_node.go
@@ -1,0 +1,54 @@
+package synnergy
+
+import "sync"
+
+// IndexingNode provides fast query capabilities by indexing ledger data into
+// an in-memory key/value store.
+type IndexingNode struct {
+	mu    sync.RWMutex
+	index map[string][]byte
+}
+
+// NewIndexingNode constructs an empty IndexingNode.
+func NewIndexingNode() *IndexingNode {
+	return &IndexingNode{index: make(map[string][]byte)}
+}
+
+// Index inserts or updates the value for a given key.
+func (n *IndexingNode) Index(key string, value []byte) {
+	n.mu.Lock()
+	dup := append([]byte(nil), value...)
+	n.index[key] = dup
+	n.mu.Unlock()
+}
+
+// Query retrieves a copy of the value associated with the key.
+func (n *IndexingNode) Query(key string) ([]byte, bool) {
+	n.mu.RLock()
+	val, ok := n.index[key]
+	n.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	out := make([]byte, len(val))
+	copy(out, val)
+	return out, true
+}
+
+// Remove deletes the key from the index if present.
+func (n *IndexingNode) Remove(key string) {
+	n.mu.Lock()
+	delete(n.index, key)
+	n.mu.Unlock()
+}
+
+// Keys returns a snapshot of all indexed keys.
+func (n *IndexingNode) Keys() []string {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	keys := make([]string, 0, len(n.index))
+	for k := range n.index {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## Summary
- implement content node with AES-GCM storage
- provide metadata, distribution, operations and resource management helpers
- add simple indexing node and opcode constants for content distribution

## Testing
- `go test ./...` *(fails: case-insensitive import collision in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68902c3725b88320af89a9d454da85e2