### PR TITLE
feat: add real world asset token modules

### DIFF
--- a/core/syn1300.go
+++ b/core/syn1300.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// SupplyChainEvent records a movement or status change for a supply chain asset.
+type SupplyChainEvent struct {
+	Timestamp time.Time
+	Location  string
+	Status    string
+	Note      string
+}
+
+// SupplyChainAsset holds metadata and history for an asset tracked through the supply chain.
+type SupplyChainAsset struct {
+	ID          string
+	Description string
+	Owner       string
+	Location    string
+	Status      string
+	History     []SupplyChainEvent
+}
+
+// SupplyChainRegistry manages supply chain assets and their events.
+type SupplyChainRegistry struct {
+	assets map[string]*SupplyChainAsset
+}
+
+// NewSupplyChainRegistry creates a new empty registry.
+func NewSupplyChainRegistry() *SupplyChainRegistry {
+	return &SupplyChainRegistry{assets: make(map[string]*SupplyChainAsset)}
+}
+
+// Register inserts a new asset into the registry.
+func (r *SupplyChainRegistry) Register(id, desc, owner, location string) (*SupplyChainAsset, error) {
+	if _, exists := r.assets[id]; exists {
+		return nil, errors.New("asset already exists")
+	}
+	asset := &SupplyChainAsset{ID: id, Description: desc, Owner: owner, Location: location, Status: "created"}
+	asset.History = append(asset.History, SupplyChainEvent{Timestamp: time.Now(), Location: location, Status: "created"})
+	r.assets[id] = asset
+	return asset, nil
+}
+
+// Update records a new event for the given asset.
+func (r *SupplyChainRegistry) Update(id, location, status, note string) error {
+	asset, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	asset.Location = location
+	asset.Status = status
+	asset.History = append(asset.History, SupplyChainEvent{Timestamp: time.Now(), Location: location, Status: status, Note: note})
+	return nil
+}
+
+// Get returns the asset with the given id.
+func (r *SupplyChainRegistry) Get(id string) (*SupplyChainAsset, bool) {
+	asset, ok := r.assets[id]
+	return asset, ok
+}

--- a/core/syn131_token.go
+++ b/core/syn131_token.go
@@ -1,0 +1,48 @@
+package core
+
+import "errors"
+
+// SYN131Token represents an intangible asset token.
+type SYN131Token struct {
+	ID        string
+	Name      string
+	Symbol    string
+	Owner     string
+	Valuation uint64
+}
+
+// SYN131Registry stores issued SYN131 tokens.
+type SYN131Registry struct {
+	tokens map[string]*SYN131Token
+}
+
+// NewSYN131Registry creates a new registry.
+func NewSYN131Registry() *SYN131Registry {
+	return &SYN131Registry{tokens: make(map[string]*SYN131Token)}
+}
+
+// Create issues a new SYN131 token.
+func (r *SYN131Registry) Create(id, name, symbol, owner string, valuation uint64) (*SYN131Token, error) {
+	if _, exists := r.tokens[id]; exists {
+		return nil, errors.New("token already exists")
+	}
+	t := &SYN131Token{ID: id, Name: name, Symbol: symbol, Owner: owner, Valuation: valuation}
+	r.tokens[id] = t
+	return t, nil
+}
+
+// UpdateValuation sets a new valuation for the token.
+func (r *SYN131Registry) UpdateValuation(id string, val uint64) error {
+	tok, ok := r.tokens[id]
+	if !ok {
+		return errors.New("token not found")
+	}
+	tok.Valuation = val
+	return nil
+}
+
+// Get fetches a token by id.
+func (r *SYN131Registry) Get(id string) (*SYN131Token, bool) {
+	tok, ok := r.tokens[id]
+	return tok, ok
+}

