### PR TITLE
feat: add smart contract and vm modules

### DIFF
--- a/core/ai_enhanced_contract.go
+++ b/core/ai_enhanced_contract.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"errors"
+	"sync"
+)
+
+// AIContractRegistry wraps a base ContractRegistry to keep metadata specific to
+// AI enhanced contracts such as the model hash used for inference.
+type AIContractRegistry struct {
+	base *ContractRegistry
+	mu   sync.RWMutex
+	meta map[string]string // contract address -> model hash
+}
+
+// NewAIContractRegistry creates a new registry using the provided base
+// registry. The base registry handles deployment and invocation while this type
+// tracks additional AI metadata.
+func NewAIContractRegistry(base *ContractRegistry) *AIContractRegistry {
+	return &AIContractRegistry{
+		base: base,
+		meta: make(map[string]string),
+	}
+}
+
+// DeployAIContract deploys the WASM bytecode and records the associated model
+// hash. The returned address can later be used to invoke the contract.
+func (r *AIContractRegistry) DeployAIContract(wasm []byte, modelHash, manifest string, gasLimit uint64, owner string) (string, error) {
+	addr, err := r.base.Deploy(wasm, manifest, gasLimit, owner)
+	if err != nil {
+		return "", err
+	}
+	r.mu.Lock()
+	r.meta[addr] = modelHash
+	r.mu.Unlock()
+	return addr, nil
+}
+
+// InvokeAIContract invokes the "infer" method of the specified contract. The
+// input payload is passed as arguments to the VM.
+func (r *AIContractRegistry) InvokeAIContract(addr string, input []byte, gasLimit uint64) ([]byte, uint64, error) {
+	if _, ok := r.meta[addr]; !ok {
+		return nil, 0, errors.New("ai contract not found")
+	}
+	return r.base.Invoke(addr, "infer", input, gasLimit)
+}
+
+// ModelHash returns the stored model hash for the given contract.
+func (r *AIContractRegistry) ModelHash(addr string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	h, ok := r.meta[addr]
+	return h, ok
+}

--- a/core/ai_enhanced_contract_test.go
+++ b/core/ai_enhanced_contract_test.go
@@ -1,0 +1,24 @@
+package core
+
+import "testing"
+
+func TestAIContractRegistry(t *testing.T) {
+	vm := NewSimpleVM()
+	_ = vm.Start()
+	base := NewContractRegistry(vm)
+	aiReg := NewAIContractRegistry(base)
+	addr, err := aiReg.DeployAIContract([]byte{0x01}, "modelhash", "", 5, "owner")
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	if h, ok := aiReg.ModelHash(addr); !ok || h != "modelhash" {
+		t.Fatalf("model hash mismatch")
+	}
+	out, _, err := aiReg.InvokeAIContract(addr, []byte("input"), 5)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if string(out) != "input" {
+		t.Fatalf("unexpected output")
+	}
+}

--- a/core/contract_management.go
+++ b/core/contract_management.go
@@ -1,0 +1,76 @@
+package core
+
+import "errors"
+
+// ContractManager provides administrative operations over deployed contracts.
+type ContractManager struct {
+	registry *ContractRegistry
+}
+
+// NewContractManager wires a manager to an existing registry.
+func NewContractManager(reg *ContractRegistry) *ContractManager {
+	return &ContractManager{registry: reg}
+}
+
+// Transfer changes the owner of a contract.
+func (m *ContractManager) Transfer(addr, newOwner string) error {
+	c, ok := m.registry.Get(addr)
+	if !ok {
+		return errors.New("contract not found")
+	}
+	m.registry.mu.Lock()
+	c.Owner = newOwner
+	m.registry.mu.Unlock()
+	return nil
+}
+
+// Pause disables contract execution.
+func (m *ContractManager) Pause(addr string) error {
+	c, ok := m.registry.Get(addr)
+	if !ok {
+		return errors.New("contract not found")
+	}
+	m.registry.mu.Lock()
+	c.Paused = true
+	m.registry.mu.Unlock()
+	return nil
+}
+
+// Resume enables execution for a paused contract.
+func (m *ContractManager) Resume(addr string) error {
+	c, ok := m.registry.Get(addr)
+	if !ok {
+		return errors.New("contract not found")
+	}
+	m.registry.mu.Lock()
+	c.Paused = false
+	m.registry.mu.Unlock()
+	return nil
+}
+
+// Upgrade replaces contract bytecode and optional gas limit.
+func (m *ContractManager) Upgrade(addr string, wasm []byte, gasLimit uint64) error {
+	if len(wasm) == 0 {
+		return errors.New("wasm bytecode required")
+	}
+	c, ok := m.registry.Get(addr)
+	if !ok {
+		return errors.New("contract not found")
+	}
+	m.registry.mu.Lock()
+	c.WASM = wasm
+	if gasLimit > 0 {
+		c.GasLimit = gasLimit
+	}
+	m.registry.mu.Unlock()
+	return nil
+}
+
+// Info returns contract metadata including owner and paused status.
+func (m *ContractManager) Info(addr string) (*Contract, error) {
+	c, ok := m.registry.Get(addr)
+	if !ok {
+		return nil, errors.New("contract not found")
+	}
+	return c, nil
+}

