### PR TITLE
Add security and identity core modules

### DIFF
--- a/core/access_control.go
+++ b/core/access_control.go
@@ -1,0 +1,63 @@
+package core
+
+import "sync"
+
+// AccessController manages role based access permissions.
+type AccessController struct {
+	mu    sync.RWMutex
+	roles map[string]map[string]struct{}
+}
+
+// NewAccessController constructs a new AccessController instance.
+func NewAccessController() *AccessController {
+	return &AccessController{roles: make(map[string]map[string]struct{})}
+}
+
+// Grant assigns a role to an address.
+func (a *AccessController) Grant(role, addr string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, ok := a.roles[addr]; !ok {
+		a.roles[addr] = make(map[string]struct{})
+	}
+	a.roles[addr][role] = struct{}{}
+}
+
+// Revoke removes a role from an address.
+func (a *AccessController) Revoke(role, addr string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if roles, ok := a.roles[addr]; ok {
+		delete(roles, role)
+		if len(roles) == 0 {
+			delete(a.roles, addr)
+		}
+	}
+}
+
+// HasRole checks whether an address has a specific role.
+func (a *AccessController) HasRole(role, addr string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	roles, ok := a.roles[addr]
+	if !ok {
+		return false
+	}
+	_, ok = roles[role]
+	return ok
+}
+
+// List returns all roles assigned to an address.
+func (a *AccessController) List(addr string) []string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	roles, ok := a.roles[addr]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(roles))
+	for r := range roles {
+		out = append(out, r)
+	}
+	return out
+}

--- a/core/access_control_test.go
+++ b/core/access_control_test.go
@@ -1,0 +1,19 @@
+package core
+
+import "testing"
+
+func TestAccessController(t *testing.T) {
+	ac := NewAccessController()
+	ac.Grant("admin", "addr1")
+	if !ac.HasRole("admin", "addr1") {
+		t.Fatalf("expected role granted")
+	}
+	roles := ac.List("addr1")
+	if len(roles) != 1 || roles[0] != "admin" {
+		t.Fatalf("unexpected roles: %v", roles)
+	}
+	ac.Revoke("admin", "addr1")
+	if ac.HasRole("admin", "addr1") {
+		t.Fatalf("role should be revoked")
+	}
+}

--- a/core/address_zero.go
+++ b/core/address_zero.go
@@ -1,0 +1,11 @@
+package core
+
+import "strings"
+
+// AddressZero represents the zero-value address (all 20 bytes set to zero).
+const AddressZero = "0x0000000000000000000000000000000000000000"
+
+// IsZeroAddress returns true if the provided address equals AddressZero.
+func IsZeroAddress(addr string) bool {
+	return strings.ToLower(addr) == AddressZero
+}

--- a/core/address_zero_test.go
+++ b/core/address_zero_test.go
@@ -1,0 +1,12 @@
+package core
+
+import "testing"
+
+func TestIsZeroAddress(t *testing.T) {
+	if !IsZeroAddress(AddressZero) {
+		t.Fatalf("expected zero address to match")
+	}
+	if IsZeroAddress("0xabc") {
+		t.Fatalf("non-zero address detected as zero")
+	}
+}

--- a/core/identity_verification.go
+++ b/core/identity_verification.go
@@ -1,0 +1,76 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// IdentityInfo contains basic identity metadata.
+type IdentityInfo struct {
+	Name        string
+	DateOfBirth string
+	Nationality string
+}
+
+// VerificationLog records a verification attempt.
+type VerificationLog struct {
+	Method    string
+	Timestamp time.Time
+}
+
+// IdentityService manages verified addresses on the ledger.
+type IdentityService struct {
+	mu         sync.RWMutex
+	identities map[string]IdentityInfo
+	logs       map[string][]VerificationLog
+}
+
+// NewIdentityService creates a new IdentityService instance.
+func NewIdentityService() *IdentityService {
+	return &IdentityService{
+		identities: make(map[string]IdentityInfo),
+		logs:       make(map[string][]VerificationLog),
+	}
+}
+
+// Register stores identity information for an address.
+func (s *IdentityService) Register(addr, name, dob, nationality string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.identities[addr]; exists {
+		return errors.New("identity already registered")
+	}
+	s.identities[addr] = IdentityInfo{Name: name, DateOfBirth: dob, Nationality: nationality}
+	return nil
+}
+
+// Verify records a verification method for an address.
+func (s *IdentityService) Verify(addr, method string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.identities[addr]; !exists {
+		return errors.New("identity not registered")
+	}
+	log := VerificationLog{Method: method, Timestamp: time.Now()}
+	s.logs[addr] = append(s.logs[addr], log)
+	return nil
+}
+
+// Info retrieves identity information for an address.
+func (s *IdentityService) Info(addr string) (IdentityInfo, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	info, ok := s.identities[addr]
+	return info, ok
+}
+
+// Logs returns verification logs for an address.
+func (s *IdentityService) Logs(addr string) []VerificationLog {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entries := s.logs[addr]
+	out := make([]VerificationLog, len(entries))
+	copy(out, entries)
+	return out
+}

