### PR TITLE
Add advanced token modules

### DIFF
--- a/Tokens/syn200.go
+++ b/Tokens/syn200.go
@@ -1,0 +1,151 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// CarbonProject represents a registered carbon offset project.
+type CarbonProject struct {
+	ID             string
+	Owner          string
+	Name           string
+	TotalCredits   uint64
+	IssuedCredits  uint64
+	RetiredCredits uint64
+	Balances       map[string]uint64
+	Verifications  []Verification
+	CreatedAt      time.Time
+}
+
+// Verification captures an audit or verification record for a project.
+type Verification struct {
+	Verifier string
+	RecordID string
+	Status   string
+	Time     time.Time
+}
+
+// CarbonRegistry manages carbon credit projects and issuance.
+type CarbonRegistry struct {
+	mu       sync.RWMutex
+	projects map[string]*CarbonProject
+	counter  uint64
+}
+
+// NewCarbonRegistry creates an empty carbon credit registry.
+func NewCarbonRegistry() *CarbonRegistry {
+	return &CarbonRegistry{projects: make(map[string]*CarbonProject)}
+}
+
+// Register creates a new carbon project and returns its identifier.
+func (r *CarbonRegistry) Register(owner, name string, total uint64) *CarbonProject {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counter++
+	id := fmt.Sprintf("CP-%d", r.counter)
+	p := &CarbonProject{
+		ID:           id,
+		Owner:        owner,
+		Name:         name,
+		TotalCredits: total,
+		Balances:     make(map[string]uint64),
+		CreatedAt:    time.Now(),
+	}
+	r.projects[id] = p
+	return p
+}
+
+// Issue credits from a project to a holder.
+func (r *CarbonRegistry) Issue(projectID, holder string, amount uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.projects[projectID]
+	if !ok {
+		return errors.New("project not found")
+	}
+	if p.IssuedCredits+amount > p.TotalCredits {
+		return errors.New("insufficient credits remaining")
+	}
+	p.IssuedCredits += amount
+	p.Balances[holder] += amount
+	return nil
+}
+
+// Retire removes credits from circulation for a holder.
+func (r *CarbonRegistry) Retire(projectID, holder string, amount uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.projects[projectID]
+	if !ok {
+		return errors.New("project not found")
+	}
+	bal := p.Balances[holder]
+	if bal < amount {
+		return errors.New("insufficient holder balance")
+	}
+	p.Balances[holder] = bal - amount
+	p.RetiredCredits += amount
+	p.IssuedCredits -= amount
+	return nil
+}
+
+// AddVerification attaches a verification record to a project.
+func (r *CarbonRegistry) AddVerification(projectID, verifier, verID, status string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.projects[projectID]
+	if !ok {
+		return errors.New("project not found")
+	}
+	v := Verification{Verifier: verifier, RecordID: verID, Status: status, Time: time.Now()}
+	p.Verifications = append(p.Verifications, v)
+	return nil
+}
+
+// Verifications lists verification records for a project.
+func (r *CarbonRegistry) Verifications(projectID string) ([]Verification, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.projects[projectID]
+	if !ok {
+		return nil, false
+	}
+	return append([]Verification(nil), p.Verifications...), true
+}
+
+// ProjectInfo returns project details by ID.
+func (r *CarbonRegistry) ProjectInfo(projectID string) (*CarbonProject, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.projects[projectID]
+	if !ok {
+		return nil, false
+	}
+	cp := *p
+	cp.Balances = make(map[string]uint64)
+	for k, v := range p.Balances {
+		cp.Balances[k] = v
+	}
+	cp.Verifications = append([]Verification(nil), p.Verifications...)
+	return &cp, true
+}
+
+// ListProjects returns all registered carbon projects.
+func (r *CarbonRegistry) ListProjects() []*CarbonProject {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	res := make([]*CarbonProject, 0, len(r.projects))
+	for _, p := range r.projects {
+		cp := *p
+		cp.Balances = make(map[string]uint64)
+		for k, v := range p.Balances {
+			cp.Balances[k] = v
+		}
+		cp.Verifications = append([]Verification(nil), p.Verifications...)
+		res = append(res, &cp)
+	}
+	return res
+}

