### PR TITLE
Add networking and P2P modules

### DIFF
--- a/core/connection_pool.go
+++ b/core/connection_pool.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"errors"
+	"sync"
+)
+
+// Connection represents a lightweight placeholder for an outbound connection.
+type Connection struct {
+	ID string
+}
+
+// ConnectionPool manages reusable connections to peers.
+type ConnectionPool struct {
+	mu    sync.Mutex
+	conns map[string]*Connection
+	max   int
+}
+
+// NewConnectionPool creates a pool with a maximum number of connections.
+func NewConnectionPool(max int) *ConnectionPool {
+	if max <= 0 {
+		max = 1
+	}
+	return &ConnectionPool{conns: make(map[string]*Connection), max: max}
+}
+
+// Acquire returns an existing connection for the id or creates a new one if
+// capacity allows.
+func (p *ConnectionPool) Acquire(id string) (*Connection, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if c, ok := p.conns[id]; ok {
+		return c, nil
+	}
+	if len(p.conns) >= p.max {
+		return nil, errors.New("connection pool exhausted")
+	}
+	c := &Connection{ID: id}
+	p.conns[id] = c
+	return c, nil
+}
+
+// Release removes a connection from the pool.
+func (p *ConnectionPool) Release(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.conns, id)
+}
+
+// Size returns the current number of active connections.
+func (p *ConnectionPool) Size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.conns)
+}

--- a/core/connection_pool_test.go
+++ b/core/connection_pool_test.go
@@ -1,0 +1,20 @@
+package core
+
+import "testing"
+
+func TestConnectionPool(t *testing.T) {
+	p := NewConnectionPool(1)
+	if _, err := p.Acquire("a"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := p.Acquire("b"); err == nil {
+		t.Fatalf("expected pool exhaustion error")
+	}
+	if p.Size() != 1 {
+		t.Fatalf("expected size 1, got %d", p.Size())
+	}
+	p.Release("a")
+	if p.Size() != 0 {
+		t.Fatalf("release failed")
+	}
+}

--- a/core/kademlia.go
+++ b/core/kademlia.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"encoding/hex"
+	"math/big"
+	"sync"
+)
+
+// Kademlia provides a minimal key/value store with XOR distance lookups
+// inspired by the Kademlia DHT. It is intended for lightweight peer discovery
+// and metadata storage.
+type Kademlia struct {
+	mu    sync.RWMutex
+	store map[string][]byte
+}
+
+// NewKademlia creates an empty Kademlia table.
+func NewKademlia() *Kademlia {
+	return &Kademlia{store: make(map[string][]byte)}
+}
+
+// Store saves a key/value pair in the DHT.
+func (k *Kademlia) Store(key string, value []byte) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.store[key] = append([]byte(nil), value...)
+}
+
+// FindValue retrieves a value for a given key.
+func (k *Kademlia) FindValue(key string) ([]byte, bool) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	v, ok := k.store[key]
+	if !ok {
+		return nil, false
+	}
+	return append([]byte(nil), v...), true
+}
+
+// Distance returns the XOR distance between two hex encoded identifiers.
+func Distance(a, b string) *big.Int {
+	ab, _ := hex.DecodeString(a)
+	bb, _ := hex.DecodeString(b)
+	// Pad shorter slice
+	if len(ab) > len(bb) {
+		bb = append(make([]byte, len(ab)-len(bb)), bb...)
+	} else if len(bb) > len(ab) {
+		ab = append(make([]byte, len(bb)-len(ab)), ab...)
+	}
+	dist := new(big.Int)
+	for i := 0; i < len(ab); i++ {
+		dist.Lsh(dist, 8)
+		dist.Or(dist, big.NewInt(int64(ab[i]^bb[i])))
+	}
+	return dist
+}

--- a/core/kademlia_test.go
+++ b/core/kademlia_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestKademliaStoreFind(t *testing.T) {
+	k := NewKademlia()
+	k.Store("a1", []byte("value"))
+	v, ok := k.FindValue("a1")
+	if !ok || string(v) != "value" {
+		t.Fatalf("expected to retrieve stored value")
+	}
+}
+
+func TestDistance(t *testing.T) {
+	id1 := hex.EncodeToString([]byte{0x00, 0x01})
+	id2 := hex.EncodeToString([]byte{0x01, 0x01})
+	dist := Distance(id1, id2)
+	if dist.Sign() == 0 {
+		t.Fatalf("expected non-zero distance")
+	}
+}