--- a/core/identity_verification_test.go
+++ b/core/identity_verification_test.go
@@ -1,0 +1,21 @@
+package core
+
+import "testing"
+
+func TestIdentityService(t *testing.T) {
+	svc := NewIdentityService()
+	if err := svc.Register("addr1", "Alice", "2000-01-01", "US"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := svc.Verify("addr1", "passport"); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	info, ok := svc.Info("addr1")
+	if !ok || info.Name != "Alice" {
+		t.Fatalf("unexpected info: %v", info)
+	}
+	logs := svc.Logs("addr1")
+	if len(logs) != 1 || logs[0].Method != "passport" {
+		t.Fatalf("unexpected logs: %v", logs)
+	}
+}

--- a/core/idwallet_registration.go
+++ b/core/idwallet_registration.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"errors"
+	"sync"
+)
+
+// IDRegistry manages on-chain registration of wallets that hold identity tokens.
+type IDRegistry struct {
+	mu      sync.RWMutex
+	wallets map[string]string // address -> metadata/info
+}
+
+// NewIDRegistry creates a new IDRegistry instance.
+func NewIDRegistry() *IDRegistry {
+	return &IDRegistry{wallets: make(map[string]string)}
+}
+
+// Register adds a wallet with associated info. Returns error if already registered.
+func (r *IDRegistry) Register(addr, info string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.wallets[addr]; exists {
+		return errors.New("wallet already registered")
+	}
+	r.wallets[addr] = info
+	return nil
+}
+
+// Info returns registration info for an address if present.
+func (r *IDRegistry) Info(addr string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	info, ok := r.wallets[addr]
+	return info, ok
+}

--- a/core/idwallet_registration_test.go
+++ b/core/idwallet_registration_test.go
@@ -1,0 +1,16 @@
+package core
+
+import "testing"
+
+func TestIDRegistry(t *testing.T) {
+	reg := NewIDRegistry()
+	if err := reg.Register("addr1", "metadata"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, ok := reg.Info("addr1"); !ok {
+		t.Fatalf("expected wallet registered")
+	}
+	if err := reg.Register("addr1", "other"); err == nil {
+		t.Fatalf("expected error for duplicate registration")
+	}
+}

--- a/core/private_transactions.go
+++ b/core/private_transactions.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"io"
+	"sync"
+)
+
+// Encrypt encrypts plaintext using AES-GCM with the provided key.
+// The returned slice contains nonce||ciphertext.
+func Encrypt(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	cipherText := gcm.Seal(nonce, nonce, plaintext, nil)
+	return cipherText, nil
+}
+
+// Decrypt decrypts data produced by Encrypt.
+func Decrypt(key, data []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return nil, io.ErrUnexpectedEOF
+	}
+	nonce, cipherText := data[:nonceSize], data[nonceSize:]
+	return gcm.Open(nil, nonce, cipherText, nil)
+}
+
+// PrivateTransaction holds an encrypted payload.
+type PrivateTransaction struct {
+	Payload []byte
+}
+
+// PrivateTxManager manages private transactions.
+type PrivateTxManager struct {
+	mu  sync.Mutex
+	txs []PrivateTransaction
+}
+
+// NewPrivateTxManager creates a new PrivateTxManager.
+func NewPrivateTxManager() *PrivateTxManager {
+	return &PrivateTxManager{}
+}
+
+// Send adds a private transaction to the internal pool.
+func (m *PrivateTxManager) Send(tx PrivateTransaction) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.txs = append(m.txs, tx)
+}
+
+// List returns a copy of stored private transactions.
+func (m *PrivateTxManager) List() []PrivateTransaction {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]PrivateTransaction, len(m.txs))
+	copy(out, m.txs)
+	return out
+}

