### PR TITLE
Add specialised token modules

### DIFF
--- a/core/syn1600.go
+++ b/core/syn1600.go
@@ -1,0 +1,60 @@
+package core
+
+import "errors"
+
+// MusicToken represents metadata and royalty distribution for a SYN1600 token.
+type MusicToken struct {
+	Title  string
+	Artist string
+	Album  string
+
+	royaltySplits map[string]uint64
+	totalShares   uint64
+}
+
+// NewMusicToken initialises a music token with basic metadata.
+func NewMusicToken(title, artist, album string) *MusicToken {
+	return &MusicToken{
+		Title:         title,
+		Artist:        artist,
+		Album:         album,
+		royaltySplits: make(map[string]uint64),
+	}
+}
+
+// Info returns the music metadata.
+func (m *MusicToken) Info() (string, string, string) {
+	return m.Title, m.Artist, m.Album
+}
+
+// Update modifies the music metadata. Empty values are ignored.
+func (m *MusicToken) Update(title, artist, album string) {
+	if title != "" {
+		m.Title = title
+	}
+	if artist != "" {
+		m.Artist = artist
+	}
+	if album != "" {
+		m.Album = album
+	}
+}
+
+// SetRoyaltyShare sets the royalty share for an address.
+func (m *MusicToken) SetRoyaltyShare(addr string, share uint64) {
+	m.totalShares -= m.royaltySplits[addr]
+	m.royaltySplits[addr] = share
+	m.totalShares += share
+}
+
+// Distribute calculates payouts for each royalty recipient based on shares.
+func (m *MusicToken) Distribute(amount uint64) (map[string]uint64, error) {
+	if m.totalShares == 0 {
+		return nil, errors.New("no royalty recipients")
+	}
+	payouts := make(map[string]uint64, len(m.royaltySplits))
+	for addr, share := range m.royaltySplits {
+		payouts[addr] = amount * share / m.totalShares
+	}
+	return payouts, nil
+}

