### PR TITLE
feat(tokens): add core token implementations

### DIFF
--- a/Tokens/base.go
+++ b/Tokens/base.go
@@ -1,0 +1,87 @@
+package tokens
+
+import "fmt"
+
+// TokenID uniquely identifies a token instance within the registry.
+type TokenID uint64
+
+// Token defines basic behaviours for all tokens.
+type Token interface {
+	ID() TokenID
+	Name() string
+	Symbol() string
+	Decimals() uint8
+	TotalSupply() uint64
+	BalanceOf(addr string) uint64
+	Transfer(from, to string, amount uint64) error
+	Mint(to string, amount uint64) error
+	Burn(from string, amount uint64) error
+}
+
+// BaseToken implements the Token interface providing basic accounting.
+type BaseToken struct {
+	id       TokenID
+	name     string
+	symbol   string
+	decimals uint8
+	balances map[string]uint64
+	supply   uint64
+}
+
+// NewBaseToken creates a new base token instance.
+func NewBaseToken(id TokenID, name, symbol string, decimals uint8) *BaseToken {
+	return &BaseToken{
+		id:       id,
+		name:     name,
+		symbol:   symbol,
+		decimals: decimals,
+		balances: make(map[string]uint64),
+	}
+}
+
+// ID returns the unique identifier of the token.
+func (t *BaseToken) ID() TokenID { return t.id }
+
+// Name returns the human readable token name.
+func (t *BaseToken) Name() string { return t.name }
+
+// Symbol returns the token trading symbol.
+func (t *BaseToken) Symbol() string { return t.symbol }
+
+// Decimals returns the decimal precision for the token.
+func (t *BaseToken) Decimals() uint8 { return t.decimals }
+
+// TotalSupply returns the current token supply.
+func (t *BaseToken) TotalSupply() uint64 { return t.supply }
+
+// BalanceOf retrieves the balance for the specified address.
+func (t *BaseToken) BalanceOf(addr string) uint64 {
+	return t.balances[addr]
+}
+
+// Transfer moves tokens between addresses.
+func (t *BaseToken) Transfer(from, to string, amount uint64) error {
+	if t.balances[from] < amount {
+		return fmt.Errorf("insufficient balance")
+	}
+	t.balances[from] -= amount
+	t.balances[to] += amount
+	return nil
+}
+
+// Mint creates new tokens for the specified address.
+func (t *BaseToken) Mint(to string, amount uint64) error {
+	t.balances[to] += amount
+	t.supply += amount
+	return nil
+}
+
+// Burn removes tokens from the specified address.
+func (t *BaseToken) Burn(from string, amount uint64) error {
+	if t.balances[from] < amount {
+		return fmt.Errorf("insufficient balance")
+	}
+	t.balances[from] -= amount
+	t.supply -= amount
+	return nil
+}

