### PR TITLE
fix: resolve stage 4 opcode and gas conflicts

### DIFF
--- a/core/gas_table.go
+++ b/core/gas_table.go
@@ -7,9 +7,9 @@ var gasTable GasTable
 // registration to ensure a baseline set of prices is available. The table can
 // be updated at runtime via governance mechanisms.
 func initGasTable() {
-    if len(gasTable) == 0 {
-        gasTable = DefaultGasTable()
-    }
+	if len(gasTable) == 0 {
+		gasTable = DefaultGasTable()
+	}
 }
 
 // Gas table placeholder.
@@ -25,13 +25,4 @@ var gasTable GasTable
 // the opcode dispatcher after all opcodes are registered.
 func initGasTable() {
 	gasTable = DefaultGasTable()
-}
-
-// GasCost returns the gas cost for a given opcode. Undefined opcodes return
-// zero, allowing callers to treat them as invalid.
-func GasCost(op Opcode) uint64 {
-	if cost, ok := gasTable[op]; ok {
-		return cost
-	}
-	return 0
 }

--- a/core/opcodes_basic.go
+++ b/core/opcodes_basic.go
@@ -2,10 +2,7 @@ package core
 
 // Basic opcode definitions used by the VM and gas table.
 const (
-	OpNoop Opcode = iota
-	OpPush
-	OpAdd
-	OpSub
+	OpSub Opcode = iota
 	OpMul
 	OpDiv
 	OpTransfer


### PR DESCRIPTION
## Summary
- remove redundant GasCost helper from gas table
- trim duplicate basic opcode constants to avoid redeclaration

## Testing
- `go test ./...` *(fails: case-insensitive import collision in core/base_node.go)*

------
https://chatgpt.com/codex/tasks/task_e_6890358f7714832099f094773e73ca7b