### PR TITLE
Resolve cross-chain contract registry naming conflicts

### DIFF
--- a/core/cross_chain_contracts.go
+++ b/core/cross_chain_contracts.go
@@ -9,46 +9,46 @@ type ContractMapping struct {
 	RemoteAddr  string
 }
 
-// ContractRegistry manages cross-chain contract mappings.
-type ContractRegistry struct {
-	mu       sync.RWMutex
-	mappings map[string]*ContractMapping
+// CrossChainContractRegistry manages cross-chain contract mappings.
+type CrossChainContractRegistry struct {
+        mu       sync.RWMutex
+        mappings map[string]*ContractMapping
 }
 
-// NewContractRegistry creates an empty registry.
-func NewContractRegistry() *ContractRegistry {
-	return &ContractRegistry{mappings: make(map[string]*ContractMapping)}
+// NewCrossChainContractRegistry creates an empty registry.
+func NewCrossChainContractRegistry() *CrossChainContractRegistry {
+        return &CrossChainContractRegistry{mappings: make(map[string]*ContractMapping)}
 }
 
 // RegisterMapping registers a new contract mapping.
-func (r *ContractRegistry) RegisterMapping(local, remoteChain, remoteAddr string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.mappings[local] = &ContractMapping{LocalAddr: local, RemoteChain: remoteChain, RemoteAddr: remoteAddr}
+func (r *CrossChainContractRegistry) RegisterMapping(local, remoteChain, remoteAddr string) {
+        r.mu.Lock()
+        defer r.mu.Unlock()
+        r.mappings[local] = &ContractMapping{LocalAddr: local, RemoteChain: remoteChain, RemoteAddr: remoteAddr}
 }
 
 // GetMapping retrieves a mapping by local address.
-func (r *ContractRegistry) GetMapping(local string) (*ContractMapping, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	m, ok := r.mappings[local]
-	return m, ok
+func (r *CrossChainContractRegistry) GetMapping(local string) (*ContractMapping, bool) {
+        r.mu.RLock()
+        defer r.mu.RUnlock()
+        m, ok := r.mappings[local]
+        return m, ok
 }
 
 // ListMappings returns all registered mappings.
-func (r *ContractRegistry) ListMappings() []*ContractMapping {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	out := make([]*ContractMapping, 0, len(r.mappings))
-	for _, m := range r.mappings {
-		out = append(out, m)
-	}
-	return out
+func (r *CrossChainContractRegistry) ListMappings() []*ContractMapping {
+        r.mu.RLock()
+        defer r.mu.RUnlock()
+        out := make([]*ContractMapping, 0, len(r.mappings))
+        for _, m := range r.mappings {
+                out = append(out, m)
+        }
+        return out
 }
 
 // RemoveMapping deletes a mapping by local address.
-func (r *ContractRegistry) RemoveMapping(local string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.mappings, local)
+func (r *CrossChainContractRegistry) RemoveMapping(local string) {
+        r.mu.Lock()
+        defer r.mu.Unlock()
+        delete(r.mappings, local)
 }

--- a/core/cross_chain_contracts_test.go
+++ b/core/cross_chain_contracts_test.go
@@ -2,8 +2,8 @@ package core
 
 import "testing"
 
-func TestContractRegistry(t *testing.T) {
-	reg := NewContractRegistry()
+func TestCrossChainContractRegistry(t *testing.T) {
+        reg := NewCrossChainContractRegistry()
 	reg.RegisterMapping("local1", "chainB", "remote1")
 	if _, ok := reg.GetMapping("local1"); !ok {
 		t.Fatalf("mapping not found")

--- a/list_of_errors.md
+++ b/list_of_errors.md
@@ -1,19 +1,6 @@
-### Stage 1
-# synnergy/core
-core/cross_chain_contracts.go:13:6: ContractRegistry redeclared in this block
-	core/contracts.go:32:6: other declaration of ContractRegistry
-core/cross_chain_contracts.go:19:6: NewContractRegistry redeclared in this block
-	core/contracts.go:39:6: other declaration of NewContractRegistry
-core/cross_chain_contracts.go:20:27: unknown field mappings in struct literal of type ContractRegistry
-core/cross_chain_contracts.go:27:4: r.mappings undefined (type *ContractRegistry has no field or method mappings)
-
 ### Stage 2
-core/cross_chain_contracts.go:34:13: r.mappings undefined (type *ContractRegistry has no field or method mappings)
-core/cross_chain_contracts.go:42:43: r.mappings undefined (type *ContractRegistry has no field or method mappings)
-core/cross_chain_contracts.go:43:22: r.mappings undefined (type *ContractRegistry has no field or method mappings)
-core/cross_chain_contracts.go:53:11: r.mappings undefined (type *ContractRegistry has no field or method mappings)
 core/gas_table.go:4:5: gasTable redeclared in this block
-	core/gas.go:14:5: other declaration of gasTable
+        core/gas.go:14:5: other declaration of gasTable
 core/gas_table.go:9:6: initGasTable redeclared in this block
 
 ### Stage 3


### PR DESCRIPTION
## Summary
- Replace duplicate `ContractRegistry` with dedicated `CrossChainContractRegistry` for cross-chain mappings
- Update tests to use new cross-chain registry constructor
- Remove resolved Stage 1 entries from `list_of_errors.md`

## Testing
- `go test core/cross_chain_contracts.go core/cross_chain_contracts_test.go`
- `go test ./...` *(fails: case-insensitive import collision "synnergy/nodes" and "synnergy/Nodes" in packages)*

------
https://chatgpt.com/codex/tasks/task_e_6890356b3cc88320b884dfe0a7fb63a3