--- a/core/syn1600_test.go
+++ b/core/syn1600_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestMusicToken(t *testing.T) {
+	m := NewMusicToken("Song", "Artist", "Album")
+	title, artist, album := m.Info()
+	if title != "Song" || artist != "Artist" || album != "Album" {
+		t.Fatalf("unexpected metadata: %s %s %s", title, artist, album)
+	}
+
+	m.Update("NewSong", "", "")
+	if t2, _, _ := m.Info(); t2 != "NewSong" {
+		t.Fatalf("expected title update, got %s", t2)
+	}
+
+	m.SetRoyaltyShare("addr1", 1)
+	m.SetRoyaltyShare("addr2", 1)
+	payouts, err := m.Distribute(100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if payouts["addr1"] != 50 || payouts["addr2"] != 50 {
+		t.Fatalf("incorrect payouts: %#v", payouts)
+	}
+}

--- a/core/syn1700_token.go
+++ b/core/syn1700_token.go
@@ -1,0 +1,65 @@
+package core
+
+import "errors"
+
+// EventMetadata holds event information and issued tickets for SYN1700 tokens.
+type EventMetadata struct {
+	Name        string
+	Description string
+	Location    string
+	Start       int64
+	End         int64
+	Supply      uint64
+
+	nextTicketID uint64
+	Tickets      map[uint64]*Ticket
+}
+
+// Ticket represents an issued event ticket.
+type Ticket struct {
+	ID    uint64
+	Owner string
+	Class string
+	Type  string
+	Price uint64
+}
+
+// NewEvent initialises a new event metadata record.
+func NewEvent(name, desc, location string, start, end int64, supply uint64) *EventMetadata {
+	return &EventMetadata{
+		Name:        name,
+		Description: desc,
+		Location:    location,
+		Start:       start,
+		End:         end,
+		Supply:      supply,
+		Tickets:     make(map[uint64]*Ticket),
+	}
+}
+
+// IssueTicket issues a ticket to an owner if supply allows and returns its ID.
+func (e *EventMetadata) IssueTicket(owner, class, ticketType string, price uint64) (uint64, error) {
+	if uint64(len(e.Tickets)) >= e.Supply {
+		return 0, errors.New("ticket supply exhausted")
+	}
+	e.nextTicketID++
+	id := e.nextTicketID
+	e.Tickets[id] = &Ticket{ID: id, Owner: owner, Class: class, Type: ticketType, Price: price}
+	return id, nil
+}
+
+// TransferTicket transfers ownership of a ticket.
+func (e *EventMetadata) TransferTicket(id uint64, from, to string) error {
+	t, ok := e.Tickets[id]
+	if !ok || t.Owner != from {
+		return errors.New("ticket not owned by sender")
+	}
+	t.Owner = to
+	return nil
+}
+
+// VerifyTicket checks if a holder owns the ticket.
+func (e *EventMetadata) VerifyTicket(id uint64, holder string) bool {
+	t, ok := e.Tickets[id]
+	return ok && t.Owner == holder
+}

--- a/core/syn1700_token_test.go
+++ b/core/syn1700_token_test.go
@@ -1,0 +1,20 @@
+package core
+
+import "testing"
+
+func TestEventTickets(t *testing.T) {
+	e := NewEvent("Concert", "Live show", "NYC", 1000, 2000, 2)
+	id, err := e.IssueTicket("alice", "VIP", "standard", 100)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if !e.VerifyTicket(id, "alice") {
+		t.Fatalf("expected alice to own ticket")
+	}
+	if err := e.TransferTicket(id, "alice", "bob"); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if !e.VerifyTicket(id, "bob") {
+		t.Fatalf("expected bob to own ticket")
+	}
+}

--- a/core/syn2100.go
+++ b/core/syn2100.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// FinancialDocument captures metadata for a trade finance instrument.
+type FinancialDocument struct {
+	DocID       string
+	Issuer      string
+	Recipient   string
+	Amount      uint64
+	IssueDate   time.Time
+	DueDate     time.Time
+	Description string
+	Financed    bool
+	Financier   string
+}
+
+// TradeFinanceToken manages financial documents and liquidity pools for SYN2100.
+type TradeFinanceToken struct {
+	Documents map[string]*FinancialDocument
+	Liquidity map[string]uint64
+}
+
+// NewTradeFinanceToken creates a new registry instance.
+func NewTradeFinanceToken() *TradeFinanceToken {
+	return &TradeFinanceToken{
+		Documents: make(map[string]*FinancialDocument),
+		Liquidity: make(map[string]uint64),
+	}
+}
+
+// RegisterDocument registers a financing document.
+func (t *TradeFinanceToken) RegisterDocument(docID, issuer, recipient string, amount uint64, issue, due time.Time, desc string) {
+	t.Documents[docID] = &FinancialDocument{
+		DocID:       docID,
+		Issuer:      issuer,
+		Recipient:   recipient,
+		Amount:      amount,
+		IssueDate:   issue,
+		DueDate:     due,
+		Description: desc,
+	}
+}
+
+// FinanceDocument marks a document as financed by a financier.
+func (t *TradeFinanceToken) FinanceDocument(docID, financier string) error {
+	d, ok := t.Documents[docID]
+	if !ok {
+		return errors.New("document not found")
+	}
+	if d.Financed {
+		return errors.New("document already financed")
+	}
+	d.Financed = true
+	d.Financier = financier
+	return nil
+}
+
+// GetDocument fetches a document by ID.
+func (t *TradeFinanceToken) GetDocument(docID string) (*FinancialDocument, bool) {
+	d, ok := t.Documents[docID]
+	return d, ok
+}
+
+// ListDocuments returns all registered documents.
+func (t *TradeFinanceToken) ListDocuments() []*FinancialDocument {
+	res := make([]*FinancialDocument, 0, len(t.Documents))
+	for _, d := range t.Documents {
+		res = append(res, d)
+	}
+	return res
+}
+
+// AddLiquidity adds funds to the liquidity pool from an address.
+func (t *TradeFinanceToken) AddLiquidity(addr string, amt uint64) {
+	t.Liquidity[addr] += amt
+}
+
+// RemoveLiquidity removes funds from the liquidity pool.
+func (t *TradeFinanceToken) RemoveLiquidity(addr string, amt uint64) error {
+	if t.Liquidity[addr] < amt {
+		return errors.New("insufficient liquidity")
+	}
+	t.Liquidity[addr] -= amt
+	return nil
+}

--- a/core/syn2100_test.go
+++ b/core/syn2100_test.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTradeFinanceToken(t *testing.T) {
+	token := NewTradeFinanceToken()
+	issue := time.Unix(0, 0)
+	due := issue.Add(24 * time.Hour)
+	token.RegisterDocument("doc1", "issuer", "recip", 1000, issue, due, "test")
+
+	if err := token.FinanceDocument("doc1", "financier"); err != nil {
+		t.Fatalf("finance: %v", err)
+	}
+
+	if _, ok := token.GetDocument("doc1"); !ok {
+		t.Fatalf("document not found")
+	}
+
+	docs := token.ListDocuments()
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	token.AddLiquidity("alice", 500)
+	if err := token.RemoveLiquidity("alice", 200); err != nil {
+		t.Fatalf("remove liquidity: %v", err)
+	}
+	if token.Liquidity["alice"] != 300 {
+		t.Fatalf("unexpected liquidity balance: %d", token.Liquidity["alice"])
+	}
+}

--- a/core/syn2700.go
+++ b/core/syn2700.go
@@ -1,0 +1,44 @@
+package core
+
+import "time"
+
+// VestingEntry defines a point in time when a portion becomes available.
+type VestingEntry struct {
+	ReleaseTime time.Time
+	Amount      uint64
+	Claimed     bool
+}
+
+// VestingSchedule represents a series of vesting entries.
+type VestingSchedule struct {
+	Entries []VestingEntry
+}
+
+// NewVestingSchedule creates a schedule with the given entries.
+func NewVestingSchedule(entries []VestingEntry) *VestingSchedule {
+	return &VestingSchedule{Entries: entries}
+}
+
+// Claim releases all matured, unclaimed amounts up to now.
+func (v *VestingSchedule) Claim(now time.Time) uint64 {
+	var total uint64
+	for i := range v.Entries {
+		e := &v.Entries[i]
+		if !e.Claimed && !now.Before(e.ReleaseTime) {
+			e.Claimed = true
+			total += e.Amount
+		}
+	}
+	return total
+}
+
+// Pending returns the amount still locked after the provided time.
+func (v *VestingSchedule) Pending(now time.Time) uint64 {
+	var total uint64
+	for _, e := range v.Entries {
+		if !e.Claimed && now.Before(e.ReleaseTime) {
+			total += e.Amount
+		}
+	}
+	return total
+}

--- a/core/syn2700_test.go
+++ b/core/syn2700_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVestingSchedule(t *testing.T) {
+	now := time.Unix(0, 0)
+	entries := []VestingEntry{{ReleaseTime: now.Add(time.Hour), Amount: 50}, {ReleaseTime: now.Add(2 * time.Hour), Amount: 50}}
+	schedule := NewVestingSchedule(entries)
+
+	if claimed := schedule.Claim(now); claimed != 0 {
+		t.Fatalf("expected nothing claimable at start")
+	}
+
+	after := now.Add(time.Hour + time.Minute)
+	if claimed := schedule.Claim(after); claimed != 50 {
+		t.Fatalf("expected 50, got %d", claimed)
+	}
+	if pending := schedule.Pending(after); pending != 50 {
+		t.Fatalf("expected 50 pending, got %d", pending)
+	}
+}

--- a/core/syn2900.go
+++ b/core/syn2900.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"errors"
+	"time"
+)
+
+// TokenInsurancePolicy represents a blockchain based insurance policy.
+type TokenInsurancePolicy struct {
+	PolicyID   string
+	Holder     string
+	Coverage   string
+	Premium    uint64
+	Payout     uint64
+	Deductible uint64
+	Limit      uint64
+	Start      time.Time
+	End        time.Time
+	Claimed    bool
+}
+
+// NewTokenInsurancePolicy issues a new policy.
+func NewTokenInsurancePolicy(id, holder, coverage string, premium, payout, deductible, limit uint64, start, end time.Time) *TokenInsurancePolicy {
+	return &TokenInsurancePolicy{
+		PolicyID:   id,
+		Holder:     holder,
+		Coverage:   coverage,
+		Premium:    premium,
+		Payout:     payout,
+		Deductible: deductible,
+		Limit:      limit,
+		Start:      start,
+		End:        end,
+	}
+}
+
+// IsActive reports whether the policy is active at the given time.
+func (p *TokenInsurancePolicy) IsActive(now time.Time) bool {
+	return !now.Before(p.Start) && now.Before(p.End) && !p.Claimed
+}
+
+// Claim marks the policy as claimed and returns the payout.
+func (p *TokenInsurancePolicy) Claim(now time.Time) (uint64, error) {
+	if !p.IsActive(now) {
+		return 0, errors.New("policy inactive")
+	}
+	p.Claimed = true
+	return p.Payout, nil
+}

