### PR TITLE
Stage 16: add blockchain operations modules

### DIFF
--- a/core/blockchain_compression.go
+++ b/core/blockchain_compression.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+)
+
+// CompressLedger returns the gzip-compressed JSON encoding of the provided ledger.
+func CompressLedger(l *Ledger) ([]byte, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if err := json.NewEncoder(gz).Encode(l); err != nil {
+		_ = gz.Close()
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecompressLedger converts a gzip-compressed JSON blob back into a ledger.
+func DecompressLedger(data []byte) (*Ledger, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	var l Ledger
+	if err := json.NewDecoder(gz).Decode(&l); err != nil {
+		return nil, err
+	}
+	if l.balances == nil {
+		l.balances = make(map[string]uint64)
+	}
+	return &l, nil
+}
+
+// SaveCompressedSnapshot writes a compressed snapshot of the ledger to the given path.
+func SaveCompressedSnapshot(l *Ledger, path string) error {
+	data, err := CompressLedger(l)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// LoadCompressedSnapshot reads a compressed snapshot from disk and returns the decoded ledger.
+func LoadCompressedSnapshot(path string) (*Ledger, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return DecompressLedger(data)
+}

--- a/core/blockchain_compression_test.go
+++ b/core/blockchain_compression_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestLedgerCompressionRoundTrip(t *testing.T) {
+	l := NewLedger()
+	l.Credit("alice", 50)
+	b := NewBlock(nil, "")
+	b.Hash = "gen" // ensure deterministic
+	l.AddBlock(b)
+
+	tmp := t.TempDir() + "/snap.gz"
+	if err := SaveCompressedSnapshot(l, tmp); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+	loaded, err := LoadCompressedSnapshot(tmp)
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+	if h, _ := loaded.Head(); h != 1 {
+		t.Fatalf("expected height 1 got %d", h)
+	}
+	if bal := loaded.GetBalance("alice"); bal != 50 {
+		t.Fatalf("unexpected balance %d", bal)
+	}
+}

--- a/core/blockchain_synchronization.go
+++ b/core/blockchain_synchronization.go
@@ -1,0 +1,48 @@
+package core
+
+import "sync"
+
+// SyncManager coordinates block download and verification to keep a node's
+// ledger in sync with the network. The implementation here tracks state in
+// memory and exposes helpers for the CLI to control the process.
+type SyncManager struct {
+	mu         sync.RWMutex
+	ledger     *Ledger
+	running    bool
+	lastHeight int
+}
+
+// NewSyncManager returns a new SyncManager bound to a ledger.
+func NewSyncManager(l *Ledger) *SyncManager {
+	return &SyncManager{ledger: l}
+}
+
+// Start marks the manager as running.
+func (s *SyncManager) Start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.running = true
+}
+
+// Stop halts synchronization.
+func (s *SyncManager) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.running = false
+}
+
+// Status reports whether synchronization is active and the last synced height.
+func (s *SyncManager) Status() (bool, int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.running, s.lastHeight
+}
+
+// Once performs a single synchronization round by checking the ledger head.
+func (s *SyncManager) Once() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	h, _ := s.ledger.Head()
+	s.lastHeight = h
+	return nil
+}

--- a/core/blockchain_synchronization_test.go
+++ b/core/blockchain_synchronization_test.go
@@ -1,0 +1,29 @@
+package core
+
+import "testing"
+
+func TestSyncManagerLifecycle(t *testing.T) {
+	l := NewLedger()
+	sm := NewSyncManager(l)
+
+	sm.Start()
+	running, _ := sm.Status()
+	if !running {
+		t.Fatalf("expected running")
+	}
+
+	l.AddBlock(&Block{Hash: "b1"})
+	if err := sm.Once(); err != nil {
+		t.Fatalf("once: %v", err)
+	}
+	_, h := sm.Status()
+	if h != 1 {
+		t.Fatalf("expected height 1 got %d", h)
+	}
+
+	sm.Stop()
+	running, _ = sm.Status()
+	if running {
+		t.Fatalf("expected stopped")
+	}
+}

--- a/core/immutability_enforcement.go
+++ b/core/immutability_enforcement.go
@@ -1,0 +1,31 @@
+package core
+
+import "errors"
+
+// ImmutabilityEnforcer ensures the genesis block cannot be altered. It stores
+// the expected hash of the genesis block and verifies ledgers against it.
+type ImmutabilityEnforcer struct {
+	genesisHash string
+}
+
+// NewImmutabilityEnforcer creates an enforcer for the supplied genesis block.
+func NewImmutabilityEnforcer(genesis *Block) *ImmutabilityEnforcer {
+	return &ImmutabilityEnforcer{genesisHash: genesis.Hash}
+}
+
+// ErrGenesisChanged is returned when the stored genesis block hash differs from
+// the ledger's genesis block.
+var ErrGenesisChanged = errors.New("genesis block hash mismatch")
+
+// CheckLedger verifies that the ledger's first block matches the expected
+// genesis hash.
+func (i *ImmutabilityEnforcer) CheckLedger(l *Ledger) error {
+	b, ok := l.GetBlock(1)
+	if !ok {
+		return ErrGenesisChanged
+	}
+	if b.Hash != i.genesisHash {
+		return ErrGenesisChanged
+	}
+	return nil
+}