--- a/core/syn1401.go
+++ b/core/syn1401.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// InvestmentRecord stores state for a SYN1401 investment token issuance.
+type InvestmentRecord struct {
+	ID          string
+	Owner       string
+	Principal   uint64
+	Rate        float64
+	Maturity    time.Time
+	Accrued     uint64
+	LastAccrued time.Time
+}
+
+// InvestmentRegistry manages issued investments.
+type InvestmentRegistry struct {
+	investments map[string]*InvestmentRecord
+}
+
+// NewInvestmentRegistry creates a new registry.
+func NewInvestmentRegistry() *InvestmentRegistry {
+	return &InvestmentRegistry{investments: make(map[string]*InvestmentRecord)}
+}
+
+// Issue creates a new investment record.
+func (r *InvestmentRegistry) Issue(id, owner string, principal uint64, rate float64, maturity time.Time) (*InvestmentRecord, error) {
+	if _, exists := r.investments[id]; exists {
+		return nil, errors.New("investment already exists")
+	}
+	rec := &InvestmentRecord{ID: id, Owner: owner, Principal: principal, Rate: rate, Maturity: maturity, LastAccrued: time.Now()}
+	r.investments[id] = rec
+	return rec, nil
+}
+
+// Accrue accrues interest up to now and returns the accrued amount.
+func (r *InvestmentRegistry) Accrue(id string, now time.Time) (uint64, error) {
+	rec, ok := r.investments[id]
+	if !ok {
+		return 0, errors.New("investment not found")
+	}
+	if now.Before(rec.LastAccrued) {
+		return 0, nil
+	}
+	elapsed := now.Sub(rec.LastAccrued).Hours() / 24 / 365
+	interest := uint64(float64(rec.Principal) * rec.Rate * elapsed)
+	rec.Accrued += interest
+	rec.LastAccrued = now
+	return interest, nil
+}
+
+// Get returns an investment record.
+func (r *InvestmentRegistry) Get(id string) (*InvestmentRecord, bool) {
+	rec, ok := r.investments[id]
+	return rec, ok
+}

--- a/core/syn3200.go
+++ b/core/syn3200.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// Bill represents a bill record managed by the SYN3200 standard.
+type Bill struct {
+	ID       string
+	Issuer   string
+	Payer    string
+	Amount   uint64
+	DueDate  time.Time
+	Metadata string
+	Payments []BillPayment
+}
+
+// BillPayment captures a single payment toward a bill.
+type BillPayment struct {
+	Payer     string
+	Amount    uint64
+	Timestamp time.Time
+}
+
+// BillRegistry manages bills and payments.
+type BillRegistry struct {
+	bills map[string]*Bill
+}
+
+// NewBillRegistry creates a new registry.
+func NewBillRegistry() *BillRegistry {
+	return &BillRegistry{bills: make(map[string]*Bill)}
+}
+
+// Create adds a new bill to the registry.
+func (r *BillRegistry) Create(id, issuer, payer string, amt uint64, due time.Time, meta string) (*Bill, error) {
+	if _, exists := r.bills[id]; exists {
+		return nil, errors.New("bill already exists")
+	}
+	b := &Bill{ID: id, Issuer: issuer, Payer: payer, Amount: amt, DueDate: due, Metadata: meta}
+	r.bills[id] = b
+	return b, nil
+}
+
+// Pay records a payment toward the bill.
+func (r *BillRegistry) Pay(id, payer string, amt uint64) error {
+	b, ok := r.bills[id]
+	if !ok {
+		return errors.New("bill not found")
+	}
+	if amt == 0 {
+		return errors.New("amount must be positive")
+	}
+	b.Payments = append(b.Payments, BillPayment{Payer: payer, Amount: amt, Timestamp: time.Now()})
+	if amt >= b.Amount {
+		b.Amount = 0
+	} else {
+		b.Amount -= amt
+	}
+	return nil
+}
+
+// Adjust changes the amount due on a bill.
+func (r *BillRegistry) Adjust(id string, amt uint64) error {
+	b, ok := r.bills[id]
+	if !ok {
+		return errors.New("bill not found")
+	}
+	b.Amount = amt
+	return nil
+}
+
+// Get returns bill information.
+func (r *BillRegistry) Get(id string) (*Bill, bool) {
+	b, ok := r.bills[id]
+	return b, ok
+}