--- a/Tokens/base_test.go
+++ b/Tokens/base_test.go
@@ -1,0 +1,71 @@
+package tokens
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestBaseTokenMintTransferBurn(t *testing.T) {
+	tok := NewBaseToken(1, "Test", "TST", 0)
+	if err := tok.Mint("alice", 100); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if err := tok.Transfer("alice", "bob", 40); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if tok.BalanceOf("bob") != 40 {
+		t.Fatalf("expected bob=40 got %d", tok.BalanceOf("bob"))
+	}
+	if err := tok.Burn("alice", 10); err != nil {
+		t.Fatalf("burn: %v", err)
+	}
+	if tok.TotalSupply() != 90 {
+		t.Fatalf("unexpected supply %d", tok.TotalSupply())
+	}
+}
+
+func TestSYN10Info(t *testing.T) {
+	tkn := NewSYN10Token(2, "CBDC", "CBD", "Central Bank", 1.0, 2)
+	if err := tkn.Mint("alice", 50); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	info := tkn.Info()
+	if info.Issuer != "Central Bank" || info.ExchangeRate != 1.0 {
+		t.Fatalf("unexpected info %+v", info)
+	}
+}
+
+func TestSYN1000ReserveValue(t *testing.T) {
+	idx := NewSYN1000Index()
+	id := idx.Create("Stable", "STBL", 2)
+	if err := idx.AddReserve(id, "USD", 100); err != nil {
+		t.Fatalf("add reserve: %v", err)
+	}
+	if err := idx.SetReservePrice(id, "USD", 1.0); err != nil {
+		t.Fatalf("set price: %v", err)
+	}
+	val, err := idx.TotalValue(id)
+	if err != nil || val != 100 {
+		t.Fatalf("unexpected value %f err %v", val, err)
+	}
+}
+
+func TestSYN1100Access(t *testing.T) {
+	store := NewSYN1100Token()
+	data, _ := hex.DecodeString("abcd")
+	if err := store.AddRecord(1, "alice", data); err != nil {
+		t.Fatalf("add record: %v", err)
+	}
+	if err := store.GrantAccess(1, "bob"); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	if _, err := store.GetRecord(1, "bob"); err != nil {
+		t.Fatalf("bob should access: %v", err)
+	}
+	if err := store.RevokeAccess(1, "bob"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := store.GetRecord(1, "bob"); err == nil {
+		t.Fatalf("expected access denied")
+	}
+}

--- a/Tokens/index.go
+++ b/Tokens/index.go
@@ -1,0 +1,29 @@
+package tokens
+
+// Registry maintains a lookup of token instances by their identifiers.
+type Registry struct {
+	tokens map[TokenID]Token
+	next   TokenID
+}
+
+// NewRegistry creates an empty token registry.
+func NewRegistry() *Registry {
+	return &Registry{tokens: make(map[TokenID]Token)}
+}
+
+// NextID returns a unique identifier for a new token.
+func (r *Registry) NextID() TokenID {
+	r.next++
+	return r.next
+}
+
+// Register adds the token to the registry using its ID.
+func (r *Registry) Register(t Token) {
+	r.tokens[t.ID()] = t
+}
+
+// Get retrieves a token by ID if present.
+func (r *Registry) Get(id TokenID) (Token, bool) {
+	t, ok := r.tokens[id]
+	return t, ok
+}

--- a/Tokens/syn10.go
+++ b/Tokens/syn10.go
@@ -1,0 +1,42 @@
+package tokens
+
+// SYN10Token represents a central bank digital currency pegged to fiat.
+type SYN10Token struct {
+	*BaseToken
+	issuer       string
+	exchangeRate float64
+}
+
+// NewSYN10Token initialises a SYN10 token with the given metadata.
+func NewSYN10Token(id TokenID, name, symbol, issuer string, rate float64, decimals uint8) *SYN10Token {
+	return &SYN10Token{
+		BaseToken:    NewBaseToken(id, name, symbol, decimals),
+		issuer:       issuer,
+		exchangeRate: rate,
+	}
+}
+
+// SetExchangeRate updates the fiat exchange rate for the CBDC.
+func (t *SYN10Token) SetExchangeRate(rate float64) {
+	t.exchangeRate = rate
+}
+
+// SYN10Info summarises token configuration.
+type SYN10Info struct {
+	Name         string
+	Symbol       string
+	Issuer       string
+	ExchangeRate float64
+	TotalSupply  uint64
+}
+
+// Info returns the current token information.
+func (t *SYN10Token) Info() SYN10Info {
+	return SYN10Info{
+		Name:         t.Name(),
+		Symbol:       t.Symbol(),
+		Issuer:       t.issuer,
+		ExchangeRate: t.exchangeRate,
+		TotalSupply:  t.TotalSupply(),
+	}
+}

--- a/Tokens/syn1000.go
+++ b/Tokens/syn1000.go
@@ -1,0 +1,44 @@
+package tokens
+
+// ReserveAsset tracks backing assets for a stablecoin.
+type ReserveAsset struct {
+	Amount float64
+	Price  float64
+}
+
+// SYN1000Token represents a stablecoin backed by reserve assets.
+type SYN1000Token struct {
+	*BaseToken
+	reserves map[string]ReserveAsset
+}
+
+// NewSYN1000Token creates a new stablecoin token.
+func NewSYN1000Token(id TokenID, name, symbol string, decimals uint8) *SYN1000Token {
+	return &SYN1000Token{
+		BaseToken: NewBaseToken(id, name, symbol, decimals),
+		reserves:  make(map[string]ReserveAsset),
+	}
+}
+
+// AddReserve adds a backing asset to the reserve list.
+func (t *SYN1000Token) AddReserve(asset string, amount float64) {
+	r := t.reserves[asset]
+	r.Amount += amount
+	t.reserves[asset] = r
+}
+
+// SetReservePrice updates the unit price of a reserve asset.
+func (t *SYN1000Token) SetReservePrice(asset string, price float64) {
+	r := t.reserves[asset]
+	r.Price = price
+	t.reserves[asset] = r
+}
+
+// TotalReserveValue calculates the total market value of all reserves.
+func (t *SYN1000Token) TotalReserveValue() float64 {
+	var v float64
+	for _, r := range t.reserves {
+		v += r.Amount * r.Price
+	}
+	return v
+}

--- a/Tokens/syn1000_index.go
+++ b/Tokens/syn1000_index.go
@@ -1,0 +1,60 @@
+package tokens
+
+import "fmt"
+
+// SYN1000Index manages multiple SYN1000 stablecoin instances.
+type SYN1000Index struct {
+	tokens map[TokenID]*SYN1000Token
+	next   TokenID
+}
+
+// NewSYN1000Index creates an empty index.
+func NewSYN1000Index() *SYN1000Index {
+	return &SYN1000Index{tokens: make(map[TokenID]*SYN1000Token)}
+}
+
+// Create instantiates a new SYN1000 token and returns its identifier.
+func (i *SYN1000Index) Create(name, symbol string, decimals uint8) TokenID {
+	i.next++
+	id := i.next
+	i.tokens[id] = NewSYN1000Token(id, name, symbol, decimals)
+	return id
+}
+
+// Token retrieves a SYN1000 token by ID.
+func (i *SYN1000Index) Token(id TokenID) (*SYN1000Token, error) {
+	t, ok := i.tokens[id]
+	if !ok {
+		return nil, fmt.Errorf("token not found")
+	}
+	return t, nil
+}
+
+// AddReserve adds reserve assets to a specific token.
+func (i *SYN1000Index) AddReserve(id TokenID, asset string, amount float64) error {
+	t, err := i.Token(id)
+	if err != nil {
+		return err
+	}
+	t.AddReserve(asset, amount)
+	return nil
+}
+
+// SetReservePrice updates price information for an asset backing a token.
+func (i *SYN1000Index) SetReservePrice(id TokenID, asset string, price float64) error {
+	t, err := i.Token(id)
+	if err != nil {
+		return err
+	}
+	t.SetReservePrice(asset, price)
+	return nil
+}
+
+// TotalValue returns the current total reserve value for the token.
+func (i *SYN1000Index) TotalValue(id TokenID) (float64, error) {
+	t, err := i.Token(id)
+	if err != nil {
+		return 0, err
+	}
+	return t.TotalReserveValue(), nil
+}

--- a/Tokens/syn1100.go
+++ b/Tokens/syn1100.go
@@ -1,0 +1,61 @@
+package tokens
+
+import "fmt"
+
+// HealthRecord represents encrypted healthcare data tied to an owner.
+type HealthRecord struct {
+	Owner  string
+	Data   []byte
+	Access map[string]bool
+}
+
+// SYN1100Token manages healthcare records with access control.
+type SYN1100Token struct {
+	records map[TokenID]*HealthRecord
+}
+
+// NewSYN1100Token creates an empty healthcare record store.
+func NewSYN1100Token() *SYN1100Token {
+	return &SYN1100Token{records: make(map[TokenID]*HealthRecord)}
+}
+
+// AddRecord stores a new healthcare record with the given ID.
+func (t *SYN1100Token) AddRecord(id TokenID, owner string, data []byte) error {
+	if _, exists := t.records[id]; exists {
+		return fmt.Errorf("record exists")
+	}
+	t.records[id] = &HealthRecord{Owner: owner, Data: data, Access: map[string]bool{owner: true}}
+	return nil
+}
+
+// GrantAccess allows a grantee to read the specified record.
+func (t *SYN1100Token) GrantAccess(id TokenID, grantee string) error {
+	rec, ok := t.records[id]
+	if !ok {
+		return fmt.Errorf("record not found")
+	}
+	rec.Access[grantee] = true
+	return nil
+}
+
+// RevokeAccess revokes a previously granted permission.
+func (t *SYN1100Token) RevokeAccess(id TokenID, grantee string) error {
+	rec, ok := t.records[id]
+	if !ok {
+		return fmt.Errorf("record not found")
+	}
+	delete(rec.Access, grantee)
+	return nil
+}
+
+// GetRecord returns the record data if the caller has access rights.
+func (t *SYN1100Token) GetRecord(id TokenID, caller string) ([]byte, error) {
+	rec, ok := t.records[id]
+	if !ok {
+		return nil, fmt.Errorf("record not found")
+	}
+	if !rec.Access[caller] {
+		return nil, fmt.Errorf("access denied")
+	}
+	return rec.Data, nil
+}

--- a/Tokens/syn12.go
+++ b/Tokens/syn12.go
@@ -1,0 +1,27 @@
+package tokens
+
+import "time"
+
+// SYN12Metadata defines treasury bill properties for CBDC instruments.
+type SYN12Metadata struct {
+	BillID    string
+	Issuer    string
+	IssueDate time.Time
+	Maturity  time.Time
+	Discount  float64
+	FaceValue uint64
+}
+
+// SYN12Token represents a tokenised treasury bill.
+type SYN12Token struct {
+	*BaseToken
+	Metadata SYN12Metadata
+}
+
+// NewSYN12Token creates a new SYN12 token with the provided metadata.
+func NewSYN12Token(id TokenID, name, symbol string, meta SYN12Metadata, decimals uint8) *SYN12Token {
+	return &SYN12Token{
+		BaseToken: NewBaseToken(id, name, symbol, decimals),
+		Metadata:  meta,
+	}
+}

--- a/Tokens/syn20.go
+++ b/Tokens/syn20.go
@@ -1,0 +1,57 @@
+package tokens
+
+import "fmt"
+
+// SYN20Token extends BaseToken with pause and freeze capabilities.
+type SYN20Token struct {
+	*BaseToken
+	paused bool
+	frozen map[string]bool
+}
+
+// NewSYN20Token creates a new SYN20 token.
+func NewSYN20Token(id TokenID, name, symbol string, decimals uint8) *SYN20Token {
+	return &SYN20Token{
+		BaseToken: NewBaseToken(id, name, symbol, decimals),
+		frozen:    make(map[string]bool),
+	}
+}
+
+// Pause halts all transfer, mint and burn operations.
+func (t *SYN20Token) Pause() { t.paused = true }
+
+// Unpause resumes operations.
+func (t *SYN20Token) Unpause() { t.paused = false }
+
+// Freeze prevents an address from participating in transfers.
+func (t *SYN20Token) Freeze(addr string) { t.frozen[addr] = true }
+
+// Unfreeze lifts restrictions on an address.
+func (t *SYN20Token) Unfreeze(addr string) { delete(t.frozen, addr) }
+
+// Transfer overrides BaseToken.Transfer adding pause/freeze checks.
+func (t *SYN20Token) Transfer(from, to string, amount uint64) error {
+	if t.paused {
+		return fmt.Errorf("token transfers are paused")
+	}
+	if t.frozen[from] || t.frozen[to] {
+		return fmt.Errorf("address frozen")
+	}
+	return t.BaseToken.Transfer(from, to, amount)
+}
+
+// Mint creates tokens if operations are not paused or frozen.
+func (t *SYN20Token) Mint(to string, amount uint64) error {
+	if t.paused || t.frozen[to] {
+		return fmt.Errorf("minting restricted")
+	}
+	return t.BaseToken.Mint(to, amount)
+}
+
+// Burn destroys tokens if operations are allowed.
+func (t *SYN20Token) Burn(from string, amount uint64) error {
+	if t.paused || t.frozen[from] {
+		return fmt.Errorf("burning restricted")
+	}
+	return t.BaseToken.Burn(from, amount)
+}

--- a/Tokens/syn70.go
+++ b/Tokens/syn70.go
@@ -1,0 +1,56 @@
+package tokens
+
+import "fmt"
+
+// SYN70Asset represents a single game asset tracked by the SYN70 token standard.
+type SYN70Asset struct {
+	ID       string
+	Owner    string
+	Metadata string
+}
+
+// SYN70Token manages in-game assets.
+type SYN70Token struct {
+	*BaseToken
+	assets map[string]SYN70Asset
+}
+
+// NewSYN70Token constructs a SYN70 token instance.
+func NewSYN70Token(id TokenID, name, symbol string, decimals uint8) *SYN70Token {
+	return &SYN70Token{
+		BaseToken: NewBaseToken(id, name, symbol, decimals),
+		assets:    make(map[string]SYN70Asset),
+	}
+}
+
+// MintAsset creates a new asset and assigns it to the owner.
+func (t *SYN70Token) MintAsset(owner, assetID, metadata string) error {
+	if _, exists := t.assets[assetID]; exists {
+		return fmt.Errorf("asset already exists")
+	}
+	t.assets[assetID] = SYN70Asset{ID: assetID, Owner: owner, Metadata: metadata}
+	return t.BaseToken.Mint(owner, 1)
+}
+
+// TransferAsset moves an asset from one owner to another.
+func (t *SYN70Token) TransferAsset(assetID, from, to string) error {
+	asset, ok := t.assets[assetID]
+	if !ok {
+		return fmt.Errorf("asset not found")
+	}
+	if asset.Owner != from {
+		return fmt.Errorf("not asset owner")
+	}
+	if err := t.BaseToken.Transfer(from, to, 1); err != nil {
+		return err
+	}
+	asset.Owner = to
+	t.assets[assetID] = asset
+	return nil
+}
+
+// GetAsset returns asset information if present.
+func (t *SYN70Token) GetAsset(assetID string) (SYN70Asset, bool) {
+	a, ok := t.assets[assetID]
+	return a, ok
+}


### PR DESCRIPTION
## Summary
- add token base types and registry for tracking issued assets
- implement SYN10, SYN12, SYN20, SYN70, SYN1000, and SYN1100 token standards
- provide unit tests covering core token behaviours

## Testing
- `go test ./...` *(fails: case-insensitive import collision: "synnergy/nodes" and "synnergy/Nodes")*
- `go test ./Tokens`


------
https://chatgpt.com/codex/tasks/task_e_68902cb7c6ec83209913e4faac9816c6