--- a/core/contract_management_test.go
+++ b/core/contract_management_test.go
@@ -1,0 +1,32 @@
+package core
+
+import "testing"
+
+func TestContractManager(t *testing.T) {
+	vm := NewSimpleVM()
+	_ = vm.Start()
+	reg := NewContractRegistry(vm)
+	addr, err := reg.Deploy([]byte{0x01}, "", 5, "owner")
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	mgr := NewContractManager(reg)
+	if err := mgr.Pause(addr); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if _, _, err := reg.Invoke(addr, "", nil, 5); err == nil {
+		t.Fatalf("expected error invoking paused contract")
+	}
+	if err := mgr.Resume(addr); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if err := mgr.Transfer(addr, "new"); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if c, err := mgr.Info(addr); err != nil || c.Owner != "new" {
+		t.Fatalf("info mismatch")
+	}
+	if err := mgr.Upgrade(addr, []byte{0x02}, 6); err != nil {
+		t.Fatalf("upgrade: %v", err)
+	}
+}

--- a/core/contracts.go
+++ b/core/contracts.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sync"
+)
+
+// Contract represents a deployed smart contract. It keeps minimal metadata
+// required by the CLI and other modules to manage and invoke contracts.
+type Contract struct {
+	Address  string // deterministic hash of the WASM bytecode
+	Owner    string // creator/owner address
+	WASM     []byte // raw WASM bytecode
+	Manifest string // optional Ricardian manifest JSON
+	GasLimit uint64 // max gas allowed per invocation
+	Paused   bool   // whether execution is paused
+}
+
+// VirtualMachine defines the execution interface required by the contract
+// registry. The VM is implemented in virtual_machine.go.
+type VirtualMachine interface {
+	Execute(wasm []byte, method string, args []byte, gasLimit uint64) ([]byte, uint64, error)
+	Start() error
+	Stop() error
+	Status() bool
+}
+
+// ContractRegistry stores deployed contracts and offers helper methods for
+// deployment and invocation. It is safe for concurrent use.
+type ContractRegistry struct {
+	mu        sync.RWMutex
+	contracts map[string]*Contract
+	vm        VirtualMachine
+}
+
+// NewContractRegistry initialises an empty registry backed by the provided VM.
+func NewContractRegistry(vm VirtualMachine) *ContractRegistry {
+	return &ContractRegistry{
+		contracts: make(map[string]*Contract),
+		vm:        vm,
+	}
+}
+
+// CompileWASM returns the input bytecode and its sha256 hash. In the full
+// implementation this would also convert WAT to WASM, but here we simply return
+// the bytes unmodified for deterministic builds.
+func CompileWASM(src []byte) ([]byte, string, error) {
+	if len(src) == 0 {
+		return nil, "", errors.New("source bytecode is empty")
+	}
+	h := sha256.Sum256(src)
+	return src, hex.EncodeToString(h[:]), nil
+}
+
+// Deploy registers a new contract. The address is derived from the bytecode
+// hash. If a contract with the same address already exists an error is
+// returned.
+func (r *ContractRegistry) Deploy(wasm []byte, manifest string, gasLimit uint64, owner string) (string, error) {
+	if len(wasm) == 0 {
+		return "", errors.New("wasm bytecode required")
+	}
+	hash := sha256.Sum256(wasm)
+	addr := hex.EncodeToString(hash[:])
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.contracts[addr]; exists {
+		return "", errors.New("contract already deployed")
+	}
+	r.contracts[addr] = &Contract{
+		Address:  addr,
+		Owner:    owner,
+		WASM:     wasm,
+		Manifest: manifest,
+		GasLimit: gasLimit,
+	}
+	return addr, nil
+}
+
+// Invoke executes a method on the specified contract via the configured VM.
+// It returns the output bytes and the gas consumed.
+func (r *ContractRegistry) Invoke(addr, method string, args []byte, gasLimit uint64) ([]byte, uint64, error) {
+	r.mu.RLock()
+	c, ok := r.contracts[addr]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, 0, errors.New("contract not found")
+	}
+	if c.Paused {
+		return nil, 0, errors.New("contract paused")
+	}
+	if gasLimit == 0 || gasLimit > c.GasLimit {
+		gasLimit = c.GasLimit
+	}
+	return r.vm.Execute(c.WASM, method, args, gasLimit)
+}
+
+// List returns all deployed contracts.
+func (r *ContractRegistry) List() []*Contract {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*Contract, 0, len(r.contracts))
+	for _, c := range r.contracts {
+		out = append(out, c)
+	}
+	return out
+}
+
+// Get fetches a contract by address.
+func (r *ContractRegistry) Get(addr string) (*Contract, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.contracts[addr]
+	return c, ok
+}

