### PR TITLE
core: add mining, staking, and faucet modules

### DIFF
--- a/core/faucet.go
+++ b/core/faucet.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// Faucet dispenses test tokens with rate limiting.
+type Faucet struct {
+	mu           sync.Mutex
+	balance      uint64
+	amount       uint64
+	cooldown     time.Duration
+	lastRequests map[string]time.Time
+}
+
+// NewFaucet returns a Faucet with the given balance, dispense amount and cooldown.
+func NewFaucet(balance, amount uint64, cooldown time.Duration) *Faucet {
+	return &Faucet{
+		balance:      balance,
+		amount:       amount,
+		cooldown:     cooldown,
+		lastRequests: make(map[string]time.Time),
+	}
+}
+
+// Request sends faucet funds to addr if cooldown has passed.
+func (f *Faucet) Request(addr string) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	now := time.Now()
+	if last, ok := f.lastRequests[addr]; ok && now.Sub(last) < f.cooldown {
+		return 0, errors.New("cooldown active")
+	}
+	if f.balance < f.amount {
+		return 0, errors.New("insufficient faucet balance")
+	}
+	f.balance -= f.amount
+	f.lastRequests[addr] = now
+	return f.amount, nil
+}
+
+// Balance returns the remaining faucet balance.
+func (f *Faucet) Balance() uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.balance
+}
+
+// UpdateConfig sets the dispense amount and cooldown period.
+func (f *Faucet) UpdateConfig(amount uint64, cooldown time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.amount = amount
+	f.cooldown = cooldown
+}

--- a/core/faucet_test.go
+++ b/core/faucet_test.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFaucet(t *testing.T) {
+	f := NewFaucet(100, 10, time.Second)
+	amt, err := f.Request("addr")
+	if err != nil || amt != 10 {
+		t.Fatalf("first request failed: %v %d", err, amt)
+	}
+	if _, err := f.Request("addr"); err == nil {
+		t.Fatalf("expected cooldown error")
+	}
+	time.Sleep(time.Second)
+	if _, err := f.Request("addr"); err != nil {
+		t.Fatalf("second request after cooldown failed: %v", err)
+	}
+	f.UpdateConfig(5, time.Millisecond)
+	if f.Balance() != 80 {
+		t.Fatalf("unexpected balance: %d", f.Balance())
+	}
+}

--- a/core/mining_node.go
+++ b/core/mining_node.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sync"
+)
+
+// MiningNode performs proof-of-work style mining operations.
+type MiningNode struct {
+	mu       sync.Mutex
+	active   bool
+	hashRate uint64
+	nonce    uint64
+}
+
+// NewMiningNode creates a mining node with the supplied hashrate hint.
+func NewMiningNode(hashRate uint64) *MiningNode {
+	return &MiningNode{hashRate: hashRate}
+}
+
+// Start activates the mining process.
+func (mn *MiningNode) Start() {
+	mn.mu.Lock()
+	mn.active = true
+	mn.mu.Unlock()
+}
+
+// Stop deactivates mining operations.
+func (mn *MiningNode) Stop() {
+	mn.mu.Lock()
+	mn.active = false
+	mn.mu.Unlock()
+}
+
+// IsMining reports whether the node is currently mining.
+func (mn *MiningNode) IsMining() bool {
+	mn.mu.Lock()
+	defer mn.mu.Unlock()
+	return mn.active
+}
+
+// Mine runs a single hashing attempt over data and returns the resulting hash.
+func (mn *MiningNode) Mine(data []byte) (string, error) {
+	mn.mu.Lock()
+	if !mn.active {
+		mn.mu.Unlock()
+		return "", errors.New("mining inactive")
+	}
+	nonce := mn.nonce
+	mn.nonce++
+	mn.mu.Unlock()
+	buf := append(data, byte(nonce))
+	h := sha256.Sum256(buf)
+	return hex.EncodeToString(h[:]), nil
+}
+
+// HashRateHint returns the configured hash rate for the node.
+func (mn *MiningNode) HashRateHint() uint64 {
+	mn.mu.Lock()
+	defer mn.mu.Unlock()
+	return mn.hashRate
+}

