### PR TITLE
Define basic types for charity pool

### DIFF
--- a/core/address.go
+++ b/core/address.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+)
+
+// Address represents a 20-byte hex encoded account identifier.
+// It is stored as a string with a leading 0x prefix to keep things simple
+// and compatible with other parts of the codebase that treat addresses as
+// strings.
+type Address string
+
+// StringToAddress converts a hex string into an Address. The string must be
+// 40 hex characters prefixed by 0x.
+func StringToAddress(s string) (Address, error) {
+	if !strings.HasPrefix(s, "0x") || len(s) != 42 {
+		return "", errors.New("invalid address")
+	}
+	if _, err := hex.DecodeString(s[2:]); err != nil {
+		return "", err
+	}
+	return Address(strings.ToLower(s)), nil
+}
+
+// Hex returns the string form of the address.
+func (a Address) Hex() string { return string(a) }
+
+// Bytes returns the raw 20 byte representation of the address.
+func (a Address) Bytes() []byte {
+	b, _ := hex.DecodeString(strings.TrimPrefix(string(a), "0x"))
+	return b
+}
+
+// Short returns a shortened representation useful for logs.
+func (a Address) Short() string {
+	h := a.Hex()
+	if len(h) <= 10 {
+		return h
+	}
+	return h[:10]
+}
+
+// Hash represents a simple 32-byte value used for identifiers.
+type Hash [32]byte

--- a/core/state_rw.go
+++ b/core/state_rw.go
@@ -1,0 +1,19 @@
+package core
+
+// StateIterator provides a minimal interface for iterating over state entries
+// with a common prefix.
+type StateIterator interface {
+	Next() bool
+	Value() []byte
+}
+
+// StateRW defines the read/write operations on chain state required by the
+// CharityPool. Implementations are provided elsewhere in the codebase.
+type StateRW interface {
+	Transfer(from, to Address, amount uint64) error
+	SetState(key []byte, value []byte)
+	GetState(key []byte) ([]byte, error)
+	HasState(key []byte) (bool, error)
+	PrefixIterator(prefix []byte) StateIterator
+	BalanceOf(addr Address) uint64
+}


### PR DESCRIPTION
## Summary
- add address and hash types with helpers
- implement state interfaces and charity pool structures
- marshal helper for charity state

## Testing
- `go build ./...` *(fails: PrivateTransaction redeclared, Nonce field, invalid operation in regulatory_management.go)*

------
https://chatgpt.com/codex/tasks/task_e_68903b9a8be883209612f1e4aa101888