--- a/core/contracts_opcodes.go
+++ b/core/contracts_opcodes.go
@@ -1,0 +1,32 @@
+package core
+
+// contracts_opcodes.go exposes well-known opcode values for contract related
+// operations. The opcodes are resolved at init time using the registry in
+// opcode.go to ensure they stay consistent with the rest of the system.
+
+// NOTE: these are variables rather than constants because the opcode catalogue
+// is normalised during package initialisation. The helper ensures lookups panic
+// if an opcode name is missing which would indicate a mismatch with the
+// catalogue.
+
+var (
+	OpInitContracts    = opcodeByName("InitContracts")
+	OpPauseContract    = opcodeByName("PauseContract")
+	OpResumeContract   = opcodeByName("ResumeContract")
+	OpUpgradeContract  = opcodeByName("UpgradeContract")
+	OpContractInfo     = opcodeByName("ContractInfo")
+	OpDeployAIContract = opcodeByName("DeployAIContract")
+	OpInvokeAIContract = opcodeByName("InvokeAIContract")
+)
+
+func opcodeByName(name string) Opcode {
+	b, err := ToBytecode(name)
+	if err != nil {
+		panic(err)
+	}
+	op, err := ParseOpcode(b)
+	if err != nil {
+		panic(err)
+	}
+	return op
+}

--- a/core/contracts_test.go
+++ b/core/contracts_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestContractRegistry(t *testing.T) {
+	vm := NewSimpleVM()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	reg := NewContractRegistry(vm)
+	wasm := []byte{0x00, 0x61}
+	addr, err := reg.Deploy(wasm, "", 10, "owner")
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	if len(reg.List()) != 1 {
+		t.Fatalf("expected 1 contract")
+	}
+	out, _, err := reg.Invoke(addr, "echo", []byte("hi"), 10)
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if string(out) != "hi" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}

--- a/core/virtual_machine.go
+++ b/core/virtual_machine.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// SimpleVM is a lightweight execution engine used by the contract registry. It
+// mimics gas accounting and method dispatch but does not attempt to execute real
+// WASM bytecode. The type satisfies the VirtualMachine interface.
+type SimpleVM struct {
+	mu      sync.RWMutex
+	running bool
+}
+
+// NewSimpleVM creates a new stopped virtual machine instance.
+func NewSimpleVM() *SimpleVM { return &SimpleVM{} }
+
+// Start marks the VM as running. It is safe to call multiple times.
+func (vm *SimpleVM) Start() error {
+	vm.mu.Lock()
+	defer vm.mu.Unlock()
+	if vm.running {
+		return nil
+	}
+	vm.running = true
+	return nil
+}
+
+// Stop halts the VM instance.
+func (vm *SimpleVM) Stop() error {
+	vm.mu.Lock()
+	defer vm.mu.Unlock()
+	if !vm.running {
+		return nil
+	}
+	vm.running = false
+	return nil
+}
+
+// Status reports whether the VM is running.
+func (vm *SimpleVM) Status() bool {
+	vm.mu.RLock()
+	defer vm.mu.RUnlock()
+	return vm.running
+}
+
+// Execute pretends to execute WASM bytecode. It returns the args unchanged as
+// output and consumes gas proportionally to the input size. This behaviour keeps
+// tests deterministic while providing a realistic API surface.
+func (vm *SimpleVM) Execute(wasm []byte, method string, args []byte, gasLimit uint64) ([]byte, uint64, error) {
+	if !vm.Status() {
+		return nil, 0, errors.New("vm not running")
+	}
+	// naive gas model: 1 unit per byte of args with a minimum of 1
+	gasUsed := uint64(len(args))
+	if gasUsed == 0 {
+		gasUsed = 1
+	}
+	if gasUsed > gasLimit {
+		return nil, gasLimit, errors.New("gas limit exceeded")
+	}
+	// simulate execution delay
+	time.Sleep(time.Millisecond)
+	out := make([]byte, len(args))
+	copy(out, args)
+	return out, gasUsed, nil
+}