--- a/core/private_transactions_test.go
+++ b/core/private_transactions_test.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	key := make([]byte, 32)
+	payload := []byte("hello world")
+	cipherText, err := Encrypt(key, payload)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	plain, err := Decrypt(key, cipherText)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(plain, payload) {
+		t.Fatalf("unexpected plaintext: %v", plain)
+	}
+}
+
+func TestPrivateTxManager(t *testing.T) {
+	m := NewPrivateTxManager()
+	tx := PrivateTransaction{Payload: []byte("data")}
+	m.Send(tx)
+	if len(m.List()) != 1 {
+		t.Fatalf("transaction not stored")
+	}
+}

--- a/core/zero_trust_data_channels.go
+++ b/core/zero_trust_data_channels.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"errors"
+	"sync"
+)
+
+// DataChannel represents a secure channel with an encryption key.
+type DataChannel struct {
+	Key      []byte
+	Messages [][]byte
+	Open     bool
+}
+
+// ZeroTrustEngine manages encrypted data channels backed by ledger escrows.
+type ZeroTrustEngine struct {
+	mu       sync.RWMutex
+	channels map[string]*DataChannel
+}
+
+// NewZeroTrustEngine creates a new ZeroTrustEngine instance.
+func NewZeroTrustEngine() *ZeroTrustEngine {
+	return &ZeroTrustEngine{channels: make(map[string]*DataChannel)}
+}
+
+// OpenChannel initialises a new channel with the provided key.
+func (e *ZeroTrustEngine) OpenChannel(id string, key []byte) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if _, exists := e.channels[id]; exists {
+		return errors.New("channel already exists")
+	}
+	e.channels[id] = &DataChannel{Key: key, Open: true}
+	return nil
+}
+
+// Send encrypts and stores a payload on the channel.
+func (e *ZeroTrustEngine) Send(id string, payload []byte) ([]byte, error) {
+	e.mu.RLock()
+	ch, ok := e.channels[id]
+	e.mu.RUnlock()
+	if !ok || !ch.Open {
+		return nil, errors.New("channel not open")
+	}
+	cipherText, err := Encrypt(ch.Key, payload)
+	if err != nil {
+		return nil, err
+	}
+	e.mu.Lock()
+	ch.Messages = append(ch.Messages, cipherText)
+	e.mu.Unlock()
+	return cipherText, nil
+}
+
+// Messages returns encrypted messages for a channel.
+func (e *ZeroTrustEngine) Messages(id string) [][]byte {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	ch, ok := e.channels[id]
+	if !ok {
+		return nil
+	}
+	out := make([][]byte, len(ch.Messages))
+	for i, m := range ch.Messages {
+		cp := make([]byte, len(m))
+		copy(cp, m)
+		out[i] = cp
+	}
+	return out
+}
+
+// CloseChannel closes the channel and prevents further messages.
+func (e *ZeroTrustEngine) CloseChannel(id string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	ch, ok := e.channels[id]
+	if !ok {
+		return errors.New("channel not found")
+	}
+	ch.Open = false
+	return nil
+}

--- a/core/zero_trust_data_channels_test.go
+++ b/core/zero_trust_data_channels_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestZeroTrustEngine(t *testing.T) {
+	eng := NewZeroTrustEngine()
+	key := make([]byte, 32)
+	if err := eng.OpenChannel("ch1", key); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	payload := []byte("secret")
+	ct, err := eng.Send("ch1", payload)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	pt, err := Decrypt(key, ct)
+	if err != nil || string(pt) != string(payload) {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if err := eng.CloseChannel("ch1"); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := eng.Send("ch1", payload); err == nil {
+		t.Fatalf("expected error sending on closed channel")
+	}
+}


### PR DESCRIPTION
## Summary
- implement role-based access controller
- add zero address helper
- provide identity registration and verification service
- add ID wallet registry and private transaction utilities
- manage encrypted zero-trust data channels

## Testing
- `go test ./...` *(fails: case-insensitive import collision in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68902ca92af88320985320d7f942fc8f