--- a/Tokens/syn2369.go
+++ b/Tokens/syn2369.go
@@ -1,0 +1,102 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// VirtualItem represents a virtual world asset for SYN2369 tokens.
+type VirtualItem struct {
+	ItemID      string
+	Owner       string
+	Name        string
+	Description string
+	Attributes  map[string]string
+	CreatedAt   time.Time
+}
+
+// ItemRegistry manages virtual items.
+type ItemRegistry struct {
+	mu      sync.RWMutex
+	items   map[string]*VirtualItem
+	counter uint64
+}
+
+// NewItemRegistry creates an empty registry.
+func NewItemRegistry() *ItemRegistry {
+	return &ItemRegistry{items: make(map[string]*VirtualItem)}
+}
+
+// CreateItem registers a new virtual item.
+func (r *ItemRegistry) CreateItem(owner, name, desc string, attrs map[string]string) *VirtualItem {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counter++
+	id := fmt.Sprintf("VI-%d", r.counter)
+	item := &VirtualItem{ItemID: id, Owner: owner, Name: name, Description: desc, Attributes: make(map[string]string), CreatedAt: time.Now()}
+	for k, v := range attrs {
+		item.Attributes[k] = v
+	}
+	r.items[id] = item
+	return item
+}
+
+// TransferItem transfers ownership of an item.
+func (r *ItemRegistry) TransferItem(itemID, newOwner string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	it, ok := r.items[itemID]
+	if !ok {
+		return errors.New("item not found")
+	}
+	it.Owner = newOwner
+	return nil
+}
+
+// UpdateAttributes updates custom attributes for an item.
+func (r *ItemRegistry) UpdateAttributes(itemID string, attrs map[string]string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	it, ok := r.items[itemID]
+	if !ok {
+		return errors.New("item not found")
+	}
+	for k, v := range attrs {
+		it.Attributes[k] = v
+	}
+	return nil
+}
+
+// GetItem retrieves an item by ID.
+func (r *ItemRegistry) GetItem(itemID string) (*VirtualItem, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	it, ok := r.items[itemID]
+	if !ok {
+		return nil, false
+	}
+	cp := *it
+	cp.Attributes = make(map[string]string)
+	for k, v := range it.Attributes {
+		cp.Attributes[k] = v
+	}
+	return &cp, true
+}
+
+// ListItems returns all virtual items.
+func (r *ItemRegistry) ListItems() []*VirtualItem {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	res := make([]*VirtualItem, 0, len(r.items))
+	for _, it := range r.items {
+		cp := *it
+		cp.Attributes = make(map[string]string)
+		for k, v := range it.Attributes {
+			cp.Attributes[k] = v
+		}
+		res = append(res, &cp)
+	}
+	return res
+}

--- a/Tokens/syn2600.go
+++ b/Tokens/syn2600.go
@@ -1,0 +1,107 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// InvestorTokenMeta defines metadata for SYN2600 investor tokens.
+type InvestorTokenMeta struct {
+	ID       string
+	Asset    string
+	Owner    string
+	Shares   uint64
+	IssuedAt time.Time
+	Expiry   time.Time
+	Active   bool
+	Returns  []ReturnRecord
+}
+
+// ReturnRecord logs a distribution paid to the investor.
+type ReturnRecord struct {
+	Amount uint64
+	Time   time.Time
+}
+
+// InvestorRegistry tracks issued investor tokens.
+type InvestorRegistry struct {
+	mu      sync.RWMutex
+	tokens  map[string]*InvestorTokenMeta
+	counter uint64
+}
+
+// NewInvestorRegistry creates an empty registry.
+func NewInvestorRegistry() *InvestorRegistry {
+	return &InvestorRegistry{tokens: make(map[string]*InvestorTokenMeta)}
+}
+
+// Issue creates a new investor token for a given asset.
+func (r *InvestorRegistry) Issue(asset, owner string, shares uint64, expiry time.Time) *InvestorTokenMeta {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counter++
+	id := fmt.Sprintf("INV-%d", r.counter)
+	tok := &InvestorTokenMeta{
+		ID:       id,
+		Asset:    asset,
+		Owner:    owner,
+		Shares:   shares,
+		IssuedAt: time.Now(),
+		Expiry:   expiry,
+		Active:   true,
+	}
+	r.tokens[id] = tok
+	return tok
+}
+
+// Transfer moves ownership of a token to a new owner.
+func (r *InvestorRegistry) Transfer(tokenID, newOwner string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tok, ok := r.tokens[tokenID]
+	if !ok {
+		return errors.New("token not found")
+	}
+	tok.Owner = newOwner
+	return nil
+}
+
+// RecordReturn records a return payment to an investor token.
+func (r *InvestorRegistry) RecordReturn(tokenID string, amount uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	tok, ok := r.tokens[tokenID]
+	if !ok {
+		return errors.New("token not found")
+	}
+	tok.Returns = append(tok.Returns, ReturnRecord{Amount: amount, Time: time.Now()})
+	return nil
+}
+
+// Get retrieves a token by identifier.
+func (r *InvestorRegistry) Get(tokenID string) (*InvestorTokenMeta, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	tok, ok := r.tokens[tokenID]
+	if !ok {
+		return nil, false
+	}
+	cp := *tok
+	cp.Returns = append([]ReturnRecord(nil), tok.Returns...)
+	return &cp, true
+}
+
+// List returns all issued investor tokens.
+func (r *InvestorRegistry) List() []*InvestorTokenMeta {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	res := make([]*InvestorTokenMeta, 0, len(r.tokens))
+	for _, tok := range r.tokens {
+		cp := *tok
+		cp.Returns = append([]ReturnRecord(nil), tok.Returns...)
+		res = append(res, &cp)
+	}
+	return res
+}