--- a/core/syn2900_test.go
+++ b/core/syn2900_test.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenInsurancePolicy(t *testing.T) {
+	start := time.Unix(0, 0)
+	end := start.Add(24 * time.Hour)
+	policy := NewTokenInsurancePolicy("p1", "alice", "coverage", 10, 1000, 0, 1000, start, end)
+	now := start.Add(12 * time.Hour)
+	if !policy.IsActive(now) {
+		t.Fatalf("policy should be active")
+	}
+	payout, err := policy.Claim(now)
+	if err != nil || payout != 1000 {
+		t.Fatalf("claim failed: %v %d", err, payout)
+	}
+	if policy.IsActive(now) {
+		t.Fatalf("policy should be inactive after claim")
+	}
+}

--- a/core/syn3600.go
+++ b/core/syn3600.go
@@ -1,0 +1,28 @@
+package core
+
+import "time"
+
+// FuturesContract defines the essential metadata of a futures contract.
+type FuturesContract struct {
+	Underlying string
+	Quantity   uint64
+	Price      uint64 // entry price per unit
+	Expiration time.Time
+	Settled    bool
+}
+
+// NewFuturesContract creates a new futures contract.
+func NewFuturesContract(underlying string, quantity, price uint64, expiration time.Time) *FuturesContract {
+	return &FuturesContract{Underlying: underlying, Quantity: quantity, Price: price, Expiration: expiration}
+}
+
+// IsExpired returns true if the contract has reached expiration.
+func (f *FuturesContract) IsExpired(now time.Time) bool {
+	return !now.Before(f.Expiration)
+}
+
+// Settle marks the contract settled and returns PnL for the long side.
+func (f *FuturesContract) Settle(marketPrice uint64) int64 {
+	f.Settled = true
+	return int64(marketPrice-f.Price) * int64(f.Quantity)
+}

