### PR TITLE
feat: add loanpool views

### DIFF
--- a/core/loanpool_test.go
+++ b/core/loanpool_test.go
@@ -23,6 +23,13 @@ func TestLoanPoolProposalLifecycle(t *testing.T) {
 	if stats.DisbursedCount != 1 {
 		t.Fatalf("expected disbursed count 1")
 	}
+	view, ok := lp.ProposalInfo(id)
+	if !ok || view.ID != id || view.Votes != 1 {
+		t.Fatalf("unexpected proposal view")
+	}
+	if len(lp.ProposalViews()) != 1 {
+		t.Fatalf("expected one proposal view")
+	}
 	appMgr := NewLoanPoolApply(lp)
 	appID := appMgr.Submit("alice", 50, 12, "test")
 	if err := appMgr.Vote("bob", appID); err != nil {
@@ -31,5 +38,12 @@ func TestLoanPoolProposalLifecycle(t *testing.T) {
 	appMgr.Process()
 	if err := appMgr.Disburse(appID); err != nil {
 		t.Fatalf("app disburse: %v", err)
+	}
+	appView, ok := appMgr.ApplicationInfo(appID)
+	if !ok || appView.ID != appID || appView.Votes != 1 {
+		t.Fatalf("unexpected application view")
+	}
+	if len(appMgr.ApplicationViews()) != 1 {
+		t.Fatalf("expected one application view")
 	}
 }

--- a/core/loanpool_views.go
+++ b/core/loanpool_views.go
@@ -1,0 +1,97 @@
+package core
+
+import "time"
+
+// LoanProposalView provides a serialisable representation of a LoanProposal.
+type LoanProposalView struct {
+	ID          uint64    `json:"id"`
+	Creator     string    `json:"creator"`
+	Recipient   string    `json:"recipient"`
+	Type        string    `json:"type"`
+	Amount      uint64    `json:"amount"`
+	Description string    `json:"description"`
+	Votes       int       `json:"votes"`
+	Deadline    time.Time `json:"deadline"`
+	Approved    bool      `json:"approved"`
+	Disbursed   bool      `json:"disbursed"`
+}
+
+// NewLoanProposalView constructs a view from a proposal.
+func NewLoanProposalView(p *LoanProposal) LoanProposalView {
+	return LoanProposalView{
+		ID:          p.ID,
+		Creator:     p.Creator,
+		Recipient:   p.Recipient,
+		Type:        p.Type,
+		Amount:      p.Amount,
+		Description: p.Description,
+		Votes:       len(p.Votes),
+		Deadline:    p.Deadline,
+		Approved:    p.Approved,
+		Disbursed:   p.Disbursed,
+	}
+}
+
+// ProposalInfo returns a view for a proposal by ID if it exists.
+func (lp *LoanPool) ProposalInfo(id uint64) (LoanProposalView, bool) {
+	p, ok := lp.GetProposal(id)
+	if !ok {
+		return LoanProposalView{}, false
+	}
+	return NewLoanProposalView(p), true
+}
+
+// ProposalViews lists all proposals in view form.
+func (lp *LoanPool) ProposalViews() []LoanProposalView {
+	proposals := lp.ListProposals()
+	views := make([]LoanProposalView, 0, len(proposals))
+	for _, p := range proposals {
+		views = append(views, NewLoanProposalView(p))
+	}
+	return views
+}
+
+// LoanApplicationView provides a serialisable representation of a LoanApplication.
+type LoanApplicationView struct {
+	ID         uint64 `json:"id"`
+	Applicant  string `json:"applicant"`
+	Amount     uint64 `json:"amount"`
+	TermMonths uint32 `json:"term_months"`
+	Purpose    string `json:"purpose"`
+	Votes      int    `json:"votes"`
+	Approved   bool   `json:"approved"`
+	Disbursed  bool   `json:"disbursed"`
+}
+
+// NewLoanApplicationView constructs a view from an application.
+func NewLoanApplicationView(a *LoanApplication) LoanApplicationView {
+	return LoanApplicationView{
+		ID:         a.ID,
+		Applicant:  a.Applicant,
+		Amount:     a.Amount,
+		TermMonths: a.TermMonths,
+		Purpose:    a.Purpose,
+		Votes:      len(a.Votes),
+		Approved:   a.Approved,
+		Disbursed:  a.Disbursed,
+	}
+}
+
+// ApplicationInfo returns a view for an application by ID if it exists.
+func (l *LoanPoolApply) ApplicationInfo(id uint64) (LoanApplicationView, bool) {
+	app, ok := l.Get(id)
+	if !ok {
+		return LoanApplicationView{}, false
+	}
+	return NewLoanApplicationView(app), true
+}
+
+// ApplicationViews lists all applications in view form.
+func (l *LoanPoolApply) ApplicationViews() []LoanApplicationView {
+	apps := l.List()
+	views := make([]LoanApplicationView, 0, len(apps))
+	for _, a := range apps {
+		views = append(views, NewLoanApplicationView(a))
+	}
+	return views
+}


### PR DESCRIPTION
## Summary
- add serialisable views for loan pool proposals and applications
- test loanpool and application view helpers

## Testing
- `go test ./core -run TestLoanPoolProposalLifecycle -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891430d406c8320842808995a3d206c