### PR TITLE
feat: add compliance and regulatory modules

### DIFF
--- a/core/compliance.go
+++ b/core/compliance.go
@@ -1,0 +1,127 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// KYCRecord stores the commitment for an address and when it was recorded.
+type KYCRecord struct {
+	Commitment string
+	Timestamp  time.Time
+}
+
+// FraudSignal represents a fraud warning with a severity score.
+type FraudSignal struct {
+	Severity  int
+	Timestamp time.Time
+}
+
+// Transaction represents a minimal transaction for compliance checks.
+type Transaction struct {
+	ID     string
+	From   string
+	To     string
+	Amount float64
+}
+
+// ComplianceService manages KYC records and fraud risk scores.
+type ComplianceService struct {
+	mu         sync.RWMutex
+	kycs       map[string]KYCRecord
+	frauds     map[string][]FraudSignal
+	audits     map[string][]AuditEntry
+	riskScores map[string]int
+}
+
+// NewComplianceService creates a new ComplianceService instance.
+func NewComplianceService() *ComplianceService {
+	return &ComplianceService{
+		kycs:       make(map[string]KYCRecord),
+		frauds:     make(map[string][]FraudSignal),
+		audits:     make(map[string][]AuditEntry),
+		riskScores: make(map[string]int),
+	}
+}
+
+// ValidateKYC validates and stores a KYC document commitment for an address.
+func (s *ComplianceService) ValidateKYC(address string, kycData []byte) (string, error) {
+	if address == "" {
+		return "", errors.New("address required")
+	}
+	hash := sha256.Sum256(kycData)
+	commitment := hex.EncodeToString(hash[:])
+	s.mu.Lock()
+	s.kycs[address] = KYCRecord{Commitment: commitment, Timestamp: time.Now()}
+	s.appendAudit(address, "kyc_validated", nil)
+	s.mu.Unlock()
+	return commitment, nil
+}
+
+// EraseKYC removes stored KYC data for an address.
+func (s *ComplianceService) EraseKYC(address string) {
+	s.mu.Lock()
+	delete(s.kycs, address)
+	s.appendAudit(address, "kyc_erased", nil)
+	s.mu.Unlock()
+}
+
+// RecordFraud records a fraud signal and updates the risk score.
+func (s *ComplianceService) RecordFraud(address string, severity int) {
+	s.mu.Lock()
+	sig := FraudSignal{Severity: severity, Timestamp: time.Now()}
+	s.frauds[address] = append(s.frauds[address], sig)
+	s.riskScores[address] += severity
+	meta := map[string]string{"severity": fmt.Sprintf("%d", severity)}
+	s.appendAudit(address, "fraud_signal", meta)
+	s.mu.Unlock()
+}
+
+// RiskScore returns the accumulated fraud risk score for an address.
+func (s *ComplianceService) RiskScore(address string) int {
+	s.mu.RLock()
+	score := s.riskScores[address]
+	s.mu.RUnlock()
+	return score
+}
+
+// AuditTrail returns a copy of the audit trail for an address.
+func (s *ComplianceService) AuditTrail(address string) []AuditEntry {
+	s.mu.RLock()
+	entries := s.audits[address]
+	out := make([]AuditEntry, len(entries))
+	copy(out, entries)
+	s.mu.RUnlock()
+	return out
+}
+
+// MonitorTransaction performs a simple anomaly detection on a transaction amount.
+func (s *ComplianceService) MonitorTransaction(tx Transaction, threshold float64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.appendAudit(tx.From, "tx_monitored", map[string]string{"id": tx.ID})
+	if tx.Amount > threshold {
+		s.appendAudit(tx.From, "tx_anomaly", map[string]string{"id": tx.ID})
+		return true
+	}
+	return false
+}
+
+// VerifyZKP verifies a simple commitment for demonstration purposes.
+func (s *ComplianceService) VerifyZKP(blob []byte, commitmentHex, proofHex string) bool {
+	hash := sha256.Sum256(blob)
+	return hex.EncodeToString(hash[:]) == commitmentHex
+}
+
+func (s *ComplianceService) appendAudit(addr, event string, metadata map[string]string) {
+	s.audits[addr] = append(s.audits[addr], AuditEntry{
+		Address:   addr,
+		Event:     event,
+		Metadata:  metadata,
+		Timestamp: time.Now(),
+	})
+}