--- a/core/syn3600_test.go
+++ b/core/syn3600_test.go
@@ -1,0 +1,21 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFuturesContract(t *testing.T) {
+	exp := time.Unix(100, 0)
+	f := NewFuturesContract("BTC", 2, 1000, exp)
+	pnl := f.Settle(1100)
+	if pnl != 200 {
+		t.Fatalf("expected pnl 200, got %d", pnl)
+	}
+	if !f.Settled {
+		t.Fatalf("contract should be settled")
+	}
+	if !f.IsExpired(time.Unix(200, 0)) {
+		t.Fatalf("expected expired")
+	}
+}

--- a/core/syn3800.go
+++ b/core/syn3800.go
@@ -1,0 +1,63 @@
+package core
+
+import "errors"
+
+// GrantRecord captures metadata for a SYN3800 grant token.
+type GrantRecord struct {
+	ID          uint64
+	Beneficiary string
+	Name        string
+	Amount      uint64
+	Released    uint64
+	Notes       []string
+}
+
+// GrantRegistry manages grant records.
+type GrantRegistry struct {
+	grants map[uint64]*GrantRecord
+	nextID uint64
+}
+
+// NewGrantRegistry creates a new registry.
+func NewGrantRegistry() *GrantRegistry {
+	return &GrantRegistry{grants: make(map[uint64]*GrantRecord)}
+}
+
+// CreateGrant registers a new grant and returns its ID.
+func (r *GrantRegistry) CreateGrant(beneficiary, name string, amount uint64) uint64 {
+	r.nextID++
+	id := r.nextID
+	r.grants[id] = &GrantRecord{ID: id, Beneficiary: beneficiary, Name: name, Amount: amount}
+	return id
+}
+
+// Disburse releases a portion of the grant.
+func (r *GrantRegistry) Disburse(id uint64, amount uint64, note string) error {
+	g, ok := r.grants[id]
+	if !ok {
+		return errors.New("grant not found")
+	}
+	if g.Released+amount > g.Amount {
+		return errors.New("insufficient remaining funds")
+	}
+	g.Released += amount
+	if note != "" {
+		g.Notes = append(g.Notes, note)
+	}
+	return nil
+}
+
+// GetGrant returns a grant record by ID.
+func (r *GrantRegistry) GetGrant(id uint64) (*GrantRecord, bool) {
+	g, ok := r.grants[id]
+	return g, ok
+}
+
+// ListGrants returns all grants.
+func (r *GrantRegistry) ListGrants() []*GrantRecord {
+	res := make([]*GrantRecord, 0, len(r.grants))
+	for _, g := range r.grants {
+		res = append(res, g)
+	}
+	return res
+}

