### PR TITLE
Stage 2: Governance nodes interfaces

### DIFF
--- a/core/dao_proposal.go
+++ b/core/dao_proposal.go
@@ -13,6 +13,7 @@ type DAOProposal struct {
 	Desc     string
 	YesVotes map[string]uint64
 	NoVotes  map[string]uint64
+	Executed bool
 }
 
 // ProposalManager manages DAO proposals.
@@ -50,6 +51,31 @@ func (pm *ProposalManager) Vote(id, voter string, weight uint64, support bool) e
 		p.NoVotes[voter] = weight
 		delete(p.YesVotes, voter)
 	}
+	return nil
+}
+
+// Results sums yes and no votes for a proposal.
+func (pm *ProposalManager) Results(id string) (yes, no uint64, err error) {
+	p, ok := pm.proposals[id]
+	if !ok {
+		return 0, 0, errors.New("proposal not found")
+	}
+	for _, w := range p.YesVotes {
+		yes += w
+	}
+	for _, w := range p.NoVotes {
+		no += w
+	}
+	return yes, no, nil
+}
+
+// Execute marks a proposal as executed.
+func (pm *ProposalManager) Execute(id string) error {
+	p, ok := pm.proposals[id]
+	if !ok {
+		return errors.New("proposal not found")
+	}
+	p.Executed = true
 	return nil
 }
 

--- a/core/dao_proposal_test.go
+++ b/core/dao_proposal_test.go
@@ -10,10 +10,20 @@ func TestDAOProposal(t *testing.T) {
 	if prop.DAOID != dao.ID {
 		t.Fatalf("dao id mismatch")
 	}
-	if err := pm.Vote(prop.ID, "v1", 1, true); err != nil {
+	if err := pm.Vote(prop.ID, "v1", 4, true); err != nil {
 		t.Fatalf("vote: %v", err)
 	}
-	if prop.YesVotes["v1"] != 1 {
-		t.Fatalf("vote not recorded")
+	if err := pm.Vote(prop.ID, "v2", 1, false); err != nil {
+		t.Fatalf("vote: %v", err)
+	}
+	yes, no, err := pm.Results(prop.ID)
+	if err != nil || yes != 4 || no != 1 {
+		t.Fatalf("unexpected tally: %d %d %v", yes, no, err)
+	}
+	if err := pm.Execute(prop.ID); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !prop.Executed {
+		t.Fatalf("proposal not marked executed")
 	}
 }

--- a/nodes/authority_nodes/index.go
+++ b/nodes/authority_nodes/index.go
@@ -1,0 +1,46 @@
+package authority_nodes
+
+// AuthorityNode represents a node eligible for governance actions.
+type AuthorityNode struct {
+	Address string
+	Role    string
+	Votes   map[string]bool // voter address -> approved
+}
+
+// Index maintains a lookup of authority nodes by address.
+type Index struct {
+	nodes map[string]*AuthorityNode
+}
+
+// NewIndex returns an initialised Index.
+func NewIndex() *Index {
+	return &Index{nodes: make(map[string]*AuthorityNode)}
+}
+
+// Add inserts or replaces an authority node in the index.
+func (idx *Index) Add(node *AuthorityNode) {
+	if idx.nodes == nil {
+		idx.nodes = make(map[string]*AuthorityNode)
+	}
+	idx.nodes[node.Address] = node
+}
+
+// Get retrieves an authority node by address.
+func (idx *Index) Get(addr string) (*AuthorityNode, bool) {
+	n, ok := idx.nodes[addr]
+	return n, ok
+}
+
+// Remove deletes an authority node from the index by address.
+func (idx *Index) Remove(addr string) {
+	delete(idx.nodes, addr)
+}
+
+// List returns all authority nodes in the index.
+func (idx *Index) List() []*AuthorityNode {
+	out := make([]*AuthorityNode, 0, len(idx.nodes))
+	for _, n := range idx.nodes {
+		out = append(out, n)
+	}
+	return out
+}

--- a/nodes/authority_nodes/index_test.go
+++ b/nodes/authority_nodes/index_test.go
@@ -1,0 +1,19 @@
+package authority_nodes
+
+import "testing"
+
+func TestIndex(t *testing.T) {
+	idx := NewIndex()
+	n := &AuthorityNode{Address: "a", Role: "r", Votes: make(map[string]bool)}
+	idx.Add(n)
+	if got, ok := idx.Get("a"); !ok || got.Address != "a" {
+		t.Fatalf("get failed")
+	}
+	if len(idx.List()) != 1 {
+		t.Fatalf("list size incorrect")
+	}
+	idx.Remove("a")
+	if _, ok := idx.Get("a"); ok {
+		t.Fatalf("remove failed")
+	}
+}

--- a/nodes/elected_authority_node.go
+++ b/nodes/elected_authority_node.go
@@ -1,0 +1,24 @@
+package nodes
+
+import (
+	"time"
+
+	an "synnergy/nodes/authority_nodes"
+)
+
+// ElectedAuthorityNode represents an authority node with a fixed term.
+type ElectedAuthorityNode struct {
+	*an.AuthorityNode
+	TermEnd time.Time
+}
+
+// NewElectedAuthorityNode creates a new elected authority node with the given term duration.
+func NewElectedAuthorityNode(addr Address, role string, term time.Duration) *ElectedAuthorityNode {
+	node := &an.AuthorityNode{Address: string(addr), Role: role, Votes: make(map[string]bool)}
+	return &ElectedAuthorityNode{AuthorityNode: node, TermEnd: time.Now().Add(term)}
+}
+
+// IsActive returns true if the node's term has not expired.
+func (n *ElectedAuthorityNode) IsActive(now time.Time) bool {
+	return now.Before(n.TermEnd)
+}

--- a/nodes/elected_authority_node_test.go
+++ b/nodes/elected_authority_node_test.go
@@ -1,0 +1,19 @@
+package nodes
+
+import (
+	"testing"
+	"time"
+)
+
+func TestElectedAuthorityNode(t *testing.T) {
+	n := NewElectedAuthorityNode("addr", "role", time.Hour)
+	if !n.IsActive(time.Now()) {
+		t.Fatalf("node should be active")
+	}
+	if !n.IsActive(time.Now().Add(time.Minute)) {
+		t.Fatalf("node should still be active")
+	}
+	if n.IsActive(time.Now().Add(2 * time.Hour)) {
+		t.Fatalf("node should be inactive after term")
+	}
+}


### PR DESCRIPTION
## Summary
- add authority node index package and elected authority node type
- extend DAO proposal management with execution and vote tally methods

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68914301a81c8320845ae8ed2bec1778