--- a/core/nat_traversal.go
+++ b/core/nat_traversal.go
@@ -1,0 +1,37 @@
+package core
+
+import "sync"
+
+// NATManager tracks port mappings for nodes operating behind NAT devices. It is
+// a lightweight helper to register and discover externally reachable ports.
+type NATManager struct {
+	mu       sync.RWMutex
+	mappings map[string]int // node id -> external port
+}
+
+// NewNATManager creates an empty NAT manager.
+func NewNATManager() *NATManager {
+	return &NATManager{mappings: make(map[string]int)}
+}
+
+// MapPort records an external port for a node.
+func (n *NATManager) MapPort(id string, port int) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.mappings[id] = port
+}
+
+// GetPort retrieves the mapped port for a node if available.
+func (n *NATManager) GetPort(id string) (int, bool) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	p, ok := n.mappings[id]
+	return p, ok
+}
+
+// RemoveMapping deletes a node's port mapping.
+func (n *NATManager) RemoveMapping(id string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.mappings, id)
+}

--- a/core/nat_traversal_test.go
+++ b/core/nat_traversal_test.go
@@ -1,0 +1,15 @@
+package core
+
+import "testing"
+
+func TestNATManager(t *testing.T) {
+	nm := NewNATManager()
+	nm.MapPort("node1", 3030)
+	if p, ok := nm.GetPort("node1"); !ok || p != 3030 {
+		t.Fatalf("unexpected mapping")
+	}
+	nm.RemoveMapping("node1")
+	if _, ok := nm.GetPort("node1"); ok {
+		t.Fatalf("remove failed")
+	}
+}

--- a/core/peer_management.go
+++ b/core/peer_management.go
@@ -1,0 +1,48 @@
+package core
+
+import "sync"
+
+// PeerManager maintains a simple peer table for discovery and connection
+// management.
+type PeerManager struct {
+	mu    sync.RWMutex
+	peers map[string]string // id -> address
+}
+
+// NewPeerManager creates an empty peer manager.
+func NewPeerManager() *PeerManager {
+	return &PeerManager{peers: make(map[string]string)}
+}
+
+// AddPeer records a peer and its address.
+func (pm *PeerManager) AddPeer(id, addr string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.peers[id] = addr
+}
+
+// RemovePeer deletes a peer from the table.
+func (pm *PeerManager) RemovePeer(id string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	delete(pm.peers, id)
+}
+
+// GetPeer returns the address for the peer if known.
+func (pm *PeerManager) GetPeer(id string) (string, bool) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	addr, ok := pm.peers[id]
+	return addr, ok
+}
+
+// ListPeers returns a slice of all peer identifiers.
+func (pm *PeerManager) ListPeers() []string {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	ids := make([]string, 0, len(pm.peers))
+	for id := range pm.peers {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/core/peer_management_test.go
+++ b/core/peer_management_test.go
@@ -1,0 +1,19 @@
+package core
+
+import "testing"
+
+func TestPeerManager(t *testing.T) {
+	pm := NewPeerManager()
+	pm.AddPeer("p1", "addr1")
+	pm.AddPeer("p2", "addr2")
+	if addr, ok := pm.GetPeer("p1"); !ok || addr != "addr1" {
+		t.Fatalf("peer lookup failed")
+	}
+	if len(pm.ListPeers()) != 2 {
+		t.Fatalf("expected 2 peers")
+	}
+	pm.RemovePeer("p1")
+	if _, ok := pm.GetPeer("p1"); ok {
+		t.Fatalf("remove failed")
+	}
+}

--- a/core/rpc_webrtc.go
+++ b/core/rpc_webrtc.go
@@ -1,0 +1,51 @@
+package core
+
+import "sync"
+
+// WebRTCRPC simulates an RPC mechanism over WebRTC style peer connections. It
+// maintains in-memory channels for peers to exchange messages.
+type WebRTCRPC struct {
+	mu    sync.RWMutex
+	peers map[string]chan []byte
+}
+
+// NewWebRTCRPC creates a new WebRTCRPC instance.
+func NewWebRTCRPC() *WebRTCRPC {
+	return &WebRTCRPC{peers: make(map[string]chan []byte)}
+}
+
+// Connect registers a peer and returns a receive-only channel for incoming
+// messages.
+func (r *WebRTCRPC) Connect(id string) <-chan []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ch := make(chan []byte, 1)
+	r.peers[id] = ch
+	return ch
+}
+
+// Send delivers a message to the specified peer if it exists.
+func (r *WebRTCRPC) Send(id string, msg []byte) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ch, ok := r.peers[id]
+	if !ok {
+		return false
+	}
+	select {
+	case ch <- append([]byte(nil), msg...):
+		return true
+	default:
+		return false
+	}
+}
+
+// Disconnect removes a peer from the RPC network.
+func (r *WebRTCRPC) Disconnect(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if ch, ok := r.peers[id]; ok {
+		close(ch)
+		delete(r.peers, id)
+	}
+}