--- a/core/syn500.go
+++ b/core/syn500.go
@@ -1,0 +1,43 @@
+package core
+
+import "errors"
+
+// ServiceTier defines access tiers for SYN500 utility tokens.
+type ServiceTier struct {
+	Tier int
+	Max  uint64
+	Used uint64
+}
+
+// SYN500Token defines a simple utility token with usage tracking.
+type SYN500Token struct {
+	Name     string
+	Symbol   string
+	Owner    string
+	Decimals uint8
+	Supply   uint64
+	Grants   map[string]*ServiceTier
+}
+
+// NewSYN500Token creates a new utility token.
+func NewSYN500Token(name, symbol, owner string, decimals uint8, supply uint64) *SYN500Token {
+	return &SYN500Token{Name: name, Symbol: symbol, Owner: owner, Decimals: decimals, Supply: supply, Grants: make(map[string]*ServiceTier)}
+}
+
+// Grant assigns a service tier to an address.
+func (t *SYN500Token) Grant(addr string, tier int, max uint64) {
+	t.Grants[addr] = &ServiceTier{Tier: tier, Max: max}
+}
+
+// Use records a token usage for an address.
+func (t *SYN500Token) Use(addr string) error {
+	g, ok := t.Grants[addr]
+	if !ok {
+		return errors.New("no tier granted")
+	}
+	if g.Used >= g.Max {
+		return errors.New("usage limit reached")
+	}
+	g.Used++
+	return nil
+}

--- a/core/syn700.go
+++ b/core/syn700.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// License represents a usage license for an IP token.
+type License struct {
+	ID       string
+	Type     string
+	Licensee string
+	Royalty  uint64
+	Created  time.Time
+}
+
+// RoyaltyPayment records a royalty payment for a license.
+type RoyaltyPayment struct {
+	LicenseID string
+	Licensee  string
+	Amount    uint64
+	Timestamp time.Time
+}
+
+// IPTokens represents an intellectual property asset.
+type IPTokens struct {
+	TokenID     string
+	Title       string
+	Description string
+	Creator     string
+	Owner       string
+	Licenses    map[string]*License
+	Royalties   []RoyaltyPayment
+}
+
+// IPRegistry manages SYN700 tokens.
+type IPRegistry struct {
+	assets map[string]*IPTokens
+}
+
+// NewIPRegistry creates a new IP registry.
+func NewIPRegistry() *IPRegistry {
+	return &IPRegistry{assets: make(map[string]*IPTokens)}
+}
+
+// Register adds a new IP token.
+func (r *IPRegistry) Register(tokenID, title, desc, creator, owner string) (*IPTokens, error) {
+	if _, exists := r.assets[tokenID]; exists {
+		return nil, errors.New("token already exists")
+	}
+	asset := &IPTokens{TokenID: tokenID, Title: title, Description: desc, Creator: creator, Owner: owner, Licenses: make(map[string]*License)}
+	r.assets[tokenID] = asset
+	return asset, nil
+}
+
+// CreateLicense associates a license with an IP token.
+func (r *IPRegistry) CreateLicense(tokenID, licID, licType, licensee string, royalty uint64) error {
+	asset, ok := r.assets[tokenID]
+	if !ok {
+		return errors.New("token not found")
+	}
+	if _, exists := asset.Licenses[licID]; exists {
+		return errors.New("license exists")
+	}
+	asset.Licenses[licID] = &License{ID: licID, Type: licType, Licensee: licensee, Royalty: royalty, Created: time.Now()}
+	return nil
+}
+
+// RecordRoyalty records a royalty payment for a license.
+func (r *IPRegistry) RecordRoyalty(tokenID, licID, licensee string, amount uint64) error {
+	asset, ok := r.assets[tokenID]
+	if !ok {
+		return errors.New("token not found")
+	}
+	if _, exists := asset.Licenses[licID]; !exists {
+		return errors.New("license not found")
+	}
+	asset.Royalties = append(asset.Royalties, RoyaltyPayment{LicenseID: licID, Licensee: licensee, Amount: amount, Timestamp: time.Now()})
+	return nil
+}
+
+// Get returns an IP token.
+func (r *IPRegistry) Get(tokenID string) (*IPTokens, bool) {
+	asset, ok := r.assets[tokenID]
+	return asset, ok
+}