--- a/core/compliance_management.go
+++ b/core/compliance_management.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"errors"
+	"sync"
+)
+
+// ComplianceManager manages address suspensions and whitelists.
+type ComplianceManager struct {
+	mu        sync.RWMutex
+	suspended map[string]bool
+	whitelist map[string]bool
+}
+
+// NewComplianceManager creates a new ComplianceManager.
+func NewComplianceManager() *ComplianceManager {
+	return &ComplianceManager{
+		suspended: make(map[string]bool),
+		whitelist: make(map[string]bool),
+	}
+}
+
+// Suspend marks an address as suspended from transfers.
+func (m *ComplianceManager) Suspend(addr string) {
+	m.mu.Lock()
+	m.suspended[addr] = true
+	m.mu.Unlock()
+}
+
+// Resume lifts a suspension for an address.
+func (m *ComplianceManager) Resume(addr string) {
+	m.mu.Lock()
+	delete(m.suspended, addr)
+	m.mu.Unlock()
+}
+
+// Whitelist adds an address to the whitelist.
+func (m *ComplianceManager) Whitelist(addr string) {
+	m.mu.Lock()
+	m.whitelist[addr] = true
+	m.mu.Unlock()
+}
+
+// Unwhitelist removes an address from the whitelist.
+func (m *ComplianceManager) Unwhitelist(addr string) {
+	m.mu.Lock()
+	delete(m.whitelist, addr)
+	m.mu.Unlock()
+}
+
+// Status returns suspension and whitelist status for an address.
+func (m *ComplianceManager) Status(addr string) (suspended, whitelisted bool) {
+	m.mu.RLock()
+	suspended = m.suspended[addr]
+	whitelisted = m.whitelist[addr]
+	m.mu.RUnlock()
+	return
+}
+
+// ReviewTransaction checks if a transaction involves suspended parties.
+func (m *ComplianceManager) ReviewTransaction(tx Transaction) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	parties := []string{tx.From, tx.To}
+	for _, p := range parties {
+		if m.suspended[p] && !m.whitelist[p] {
+			return errors.New("transaction involves suspended address")
+		}
+	}
+	return nil
+}

--- a/core/compliance_management_test.go
+++ b/core/compliance_management_test.go
@@ -1,0 +1,23 @@
+package core
+
+import "testing"
+
+func TestComplianceManager(t *testing.T) {
+	m := NewComplianceManager()
+	m.Suspend("addr1")
+	if s, w := m.Status("addr1"); !s || w {
+		t.Fatalf("unexpected status")
+	}
+	tx := Transaction{From: "addr1", To: "addr2", Amount: 1}
+	if err := m.ReviewTransaction(tx); err == nil {
+		t.Fatalf("expected review error")
+	}
+	m.Whitelist("addr1")
+	if err := m.ReviewTransaction(tx); err != nil {
+		t.Fatalf("review failed after whitelist: %v", err)
+	}
+	m.Resume("addr1")
+	if s, _ := m.Status("addr1"); s {
+		t.Fatalf("suspension not cleared")
+	}
+}

--- a/core/compliance_test.go
+++ b/core/compliance_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestComplianceServiceKYCAndRisk(t *testing.T) {
+	svc := NewComplianceService()
+	if _, err := svc.ValidateKYC("addr1", []byte("kycdata")); err != nil {
+		t.Fatalf("validate kyc: %v", err)
+	}
+	svc.RecordFraud("addr1", 5)
+	if score := svc.RiskScore("addr1"); score != 5 {
+		t.Fatalf("expected risk score 5 got %d", score)
+	}
+	svc.EraseKYC("addr1")
+	if len(svc.AuditTrail("addr1")) == 0 {
+		t.Fatalf("expected audit trail")
+	}
+}
+
+func TestComplianceServiceMonitorTransaction(t *testing.T) {
+	svc := NewComplianceService()
+	tx := Transaction{ID: "tx1", From: "a", Amount: 100}
+	if !svc.MonitorTransaction(tx, 50) {
+		t.Fatalf("expected anomaly detection")
+	}
+}