--- a/Tokens/syn2800.go
+++ b/Tokens/syn2800.go
@@ -1,0 +1,115 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// LifePolicy defines the metadata for a SYN2800 life insurance token.
+type LifePolicy struct {
+	PolicyID    string
+	Insured     string
+	Beneficiary string
+	Coverage    uint64
+	Premium     uint64
+	Start       time.Time
+	End         time.Time
+	PaidPremium uint64
+	Claims      []Claim
+	Active      bool
+}
+
+// Claim represents a filed claim against a policy.
+type Claim struct {
+	ClaimID string
+	Amount  uint64
+	Time    time.Time
+	Settled bool
+}
+
+// LifePolicyRegistry manages life insurance policies.
+type LifePolicyRegistry struct {
+	mu       sync.RWMutex
+	policies map[string]*LifePolicy
+	counter  uint64
+}
+
+// NewLifePolicyRegistry creates an empty registry.
+func NewLifePolicyRegistry() *LifePolicyRegistry {
+	return &LifePolicyRegistry{policies: make(map[string]*LifePolicy)}
+}
+
+// IssuePolicy issues a new life insurance policy.
+func (r *LifePolicyRegistry) IssuePolicy(insured, beneficiary string, coverage, premium uint64, start, end time.Time) *LifePolicy {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counter++
+	id := fmt.Sprintf("LP-%d", r.counter)
+	p := &LifePolicy{
+		PolicyID:    id,
+		Insured:     insured,
+		Beneficiary: beneficiary,
+		Coverage:    coverage,
+		Premium:     premium,
+		Start:       start,
+		End:         end,
+		Active:      true,
+	}
+	r.policies[id] = p
+	return p
+}
+
+// PayPremium records a premium payment against a policy.
+func (r *LifePolicyRegistry) PayPremium(policyID string, amount uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.policies[policyID]
+	if !ok {
+		return errors.New("policy not found")
+	}
+	p.PaidPremium += amount
+	return nil
+}
+
+// FileClaim creates a claim record for a policy.
+func (r *LifePolicyRegistry) FileClaim(policyID string, amount uint64) (*Claim, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.policies[policyID]
+	if !ok {
+		return nil, errors.New("policy not found")
+	}
+	r.counter++
+	id := fmt.Sprintf("CL-%d", r.counter)
+	c := Claim{ClaimID: id, Amount: amount, Time: time.Now()}
+	p.Claims = append(p.Claims, c)
+	return &c, nil
+}
+
+// GetPolicy retrieves policy information.
+func (r *LifePolicyRegistry) GetPolicy(policyID string) (*LifePolicy, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.policies[policyID]
+	if !ok {
+		return nil, false
+	}
+	cp := *p
+	cp.Claims = append([]Claim(nil), p.Claims...)
+	return &cp, true
+}
+
+// ListPolicies lists all life policies.
+func (r *LifePolicyRegistry) ListPolicies() []*LifePolicy {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	res := make([]*LifePolicy, 0, len(r.policies))
+	for _, p := range r.policies {
+		cp := *p
+		cp.Claims = append([]Claim(nil), p.Claims...)
+		res = append(res, &cp)
+	}
+	return res
+}