--- a/core/mining_node_test.go
+++ b/core/mining_node_test.go
@@ -1,0 +1,25 @@
+package core
+
+import "testing"
+
+func TestMiningNode(t *testing.T) {
+	mn := NewMiningNode(100)
+	if mn.IsMining() {
+		t.Fatalf("expected node to be stopped initially")
+	}
+	mn.Start()
+	if !mn.IsMining() {
+		t.Fatalf("node should be mining after Start")
+	}
+	hash, err := mn.Mine([]byte("data"))
+	if err != nil || hash == "" {
+		t.Fatalf("mine returned invalid hash: %v %s", err, hash)
+	}
+	mn.Stop()
+	if mn.IsMining() {
+		t.Fatalf("node should be stopped after Stop")
+	}
+	if _, err := mn.Mine([]byte("data")); err == nil {
+		t.Fatalf("expected error when mining is inactive")
+	}
+}

--- a/core/mobile_mining_node.go
+++ b/core/mobile_mining_node.go
@@ -1,0 +1,52 @@
+package core
+
+import "sync"
+
+// MobileMiningNode adapts mining to operate within mobile constraints.
+type MobileMiningNode struct {
+	base       *MiningNode
+	mu         sync.Mutex
+	powerLimit uint64
+}
+
+// NewMobileMiningNode creates a MobileMiningNode wrapping a standard mining node.
+func NewMobileMiningNode(hashRate, powerLimit uint64) *MobileMiningNode {
+	return &MobileMiningNode{base: NewMiningNode(hashRate), powerLimit: powerLimit}
+}
+
+// Start activates the underlying mining node if within power limits.
+func (mm *MobileMiningNode) Start() {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+	mm.base.Start()
+}
+
+// Stop halts the mining process.
+func (mm *MobileMiningNode) Stop() { mm.base.Stop() }
+
+// IsMining reports whether the node is currently mining.
+func (mm *MobileMiningNode) IsMining() bool { return mm.base.IsMining() }
+
+// Mine delegates to the underlying mining node.
+func (mm *MobileMiningNode) Mine(data []byte) (string, error) {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+	if mm.powerLimit == 0 {
+		return "", nil
+	}
+	return mm.base.Mine(data)
+}
+
+// SetPowerLimit updates the allowed power usage for mining operations.
+func (mm *MobileMiningNode) SetPowerLimit(limit uint64) {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+	mm.powerLimit = limit
+}
+
+// PowerLimit returns the configured power limit.
+func (mm *MobileMiningNode) PowerLimit() uint64 {
+	mm.mu.Lock()
+	defer mm.mu.Unlock()
+	return mm.powerLimit
+}

--- a/core/mobile_mining_node_test.go
+++ b/core/mobile_mining_node_test.go
@@ -1,0 +1,22 @@
+package core
+
+import "testing"
+
+func TestMobileMiningNode(t *testing.T) {
+	mm := NewMobileMiningNode(50, 1)
+	mm.Start()
+	if !mm.IsMining() {
+		t.Fatalf("expected mining to be active")
+	}
+	if _, err := mm.Mine([]byte("block")); err != nil {
+		t.Fatalf("mine failed: %v", err)
+	}
+	mm.SetPowerLimit(0)
+	if hash, _ := mm.Mine([]byte("block")); hash != "" {
+		t.Fatalf("expected empty hash when power limit is zero")
+	}
+	mm.Stop()
+	if mm.IsMining() {
+		t.Fatalf("expected mining to stop")
+	}
+}

--- a/core/stake_penalty.go
+++ b/core/stake_penalty.go
@@ -1,0 +1,17 @@
+package core
+
+// StakePenaltyManager adjusts stakes for validators based on behaviour.
+type StakePenaltyManager struct{}
+
+// NewStakePenaltyManager creates a new StakePenaltyManager.
+func NewStakePenaltyManager() *StakePenaltyManager { return &StakePenaltyManager{} }
+
+// Slash reduces the stake of addr on sn by the given penalty amount.
+func (spm *StakePenaltyManager) Slash(sn *StakingNode, addr string, penalty uint64) {
+	sn.Unstake(addr, penalty)
+}
+
+// Reward increases the stake of addr on sn by the given amount.
+func (spm *StakePenaltyManager) Reward(sn *StakingNode, addr string, reward uint64) {
+	sn.Stake(addr, reward)
+}