--- a/core/regulatory_management.go
+++ b/core/regulatory_management.go
@@ -1,0 +1,75 @@
+package core
+
+import (
+	"errors"
+	"sync"
+)
+
+// Regulation defines a basic rule for transaction oversight.
+type Regulation struct {
+	ID           string
+	Jurisdiction string
+	Description  string
+	MaxAmount    float64
+}
+
+// RegulatoryManager stores and evaluates regulations.
+type RegulatoryManager struct {
+	mu          sync.RWMutex
+	regulations map[string]Regulation
+}
+
+// NewRegulatoryManager creates a new RegulatoryManager instance.
+func NewRegulatoryManager() *RegulatoryManager {
+	return &RegulatoryManager{regulations: make(map[string]Regulation)}
+}
+
+// AddRegulation registers a new regulation.
+func (m *RegulatoryManager) AddRegulation(reg Regulation) error {
+	if reg.ID == "" {
+		return errors.New("id required")
+	}
+	m.mu.Lock()
+	m.regulations[reg.ID] = reg
+	m.mu.Unlock()
+	return nil
+}
+
+// RemoveRegulation removes a regulation by ID.
+func (m *RegulatoryManager) RemoveRegulation(id string) {
+	m.mu.Lock()
+	delete(m.regulations, id)
+	m.mu.Unlock()
+}
+
+// GetRegulation retrieves a regulation by ID.
+func (m *RegulatoryManager) GetRegulation(id string) (Regulation, bool) {
+	m.mu.RLock()
+	reg, ok := m.regulations[id]
+	m.mu.RUnlock()
+	return reg, ok
+}
+
+// ListRegulations returns all registered regulations.
+func (m *RegulatoryManager) ListRegulations() []Regulation {
+	m.mu.RLock()
+	regs := make([]Regulation, 0, len(m.regulations))
+	for _, r := range m.regulations {
+		regs = append(regs, r)
+	}
+	m.mu.RUnlock()
+	return regs
+}
+
+// EvaluateTransaction returns IDs of regulations violated by the transaction.
+func (m *RegulatoryManager) EvaluateTransaction(tx Transaction) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var violations []string
+	for id, reg := range m.regulations {
+		if reg.MaxAmount > 0 && tx.Amount > reg.MaxAmount {
+			violations = append(violations, id)
+		}
+	}
+	return violations
+}

--- a/core/regulatory_management_test.go
+++ b/core/regulatory_management_test.go
@@ -1,0 +1,16 @@
+package core
+
+import "testing"
+
+func TestRegulatoryManager(t *testing.T) {
+	m := NewRegulatoryManager()
+	reg := Regulation{ID: "r1", MaxAmount: 100}
+	if err := m.AddRegulation(reg); err != nil {
+		t.Fatalf("add regulation: %v", err)
+	}
+	tx := Transaction{Amount: 150}
+	v := m.EvaluateTransaction(tx)
+	if len(v) != 1 || v[0] != "r1" {
+		t.Fatalf("expected violation r1")
+	}
+}

--- a/core/regulatory_node.go
+++ b/core/regulatory_node.go
@@ -1,0 +1,43 @@
+package core
+
+import "sync"
+
+// RegulatoryNode represents a regulator-operated node overseeing transactions.
+type RegulatoryNode struct {
+	ID      string
+	Manager *RegulatoryManager
+	mu      sync.RWMutex
+	logs    map[string][]string
+}
+
+// NewRegulatoryNode creates a new RegulatoryNode.
+func NewRegulatoryNode(id string, mgr *RegulatoryManager) *RegulatoryNode {
+	return &RegulatoryNode{
+		ID:      id,
+		Manager: mgr,
+		logs:    make(map[string][]string),
+	}
+}
+
+// ApproveTransaction checks a transaction against registered regulations.
+func (n *RegulatoryNode) ApproveTransaction(tx Transaction) bool {
+	violations := n.Manager.EvaluateTransaction(tx)
+	return len(violations) == 0
+}
+
+// FlagEntity records a regulatory flag for an address.
+func (n *RegulatoryNode) FlagEntity(addr, reason string) {
+	n.mu.Lock()
+	n.logs[addr] = append(n.logs[addr], reason)
+	n.mu.Unlock()
+}
+
+// Logs returns all flags recorded for an address.
+func (n *RegulatoryNode) Logs(addr string) []string {
+	n.mu.RLock()
+	entries := n.logs[addr]
+	out := make([]string, len(entries))
+	copy(out, entries)
+	n.mu.RUnlock()
+	return out
+}

--- a/core/regulatory_node_test.go
+++ b/core/regulatory_node_test.go
@@ -1,0 +1,22 @@
+package core
+
+import "testing"
+
+func TestRegulatoryNode(t *testing.T) {
+	mgr := NewRegulatoryManager()
+	mgr.AddRegulation(Regulation{ID: "r1", MaxAmount: 10})
+	node := NewRegulatoryNode("node1", mgr)
+	tx := Transaction{Amount: 5}
+	if !node.ApproveTransaction(tx) {
+		t.Fatalf("expected approval")
+	}
+	tx.Amount = 20
+	if node.ApproveTransaction(tx) {
+		t.Fatalf("expected rejection")
+	}
+	node.FlagEntity("addr", "suspicious")
+	logs := node.Logs("addr")
+	if len(logs) != 1 || logs[0] != "suspicious" {
+		t.Fatalf("log not recorded")
+	}
+}


### PR DESCRIPTION
## Summary
- implement compliance service for KYC, fraud scoring, anomaly detection, and simple ZKP verification
- add compliance manager to handle suspensions, whitelists, and transaction reviews
- introduce regulatory manager and node for rule enforcement and oversight logs

## Testing
- `go test ./...` *(fails: case-insensitive import collision: "synnergy/nodes" and "synnergy/Nodes")*


------
https://chatgpt.com/codex/tasks/task_e_68902c992bf4832083a3659313e257fc