--- a/core/syn800_token.go
+++ b/core/syn800_token.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// AssetMetadata describes a real world asset backing a SYN800 token.
+type AssetMetadata struct {
+	ID            string
+	Description   string
+	Valuation     uint64
+	Location      string
+	AssetType     string
+	Certification string
+	Updated       time.Time
+}
+
+// AssetRegistry stores SYN800 assets.
+type AssetRegistry struct {
+	assets map[string]*AssetMetadata
+}
+
+// NewAssetRegistry creates an empty registry.
+func NewAssetRegistry() *AssetRegistry {
+	return &AssetRegistry{assets: make(map[string]*AssetMetadata)}
+}
+
+// Register adds a new asset and returns it.
+func (r *AssetRegistry) Register(id, desc string, valuation uint64, loc, typ, cert string) (*AssetMetadata, error) {
+	if _, exists := r.assets[id]; exists {
+		return nil, errors.New("asset exists")
+	}
+	a := &AssetMetadata{ID: id, Description: desc, Valuation: valuation, Location: loc, AssetType: typ, Certification: cert, Updated: time.Now()}
+	r.assets[id] = a
+	return a, nil
+}
+
+// UpdateValuation updates the valuation of an asset.
+func (r *AssetRegistry) UpdateValuation(id string, valuation uint64) error {
+	a, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	a.Valuation = valuation
+	a.Updated = time.Now()
+	return nil
+}
+
+// Get returns asset metadata by id.
+func (r *AssetRegistry) Get(id string) (*AssetMetadata, bool) {
+	a, ok := r.assets[id]
+	return a, ok
+}

--- a/core/token_syn130.go
+++ b/core/token_syn130.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// Syn130SaleRecord tracks sale price history for tangible assets.
+type Syn130SaleRecord struct {
+	Buyer     string
+	Price     uint64
+	Timestamp time.Time
+}
+
+// LeaseInfo captures lease details for an asset.
+type LeaseInfo struct {
+	Lessee  string
+	Payment uint64
+	Start   time.Time
+	End     time.Time
+	Active  bool
+}
+
+// TangibleAsset represents a tokenised real-world asset.
+type TangibleAsset struct {
+	ID        string
+	Owner     string
+	Metadata  string
+	Valuation uint64
+	Sales     []Syn130SaleRecord
+	Lease     *LeaseInfo
+}
+
+// TangibleAssetRegistry manages tangible assets.
+type TangibleAssetRegistry struct {
+	assets map[string]*TangibleAsset
+}
+
+// NewTangibleAssetRegistry creates a new registry.
+func NewTangibleAssetRegistry() *TangibleAssetRegistry {
+	return &TangibleAssetRegistry{assets: make(map[string]*TangibleAsset)}
+}
+
+// Register adds a new tangible asset.
+func (r *TangibleAssetRegistry) Register(id, owner, meta string, value uint64) (*TangibleAsset, error) {
+	if _, exists := r.assets[id]; exists {
+		return nil, errors.New("asset exists")
+	}
+	asset := &TangibleAsset{ID: id, Owner: owner, Metadata: meta, Valuation: value}
+	r.assets[id] = asset
+	return asset, nil
+}
+
+// UpdateValuation updates the valuation of an asset.
+func (r *TangibleAssetRegistry) UpdateValuation(id string, val uint64) error {
+	asset, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	asset.Valuation = val
+	return nil
+}
+
+// RecordSale records a sale for the asset.
+func (r *TangibleAssetRegistry) RecordSale(id, buyer string, price uint64) error {
+	asset, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	asset.Owner = buyer
+	asset.Sales = append(asset.Sales, Syn130SaleRecord{Buyer: buyer, Price: price, Timestamp: time.Now()})
+	return nil
+}
+
+// StartLease begins a lease for the asset.
+func (r *TangibleAssetRegistry) StartLease(id, lessee string, payment uint64, start, end time.Time) error {
+	asset, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	asset.Lease = &LeaseInfo{Lessee: lessee, Payment: payment, Start: start, End: end, Active: true}
+	return nil
+}
+
+// EndLease terminates an active lease.
+func (r *TangibleAssetRegistry) EndLease(id string) error {
+	asset, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	if asset.Lease != nil {
+		asset.Lease.Active = false
+	}
+	return nil
+}
+
+// Get returns a tangible asset by id.
+func (r *TangibleAssetRegistry) Get(id string) (*TangibleAsset, bool) {
+	asset, ok := r.assets[id]
+	return asset, ok
+}