--- a/core/stake_penalty_test.go
+++ b/core/stake_penalty_test.go
@@ -1,0 +1,17 @@
+package core
+
+import "testing"
+
+func TestStakePenaltyManager(t *testing.T) {
+	sn := NewStakingNode()
+	sn.Stake("validator", 100)
+	spm := NewStakePenaltyManager()
+	spm.Slash(sn, "validator", 30)
+	if sn.Balance("validator") != 70 {
+		t.Fatalf("expected 70 after slash, got %d", sn.Balance("validator"))
+	}
+	spm.Reward(sn, "validator", 10)
+	if sn.Balance("validator") != 80 {
+		t.Fatalf("expected 80 after reward, got %d", sn.Balance("validator"))
+	}
+}

--- a/core/staking_node.go
+++ b/core/staking_node.go
@@ -1,0 +1,52 @@
+package core
+
+import "sync"
+
+// StakingNode manages token staking for governance or validation purposes.
+type StakingNode struct {
+	mu     sync.Mutex
+	stakes map[string]uint64
+}
+
+// NewStakingNode initializes and returns a StakingNode instance.
+func NewStakingNode() *StakingNode {
+	return &StakingNode{stakes: make(map[string]uint64)}
+}
+
+// Stake locks tokens from addr, increasing their staked balance.
+func (s *StakingNode) Stake(addr string, amt uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stakes[addr] += amt
+}
+
+// Unstake releases tokens for addr, reducing their staked balance. If the
+// amount exceeds the current stake it removes the stake entirely.
+func (s *StakingNode) Unstake(addr string, amt uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	bal := s.stakes[addr]
+	if amt >= bal {
+		delete(s.stakes, addr)
+		return
+	}
+	s.stakes[addr] = bal - amt
+}
+
+// Balance returns the current staked balance for addr.
+func (s *StakingNode) Balance(addr string) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stakes[addr]
+}
+
+// TotalStaked returns the total tokens staked across all addresses.
+func (s *StakingNode) TotalStaked() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var total uint64
+	for _, amt := range s.stakes {
+		total += amt
+	}
+	return total
+}

--- a/core/staking_node_test.go
+++ b/core/staking_node_test.go
@@ -1,0 +1,28 @@
+package core
+
+import "testing"
+
+func TestStakingNodeStakeAndUnstake(t *testing.T) {
+	sn := NewStakingNode()
+	sn.Stake("addr1", 100)
+	if sn.Balance("addr1") != 100 {
+		t.Fatalf("expected 100, got %d", sn.Balance("addr1"))
+	}
+	sn.Unstake("addr1", 40)
+	if sn.Balance("addr1") != 60 {
+		t.Fatalf("expected 60 after unstake, got %d", sn.Balance("addr1"))
+	}
+	sn.Unstake("addr1", 100)
+	if sn.Balance("addr1") != 0 {
+		t.Fatalf("expected 0 after removing stake, got %d", sn.Balance("addr1"))
+	}
+}
+
+func TestStakingNodeTotal(t *testing.T) {
+	sn := NewStakingNode()
+	sn.Stake("a", 50)
+	sn.Stake("b", 75)
+	if sn.TotalStaked() != 125 {
+		t.Fatalf("expected total 125, got %d", sn.TotalStaked())
+	}
+}


### PR DESCRIPTION
## Summary
- implement staking management with balance tracking and total stake queries
- add stake penalty manager for slashing and rewarding validators
- introduce mining node primitives including mobile variant
- provide configurable faucet with rate limiting

## Testing
- `go test -mod=mod ./core -run TestFaucet -count=1` *(fails: case-insensitive import collision in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68902c2900f483209ea218fe6fa48bd8