--- a/Tokens/syn2900.go
+++ b/Tokens/syn2900.go
@@ -1,0 +1,107 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// InsurancePolicy defines metadata for a SYN2900 general insurance token.
+type InsurancePolicy struct {
+	PolicyID   string
+	Holder     string
+	Coverage   string
+	Premium    uint64
+	Payout     uint64
+	Deductible uint64
+	Limit      uint64
+	Start      time.Time
+	End        time.Time
+	Claims     []ClaimRecord
+	Active     bool
+}
+
+// ClaimRecord captures claim details for insurance policies.
+type ClaimRecord struct {
+	ClaimID string
+	Amount  uint64
+	Desc    string
+	Time    time.Time
+	Settled bool
+}
+
+// InsuranceRegistry manages SYN2900 policies.
+type InsuranceRegistry struct {
+	mu       sync.RWMutex
+	policies map[string]*InsurancePolicy
+	counter  uint64
+}
+
+// NewInsuranceRegistry creates an empty registry.
+func NewInsuranceRegistry() *InsuranceRegistry {
+	return &InsuranceRegistry{policies: make(map[string]*InsurancePolicy)}
+}
+
+// IssuePolicy issues a new insurance policy.
+func (r *InsuranceRegistry) IssuePolicy(holder, coverage string, premium, payout, deductible, limit uint64, start, end time.Time) *InsurancePolicy {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counter++
+	id := fmt.Sprintf("IP-%d", r.counter)
+	p := &InsurancePolicy{
+		PolicyID:   id,
+		Holder:     holder,
+		Coverage:   coverage,
+		Premium:    premium,
+		Payout:     payout,
+		Deductible: deductible,
+		Limit:      limit,
+		Start:      start,
+		End:        end,
+		Active:     true,
+	}
+	r.policies[id] = p
+	return p
+}
+
+// FileClaim records a claim against a policy.
+func (r *InsuranceRegistry) FileClaim(policyID, desc string, amount uint64) (*ClaimRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.policies[policyID]
+	if !ok {
+		return nil, errors.New("policy not found")
+	}
+	r.counter++
+	id := fmt.Sprintf("IC-%d", r.counter)
+	c := ClaimRecord{ClaimID: id, Amount: amount, Desc: desc, Time: time.Now()}
+	p.Claims = append(p.Claims, c)
+	return &c, nil
+}
+
+// GetPolicy retrieves a policy by ID.
+func (r *InsuranceRegistry) GetPolicy(policyID string) (*InsurancePolicy, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.policies[policyID]
+	if !ok {
+		return nil, false
+	}
+	cp := *p
+	cp.Claims = append([]ClaimRecord(nil), p.Claims...)
+	return &cp, true
+}
+
+// ListPolicies lists all insurance policies.
+func (r *InsuranceRegistry) ListPolicies() []*InsurancePolicy {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	res := make([]*InsurancePolicy, 0, len(r.policies))
+	for _, p := range r.policies {
+		cp := *p
+		cp.Claims = append([]ClaimRecord(nil), p.Claims...)
+		res = append(res, &cp)
+	}
+	return res
+}