--- a/core/syn3800_test.go
+++ b/core/syn3800_test.go
@@ -1,0 +1,19 @@
+package core
+
+import "testing"
+
+func TestGrantRegistry(t *testing.T) {
+	r := NewGrantRegistry()
+	id := r.CreateGrant("bob", "research", 100)
+	if err := r.Disburse(id, 40, "phase1"); err != nil {
+		t.Fatalf("disburse: %v", err)
+	}
+	g, ok := r.GetGrant(id)
+	if !ok || g.Released != 40 {
+		t.Fatalf("unexpected grant state: %#v", g)
+	}
+	list := r.ListGrants()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 grant, got %d", len(list))
+	}
+}

--- a/core/syn3900.go
+++ b/core/syn3900.go
@@ -1,0 +1,50 @@
+package core
+
+import "errors"
+
+// BenefitRecord holds metadata for a government benefit token issuance.
+type BenefitRecord struct {
+	ID        uint64
+	Recipient string
+	Program   string
+	Amount    uint64
+	Claimed   bool
+}
+
+// BenefitRegistry manages benefit records.
+type BenefitRegistry struct {
+	benefits map[uint64]*BenefitRecord
+	nextID   uint64
+}
+
+// NewBenefitRegistry creates a new registry.
+func NewBenefitRegistry() *BenefitRegistry {
+	return &BenefitRegistry{benefits: make(map[uint64]*BenefitRecord)}
+}
+
+// RegisterBenefit records a new benefit and returns its ID.
+func (r *BenefitRegistry) RegisterBenefit(recipient, program string, amount uint64) uint64 {
+	r.nextID++
+	id := r.nextID
+	r.benefits[id] = &BenefitRecord{ID: id, Recipient: recipient, Program: program, Amount: amount}
+	return id
+}
+
+// Claim marks the benefit as claimed.
+func (r *BenefitRegistry) Claim(id uint64) error {
+	b, ok := r.benefits[id]
+	if !ok {
+		return errors.New("benefit not found")
+	}
+	if b.Claimed {
+		return errors.New("benefit already claimed")
+	}
+	b.Claimed = true
+	return nil
+}
+
+// GetBenefit retrieves a benefit by ID.
+func (r *BenefitRegistry) GetBenefit(id uint64) (*BenefitRecord, bool) {
+	b, ok := r.benefits[id]
+	return b, ok
+}

--- a/core/syn3900_test.go
+++ b/core/syn3900_test.go
@@ -1,0 +1,15 @@
+package core
+
+import "testing"
+
+func TestBenefitRegistry(t *testing.T) {
+	r := NewBenefitRegistry()
+	id := r.RegisterBenefit("alice", "housing", 500)
+	if err := r.Claim(id); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	b, ok := r.GetBenefit(id)
+	if !ok || !b.Claimed {
+		t.Fatalf("benefit not claimed properly")
+	}
+}