--- a/core/virtual_machine_test.go
+++ b/core/virtual_machine_test.go
@@ -1,0 +1,23 @@
+package core
+
+import "testing"
+
+func TestSimpleVM(t *testing.T) {
+	vm := NewSimpleVM()
+	if vm.Status() {
+		t.Fatalf("expected stopped")
+	}
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	out, gas, err := vm.Execute(nil, "", []byte{1, 2, 3}, 10)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gas != 3 || len(out) != 3 {
+		t.Fatalf("unexpected result")
+	}
+	if err := vm.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}

--- a/core/vm_sandbox_management.go
+++ b/core/vm_sandbox_management.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// SandboxInfo holds runtime limits and state for a single sandboxed contract
+// execution environment.
+type SandboxInfo struct {
+	ID           string
+	ContractAddr string
+	GasLimit     uint64
+	MemoryLimit  uint64
+	Active       bool
+	LastReset    time.Time
+	CreatedAt    time.Time
+}
+
+// SandboxManager manages multiple sandboxes used to isolate contract
+// execution. It is safe for concurrent use.
+type SandboxManager struct {
+	mu        sync.RWMutex
+	sandboxes map[string]*SandboxInfo
+}
+
+// NewSandboxManager returns an empty manager.
+func NewSandboxManager() *SandboxManager {
+	return &SandboxManager{sandboxes: make(map[string]*SandboxInfo)}
+}
+
+// StartSandbox creates a new sandbox for the given contract address.
+func (m *SandboxManager) StartSandbox(id, contractAddr string, gasLimit, memoryLimit uint64) (*SandboxInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.sandboxes[id]; exists {
+		return nil, errors.New("sandbox already exists")
+	}
+	sb := &SandboxInfo{
+		ID:           id,
+		ContractAddr: contractAddr,
+		GasLimit:     gasLimit,
+		MemoryLimit:  memoryLimit,
+		Active:       true,
+		CreatedAt:    time.Now(),
+		LastReset:    time.Now(),
+	}
+	m.sandboxes[id] = sb
+	return sb, nil
+}
+
+// StopSandbox deactivates a sandbox.
+func (m *SandboxManager) StopSandbox(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sb, ok := m.sandboxes[id]
+	if !ok {
+		return errors.New("sandbox not found")
+	}
+	sb.Active = false
+	return nil
+}
+
+// ResetSandbox updates the LastReset timestamp for a sandbox.
+func (m *SandboxManager) ResetSandbox(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sb, ok := m.sandboxes[id]
+	if !ok {
+		return errors.New("sandbox not found")
+	}
+	sb.LastReset = time.Now()
+	return nil
+}
+
+// SandboxStatus returns sandbox information by ID.
+func (m *SandboxManager) SandboxStatus(id string) (*SandboxInfo, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	sb, ok := m.sandboxes[id]
+	return sb, ok
+}
+
+// ListSandboxes returns all sandboxes managed by this instance.
+func (m *SandboxManager) ListSandboxes() []*SandboxInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*SandboxInfo, 0, len(m.sandboxes))
+	for _, sb := range m.sandboxes {
+		out = append(out, sb)
+	}
+	return out
+}

--- a/core/vm_sandbox_management_test.go
+++ b/core/vm_sandbox_management_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestSandboxManager(t *testing.T) {
+	m := NewSandboxManager()
+	sb, err := m.StartSandbox("sb1", "addr", 10, 64)
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !sb.Active {
+		t.Fatalf("expected active sandbox")
+	}
+	if err := m.ResetSandbox("sb1"); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if err := m.StopSandbox("sb1"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if sb, ok := m.SandboxStatus("sb1"); !ok || sb.Active {
+		t.Fatalf("status mismatch")
+	}
+	if len(m.ListSandboxes()) != 1 {
+		t.Fatalf("list mismatch")
+	}
+}


### PR DESCRIPTION
## Summary
- add contract registry with deploy and invoke helpers
- provide VM runtime, sandbox manager and opcodes
- support contract administration and AI contract registry

## Testing
- `go test ./...` *(fails: case-insensitive import collision: "synnergy/nodes" and "synnergy/Nodes")*


------
https://chatgpt.com/codex/tasks/task_e_68902c47852483209b15ff44bbfb3fe2