--- a/Tokens/syn3400.go
+++ b/Tokens/syn3400.go
@@ -1,0 +1,77 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ForexMetadata defines pair specific information for SYN3400 tokens.
+type ForexPair struct {
+	PairID    string
+	Base      string
+	Quote     string
+	Rate      float64
+	UpdatedAt time.Time
+}
+
+// ForexRegistry tracks registered Forex pairs.
+type ForexRegistry struct {
+	mu      sync.RWMutex
+	pairs   map[string]*ForexPair
+	counter uint64
+}
+
+// NewForexRegistry creates an empty registry.
+func NewForexRegistry() *ForexRegistry {
+	return &ForexRegistry{pairs: make(map[string]*ForexPair)}
+}
+
+// Register adds a new forex pair to the registry.
+func (r *ForexRegistry) Register(base, quote string, rate float64) *ForexPair {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counter++
+	id := fmt.Sprintf("FX-%d", r.counter)
+	p := &ForexPair{PairID: id, Base: base, Quote: quote, Rate: rate, UpdatedAt: time.Now()}
+	r.pairs[id] = p
+	return p
+}
+
+// UpdateRate updates the exchange rate for a pair.
+func (r *ForexRegistry) UpdateRate(pairID string, rate float64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.pairs[pairID]
+	if !ok {
+		return errors.New("pair not found")
+	}
+	p.Rate = rate
+	p.UpdatedAt = time.Now()
+	return nil
+}
+
+// Get retrieves a forex pair by ID.
+func (r *ForexRegistry) Get(pairID string) (*ForexPair, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.pairs[pairID]
+	if !ok {
+		return nil, false
+	}
+	cp := *p
+	return &cp, true
+}
+
+// List returns all registered forex pairs.
+func (r *ForexRegistry) List() []*ForexPair {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	res := make([]*ForexPair, 0, len(r.pairs))
+	for _, p := range r.pairs {
+		cp := *p
+		res = append(res, &cp)
+	}
+	return res
+}

--- a/Tokens/syn845.go
+++ b/Tokens/syn845.go
@@ -1,0 +1,99 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// DebtMetadata stores comprehensive data about a debt instrument.
+type DebtRecord struct {
+	DebtID    string
+	Borrower  string
+	Principal uint64
+	Rate      float64
+	Penalty   float64
+	Due       time.Time
+	Paid      uint64
+}
+
+// DebtToken represents a SYN845 debt token.
+type DebtToken struct {
+	ID     string
+	Name   string
+	Symbol string
+	Owner  string
+	Supply uint64
+	Debts  map[string]*DebtRecord
+}
+
+// DebtRegistry manages debt tokens.
+type DebtRegistry struct {
+	mu      sync.RWMutex
+	tokens  map[string]*DebtToken
+	counter uint64
+}
+
+// NewDebtRegistry creates an empty debt token registry.
+func NewDebtRegistry() *DebtRegistry {
+	return &DebtRegistry{tokens: make(map[string]*DebtToken)}
+}
+
+// CreateToken initializes a new debt token.
+func (r *DebtRegistry) CreateToken(name, symbol, owner string, supply uint64) (string, *DebtToken) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counter++
+	id := fmt.Sprintf("DEBT-%d", r.counter)
+	t := &DebtToken{ID: id, Name: name, Symbol: symbol, Owner: owner, Supply: supply, Debts: make(map[string]*DebtRecord)}
+	r.tokens[id] = t
+	return id, t
+}
+
+// IssueDebt issues a debt instrument under a token.
+func (r *DebtRegistry) IssueDebt(tokenID, debtID, borrower string, principal uint64, rate, penalty float64, due time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tokens[tokenID]
+	if !ok {
+		return errors.New("token not found")
+	}
+	if _, exists := t.Debts[debtID]; exists {
+		return errors.New("debt already exists")
+	}
+	t.Debts[debtID] = &DebtRecord{DebtID: debtID, Borrower: borrower, Principal: principal, Rate: rate, Penalty: penalty, Due: due}
+	return nil
+}
+
+// RecordPayment records a payment toward a debt.
+func (r *DebtRegistry) RecordPayment(tokenID, debtID string, amount uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t, ok := r.tokens[tokenID]
+	if !ok {
+		return errors.New("token not found")
+	}
+	d, ok := t.Debts[debtID]
+	if !ok {
+		return errors.New("debt not found")
+	}
+	d.Paid += amount
+	return nil
+}
+
+// GetDebt returns information about a specific debt.
+func (r *DebtRegistry) GetDebt(tokenID, debtID string) (*DebtRecord, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tokens[tokenID]
+	if !ok {
+		return nil, errors.New("token not found")
+	}
+	d, ok := t.Debts[debtID]
+	if !ok {
+		return nil, errors.New("debt not found")
+	}
+	cp := *d
+	return &cp, nil
+}


### PR DESCRIPTION
## Summary
- add carbon credit registry for SYN200 tokens with issuance, retirement and verification tracking
- introduce investor, life insurance, general insurance, forex pair, debt, and virtual item token registries

## Testing
- `go test ./...` *(fails: case-insensitive import collision in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68902cd6c0e48320b5c1784de6055931