### PR TITLE
Refine transaction metadata fields

### DIFF
--- a/core/transaction.go
+++ b/core/transaction.go
@@ -40,7 +40,15 @@ type Transaction struct {
 // reproduced deterministically prior to signing.  Transactions default to the
 // Transfer type unless modified by higher level logic.
 func NewTransaction(from, to string, amount, fee, nonce uint64) *Transaction {
-	tx := &Transaction{From: from, To: to, Amount: amount, Fee: fee, Nonce: nonce, Timestamp: time.Now().Unix(), Type: TxTypeTransfer}
+	tx := &Transaction{
+		From:      from,
+		To:        to,
+		Amount:    amount,
+		Fee:       fee,
+		Nonce:     nonce,
+		Timestamp: time.Now().Unix(),
+		Type:      TxTypeTransfer,
+	}
 	tx.ID = tx.Hash()
 	return tx
 }
@@ -49,7 +57,17 @@ func NewTransaction(from, to string, amount, fee, nonce uint64) *Transaction {
 // signature.  It is used as the message for signing and verification.
 func (t *Transaction) Hash() string {
 	bio := hex.EncodeToString(t.BiometricHash)
-	h := sha256.Sum256([]byte(fmt.Sprintf("%s%s%d%d%d%d%s", t.From, t.To, t.Amount, t.Fee, t.Nonce, t.Timestamp, bio)))
+	h := sha256.Sum256([]byte(fmt.Sprintf(
+		"%s%s%d%d%d%d%d%s",
+		t.From,
+		t.To,
+		t.Amount,
+		t.Fee,
+		t.Nonce,
+		t.Timestamp,
+		t.Type,
+		bio,
+	)))
 	return hex.EncodeToString(h[:])
 }
 


### PR DESCRIPTION
## Summary
- initialize fee, nonce, timestamp and type in Transaction constructor
- incorporate transaction type and biometric hash when computing transaction IDs

## Testing
- `go test -mod=mod ./core` *(fails: case-insensitive import collision in core/base_node.go)*

------
https://chatgpt.com/codex/tasks/task_e_689035b4047c8320951cbc1191457372