--- a/core/rpc_webrtc_test.go
+++ b/core/rpc_webrtc_test.go
@@ -1,0 +1,16 @@
+package core
+
+import "testing"
+
+func TestWebRTCRPC(t *testing.T) {
+	rpc := NewWebRTCRPC()
+	recv := rpc.Connect("peer1")
+
+	if ok := rpc.Send("peer1", []byte("hello")); !ok {
+		t.Fatalf("send failed")
+	}
+	msg := <-recv
+	if string(msg) != "hello" {
+		t.Fatalf("unexpected message: %s", msg)
+	}
+}

--- a/core/swarm.go
+++ b/core/swarm.go
@@ -1,0 +1,48 @@
+package core
+
+import "sync"
+
+// Swarm groups nodes to enable coordinated operations and simplified message
+// broadcasting among related participants.
+type Swarm struct {
+	mu    sync.RWMutex
+	nodes map[string]*Node
+}
+
+// NewSwarm creates an empty Swarm instance.
+func NewSwarm() *Swarm {
+	return &Swarm{nodes: make(map[string]*Node)}
+}
+
+// Join adds a node to the swarm.
+func (s *Swarm) Join(n *Node) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodes[n.ID] = n
+}
+
+// Leave removes a node from the swarm by its ID.
+func (s *Swarm) Leave(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.nodes, id)
+}
+
+// Members returns a snapshot slice of nodes currently in the swarm.
+func (s *Swarm) Members() []*Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*Node, 0, len(s.nodes))
+	for _, n := range s.nodes {
+		out = append(out, n)
+	}
+	return out
+}
+
+// Broadcast sends a transaction to all swarm members by invoking AddTransaction
+// on each node. Errors are ignored to keep broadcast best-effort.
+func (s *Swarm) Broadcast(tx *Transaction) {
+	for _, n := range s.Members() {
+		_ = n.AddTransaction(tx)
+	}
+}

--- a/core/swarm_test.go
+++ b/core/swarm_test.go
@@ -1,0 +1,23 @@
+package core
+
+import "testing"
+
+// TestSwarmBroadcast ensures transactions are broadcast to all swarm members.
+func TestSwarmBroadcast(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Credit("alice", 100)
+
+	n1 := NewNode("n1", "addr1", ledger)
+	n2 := NewNode("n2", "addr2", ledger)
+
+	s := NewSwarm()
+	s.Join(n1)
+	s.Join(n2)
+
+	tx := NewTransaction("alice", "bob", 1, 1, 1)
+	s.Broadcast(tx)
+
+	if len(n1.Mempool) != 1 || len(n2.Mempool) != 1 {
+		t.Fatalf("transaction was not broadcast to all nodes")
+	}
+}


### PR DESCRIPTION
## Summary
- add Swarm module for group coordination and broadcasting
- implement Kademlia DHT helper and XOR distance
- add WebRTC-style RPC stub, connection pool, peer manager, and NAT manager

## Testing
- `go test ./...` *(fails: case-insensitive import collision "synnergy/nodes" vs "synnergy/Nodes")*

------
https://chatgpt.com/codex/tasks/task_e_68902c5f2a68832088d3340f9f9eed02