### PR TITLE
Implement core address and charity types

### DIFF
--- a/core/address.go
+++ b/core/address.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+type Address string
+
+func (a Address) Hex() string { return string(a) }
+
+func (a Address) String() string { return string(a) }
+
+func (a Address) Bytes() []byte { return []byte(a) }
+
+func (a Address) Short() string {
+	s := string(a)
+	if len(s) <= 10 {
+		return s
+	}
+	return s[:6] + "..." + s[len(s)-4:]
+}
+
+func StringToAddress(s string) (Address, error) {
+	s = strings.ToLower(s)
+	if len(s) != 42 || !strings.HasPrefix(s, "0x") {
+		return "", fmt.Errorf("invalid address")
+	}
+	if _, err := hex.DecodeString(s[2:]); err != nil {
+		return "", fmt.Errorf("invalid address")
+	}
+	return Address(s), nil
+}
+
+type Hash [32]byte

--- a/core/charity_types.go
+++ b/core/charity_types.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// StateRW defines the minimal ledger operations CharityPool relies on.
+type StateRW interface {
+	Transfer(from, to Address, amount uint64) error
+	SetState(key, value []byte)
+	GetState(key []byte) ([]byte, error)
+	HasState(key []byte) (bool, error)
+	BalanceOf(addr Address) uint64
+	PrefixIterator(prefix []byte) Iterator
+}
+
+// Iterator abstracts iteration over key/value pairs with a shared prefix.
+type Iterator interface {
+	Next() bool
+	Value() []byte
+}
+
+// CharityPool maintains charity registrations, votes and payouts.
+type CharityPool struct {
+	mu        sync.Mutex
+	logger    *logrus.Logger
+	led       StateRW
+	vote      electorate
+	genesis   time.Time
+	lastDaily int64
+}
+
+// CharityRegistration holds metadata for a charity in a given cycle.
+type CharityRegistration struct {
+	Addr      Address
+	Name      string
+	Category  CharityCategory
+	Cycle     uint64
+	VoteCount uint64
+}
+
+// mustJSON encodes v to JSON and panics on failure.
+func mustJSON(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// voteKey returns the ledger key for a voter's vote in a specific cycle hash.
+func voteKey(cycle Hash, voter Address) []byte {
+	return []byte(fmt.Sprintf("charity:vote:%x:%s", cycle[:], voter.Hex()))
+}


### PR DESCRIPTION
## Summary
- add address and hash types with helpers
- provide core charity types and helper functions

## Testing
- `go test ./...` *(fails: PrivateTransaction redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_e_68903b8f94688320be06603f1d0a11a5