### PR TITLE
Refactor gas table to remove duplicate declarations

### DIFF
--- a/core/gas_table.go
+++ b/core/gas_table.go
@@ -1,37 +1,20 @@
 package core
 
-// gasTable stores the global opcode gas cost table.
-var gasTable GasTable
-
-// initGasTable initialises the global gas table. It is invoked from opcode
-// registration to ensure a baseline set of prices is available. The table can
-// be updated at runtime via governance mechanisms.
-func initGasTable() {
-    if len(gasTable) == 0 {
-        gasTable = DefaultGasTable()
-    }
-}
-
-// Gas table placeholder.
-// Future implementations should populate opcode gas costs.
-// Placeholder file ensuring the core package builds while the full gas table
-// implementation is developed elsewhere.
-
-// gasTable holds the default gas costs for opcodes. It is initialised during
-// package startup and may be extended in later stages.
-var gasTable GasTable
-
-// initGasTable populates the global gas table using DefaultGasTable. Called from
-// the opcode dispatcher after all opcodes are registered.
-func initGasTable() {
-	gasTable = DefaultGasTable()
-}
-
-// GasCost returns the gas cost for a given opcode. Undefined opcodes return
-// zero, allowing callers to treat them as invalid.
-func GasCost(op Opcode) uint64 {
-	if cost, ok := gasTable[op]; ok {
-		return cost
+// SetGasCost updates the gas cost for a specific opcode.
+// If the global gas table has not been initialised yet it
+// will be reset to the default values before applying the
+// override.
+func SetGasCost(op Opcode, cost uint64) {
+	if gasTable == nil {
+		initGasTable()
 	}
-	return 0
+	gasTable[op] = cost
+}
+
+// ResetGasTable restores the global gas table to the default
+// values returned by DefaultGasTable. This provides a simple
+// way for governance logic or tests to ensure a known set of
+// gas prices.
+func ResetGasTable() {
+	initGasTable()
 }


### PR DESCRIPTION
## Summary
- centralize gas table definition and remove redundant variables and functions
- add helpers to update and reset global gas pricing

## Testing
- `go test ./...` *(fails: go: updates to go.mod needed; run go mod tidy)*

------
https://chatgpt.com/codex/tasks/task_e_68903584a60c8320a4d1ba887f8e6ea4