### PR TITLE
feat: add consensus-specific node interface

### DIFF
--- a/nodes/consensus_specific.go
+++ b/nodes/consensus_specific.go
@@ -1,0 +1,12 @@
+package nodes
+
+// ConsensusNodeInterface defines behaviour for nodes dedicated to a single
+// consensus algorithm. Implementations typically optimise networking and
+// validation logic for the returned consensus type while still satisfying the
+// base NodeInterface.
+type ConsensusNodeInterface interface {
+	NodeInterface
+	// ConsensusType reports the consensus mechanism this node is optimised for,
+	// such as "pow" or "pos".
+	ConsensusType() string
+}

--- a/nodes/consensus_specific_test.go
+++ b/nodes/consensus_specific_test.go
@@ -1,0 +1,14 @@
+package nodes
+
+// dummyConsensusNode implements ConsensusNodeInterface for testing purposes.
+type dummyConsensusNode struct{}
+
+func (d dummyConsensusNode) ID() Address                 { return "dummy" }
+func (d dummyConsensusNode) Start() error                { return nil }
+func (d dummyConsensusNode) Stop() error                 { return nil }
+func (d dummyConsensusNode) Peers() []Address            { return nil }
+func (d dummyConsensusNode) DialSeed(addr Address) error { return nil }
+func (d dummyConsensusNode) ConsensusType() string       { return "pow" }
+
+// Ensure dummyConsensusNode satisfies the interface at compile time.
+var _ ConsensusNodeInterface = (*dummyConsensusNode)(nil)


### PR DESCRIPTION
## Summary
- add ConsensusNodeInterface to describe nodes bound to a single consensus algorithm
- provide compile-time test for the new interface

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891431a77e0832090b0c603eede5373