--- a/core/syn5000.go
+++ b/core/syn5000.go
@@ -1,0 +1,62 @@
+package core
+
+import "errors"
+
+// BetRecord stores betting activity for SYN5000 tokens.
+type BetRecord struct {
+	ID       uint64
+	Bettor   string
+	Amount   uint64
+	Odds     float64
+	Game     string
+	Resolved bool
+	Won      bool
+}
+
+// SYN5000Token implements the GamblingToken interface.
+type SYN5000Token struct {
+	Name     string
+	Symbol   string
+	Decimals uint8
+
+	nextBetID uint64
+	bets      map[uint64]*BetRecord
+}
+
+// NewSYN5000Token creates a new gambling token instance.
+func NewSYN5000Token(name, symbol string, decimals uint8) *SYN5000Token {
+	return &SYN5000Token{Name: name, Symbol: symbol, Decimals: decimals, bets: make(map[uint64]*BetRecord)}
+}
+
+// PlaceBet records a new bet and returns its ID.
+func (t *SYN5000Token) PlaceBet(bettor string, amount uint64, odds float64, game string) uint64 {
+	t.nextBetID++
+	id := t.nextBetID
+	t.bets[id] = &BetRecord{ID: id, Bettor: bettor, Amount: amount, Odds: odds, Game: game}
+	return id
+}
+
+// ResolveBet resolves a bet and returns the payout if won.
+func (t *SYN5000Token) ResolveBet(betID uint64, win bool) (uint64, error) {
+	b, ok := t.bets[betID]
+	if !ok {
+		return 0, errors.New("bet not found")
+	}
+	if b.Resolved {
+		return 0, errors.New("bet already resolved")
+	}
+	b.Resolved = true
+	b.Won = win
+	if win {
+		return uint64(float64(b.Amount) * b.Odds), nil
+	}
+	return 0, nil
+}
+
+// GetBet returns a bet record by ID.
+func (t *SYN5000Token) GetBet(betID uint64) (*BetRecord, bool) {
+	b, ok := t.bets[betID]
+	return b, ok
+}
+
+var _ GamblingToken = (*SYN5000Token)(nil)

--- a/core/syn5000_index.go
+++ b/core/syn5000_index.go
@@ -1,0 +1,8 @@
+package core
+
+// GamblingToken exposes methods of the SYN5000 token.
+type GamblingToken interface {
+	PlaceBet(bettor string, amount uint64, odds float64, game string) uint64
+	ResolveBet(betID uint64, win bool) (uint64, error)
+	GetBet(betID uint64) (*BetRecord, bool)
+}

--- a/core/syn5000_test.go
+++ b/core/syn5000_test.go
@@ -1,0 +1,15 @@
+package core
+
+import "testing"
+
+func TestSYN5000Token(t *testing.T) {
+	token := NewSYN5000Token("Gamble", "GMB", 0)
+	id := token.PlaceBet("alice", 100, 2.0, "dice")
+	payout, err := token.ResolveBet(id, true)
+	if err != nil || payout != 200 {
+		t.Fatalf("expected payout 200 got %d err %v", payout, err)
+	}
+	if b, ok := token.GetBet(id); !ok || !b.Resolved || !b.Won {
+		t.Fatalf("bet not resolved correctly")
+	}
+}

--- a/module_guide.md
+++ b/module_guide.md
@@ -366,7 +366,7 @@ Every file under `core/` is listed below with a short description derived from i
 - **module_plugin.go** – OpcodeModule represents an external package that wishes to register additional
 - **molecular_node.go** – MolecularNode operates at the molecular level combining networking with ledger
 - **monomaniac_recovery.go** – Monomaniac account recovery module provides a 3-of-4 verification
-- **music_royalty_token.go** – MusicInfo captures the metadata for a music asset represented by SYN1600.
+- **syn1600.go** – MusicToken captures metadata and royalty splits for a SYN1600 music asset.
 - **nat_traversal.go** – NATManager manages NAT traversal using NAT-PMP or UPnP.
 - **network.go** – Package core implements P2P networking for Synnergy nodes.
 - **network_test.go** – Implements network test functionality.


### PR DESCRIPTION
## Summary
- add SYN1600 music token with metadata and royalty distribution
- implement SYN1700 event ticketing token
- create registries for trade finance (SYN2100), vesting schedules (SYN2700), insurance policies (SYN2900), futures contracts (SYN3600), grants (SYN3800), benefits (SYN3900), and gambling token API (SYN5000)
- update module guide for SYN1600 entry

## Testing
- `go test ./...` *(fails: case-insensitive import collision)*
- `go test ./core` *(fails: go: updates to go.mod needed)*

------
https://chatgpt.com/codex/tasks/task_e_68902cf901f48320b818db9b8d5c646e