--- a/core/token_syn4900.go
+++ b/core/token_syn4900.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// AgriEvent captures a notable event for an agricultural asset.
+type AgriEvent struct {
+	Timestamp   time.Time
+	Description string
+}
+
+// AgriculturalAsset holds detailed metadata for SYN4900 tokens.
+type AgriculturalAsset struct {
+	ID            string
+	AssetType     string
+	Quantity      uint64
+	Owner         string
+	Origin        string
+	HarvestDate   time.Time
+	ExpiryDate    time.Time
+	Status        string
+	Certification string
+	History       []AgriEvent
+}
+
+// AgriculturalRegistry manages agricultural assets.
+type AgriculturalRegistry struct {
+	assets map[string]*AgriculturalAsset
+}
+
+// NewAgriculturalRegistry creates a new registry.
+func NewAgriculturalRegistry() *AgriculturalRegistry {
+	return &AgriculturalRegistry{assets: make(map[string]*AgriculturalAsset)}
+}
+
+// Register adds a new agricultural asset to the registry.
+func (r *AgriculturalRegistry) Register(id, assetType, owner, origin string, qty uint64, harvest, expiry time.Time, cert string) (*AgriculturalAsset, error) {
+	if _, exists := r.assets[id]; exists {
+		return nil, errors.New("asset exists")
+	}
+	a := &AgriculturalAsset{ID: id, AssetType: assetType, Quantity: qty, Owner: owner, Origin: origin, HarvestDate: harvest, ExpiryDate: expiry, Status: "fresh", Certification: cert}
+	r.assets[id] = a
+	return a, nil
+}
+
+// Transfer moves ownership of an asset.
+func (r *AgriculturalRegistry) Transfer(id, newOwner string) error {
+	a, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	a.Owner = newOwner
+	a.History = append(a.History, AgriEvent{Timestamp: time.Now(), Description: "transfer"})
+	return nil
+}
+
+// UpdateStatus updates the current status of an asset.
+func (r *AgriculturalRegistry) UpdateStatus(id, status string) error {
+	a, ok := r.assets[id]
+	if !ok {
+		return errors.New("asset not found")
+	}
+	a.Status = status
+	a.History = append(a.History, AgriEvent{Timestamp: time.Now(), Description: status})
+	return nil
+}
+
+// Get returns an agricultural asset by id.
+func (r *AgriculturalRegistry) Get(id string) (*AgriculturalAsset, bool) {
+	a, ok := r.assets[id]
+	return a, ok
+}


### PR DESCRIPTION
## Summary
- add supply chain asset tracking registry (SYN1300)
- implement intangible asset token (SYN131) with valuation updates
- add investment, billing, utility tier, IP licensing, asset metadata, tangible and agricultural token registries

## Testing
- `go test -mod=mod ./...` *(fails: case-insensitive import collision)*

------
https://chatgpt.com/codex/tasks/task_e_68902ce958bc83209a1877de3e4eb131