--- a/core/immutability_enforcement_test.go
+++ b/core/immutability_enforcement_test.go
@@ -1,0 +1,20 @@
+package core
+
+import "testing"
+
+func TestImmutabilityEnforcer(t *testing.T) {
+	genesis := &Block{Hash: "gen"}
+	l := NewLedger()
+	l.AddBlock(genesis)
+
+	enforcer := NewImmutabilityEnforcer(genesis)
+	if err := enforcer.CheckLedger(l); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// modify genesis hash to trigger failure
+	l.blocks[0].Hash = "other"
+	if err := enforcer.CheckLedger(l); err == nil {
+		t.Fatalf("expected mismatch error")
+	}
+}

--- a/core/initialization_replication.go
+++ b/core/initialization_replication.go
@@ -1,0 +1,38 @@
+package core
+
+import "sync"
+
+// InitService bootstraps a ledger using the replication subsystem. It is a
+// thin wrapper around Replicator providing start and stop controls for the CLI.
+type InitService struct {
+	mu         sync.Mutex
+	replicator *Replicator
+	running    bool
+}
+
+// NewInitService creates a new initialization service bound to a replicator.
+func NewInitService(r *Replicator) *InitService {
+	return &InitService{replicator: r}
+}
+
+// Start bootstraps the ledger and starts replication.
+func (i *InitService) Start() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.running {
+		return
+	}
+	i.replicator.Start()
+	i.running = true
+}
+
+// Stop stops the initialization service and replication.
+func (i *InitService) Stop() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if !i.running {
+		return
+	}
+	i.replicator.Stop()
+	i.running = false
+}

--- a/core/initialization_replication_test.go
+++ b/core/initialization_replication_test.go
@@ -1,0 +1,19 @@
+package core
+
+import "testing"
+
+func TestInitServiceStartStop(t *testing.T) {
+	l := NewLedger()
+	r := NewReplicator(l)
+	init := NewInitService(r)
+
+	init.Start()
+	if !r.Status() {
+		t.Fatalf("replicator should be running")
+	}
+
+	init.Stop()
+	if r.Status() {
+		t.Fatalf("replicator should be stopped")
+	}
+}

--- a/core/replication.go
+++ b/core/replication.go
@@ -1,0 +1,50 @@
+package core
+
+import "sync"
+
+// Replicator propagates blocks and snapshots to peers. This simplified
+// implementation tracks replication state for CLI testing.
+type Replicator struct {
+	mu         sync.RWMutex
+	ledger     *Ledger
+	running    bool
+	replicated map[string]bool
+}
+
+// NewReplicator constructs a Replicator bound to a ledger.
+func NewReplicator(l *Ledger) *Replicator {
+	return &Replicator{ledger: l, replicated: make(map[string]bool)}
+}
+
+// Start begins replication processes.
+func (r *Replicator) Start() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.running = true
+}
+
+// Stop halts replication.
+func (r *Replicator) Stop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.running = false
+}
+
+// Status reports whether the replicator is active.
+func (r *Replicator) Status() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.running
+}
+
+// ReplicateBlock marks a block hash as replicated. In a full implementation
+// this would gossip the block to peers.
+func (r *Replicator) ReplicateBlock(hash string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.running {
+		return false
+	}
+	r.replicated[hash] = true
+	return true
+}

--- a/core/replication_test.go
+++ b/core/replication_test.go
@@ -1,0 +1,24 @@
+package core
+
+import "testing"
+
+func TestReplicator(t *testing.T) {
+	l := NewLedger()
+	b := &Block{Hash: "b1"}
+	l.AddBlock(b)
+
+	r := NewReplicator(l)
+	r.Start()
+	if !r.Status() {
+		t.Fatalf("expected running")
+	}
+
+	if !r.ReplicateBlock("b1") {
+		t.Fatalf("replication failed")
+	}
+
+	r.Stop()
+	if r.Status() {
+		t.Fatalf("expected stopped")
+	}
+}


### PR DESCRIPTION
## Summary
- extend ledger with write-ahead logging, block tracking and transfer helpers
- add compression utilities for saving and loading gzip ledger snapshots
- implement sync, replication and initialization services with immutability enforcement
- include unit tests for new modules

## Testing
- `go test ./...` *(fails: case-insensitive import collision in core/base_node.go)*

------
https://chatgpt.com/codex/tasks/task_e_68902c6acaf4832080ceaedb71569f19