### PR TITLE
feat: add banking node interfaces

### DIFF
--- a/nodes/bank_nodes/index.go
+++ b/nodes/bank_nodes/index.go
@@ -1,0 +1,31 @@
+package banknodes
+
+import "synnergy/nodes"
+
+// BankInstitutionalNode defines behaviour for institutional banking nodes.
+// It extends the generic NodeInterface with methods to manage participating institutions.
+type BankInstitutionalNode interface {
+	nodes.NodeInterface
+	// RegisterInstitution registers a new institution by name.
+	RegisterInstitution(name string)
+	// IsRegistered checks whether an institution is already registered.
+	IsRegistered(name string) bool
+}
+
+// CentralBankingNode defines operations for nodes operated by central banks.
+type CentralBankingNode interface {
+	nodes.NodeInterface
+	// UpdatePolicy updates the node's monetary policy guidance.
+	UpdatePolicy(policy string)
+	// Mint credits the given amount to the target account within the ledger.
+	Mint(to string, amount uint64)
+}
+
+// CustodialNode models a node that holds assets on behalf of users.
+type CustodialNode interface {
+	nodes.NodeInterface
+	// Custody records assets held for a specific user.
+	Custody(user string, amount uint64)
+	// Release transfers assets back to the user if sufficient and returns success.
+	Release(user string, amount uint64) bool
+}

--- a/nodes/bank_nodes/index_test.go
+++ b/nodes/bank_nodes/index_test.go
@@ -1,0 +1,41 @@
+package banknodes
+
+import (
+	"testing"
+
+	"synnergy/core"
+	"synnergy/nodes"
+)
+
+type bankNodeAdapter struct{ *core.BankInstitutionalNode }
+
+func (a *bankNodeAdapter) ID() nodes.Address                 { return nodes.Address(a.Node.ID) }
+func (a *bankNodeAdapter) Start() error                      { return nil }
+func (a *bankNodeAdapter) Stop() error                       { return nil }
+func (a *bankNodeAdapter) Peers() []nodes.Address            { return nil }
+func (a *bankNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
+
+type centralBankNodeAdapter struct{ *core.CentralBankingNode }
+
+func (a *centralBankNodeAdapter) ID() nodes.Address                 { return nodes.Address(a.Node.ID) }
+func (a *centralBankNodeAdapter) Start() error                      { return nil }
+func (a *centralBankNodeAdapter) Stop() error                       { return nil }
+func (a *centralBankNodeAdapter) Peers() []nodes.Address            { return nil }
+func (a *centralBankNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
+
+type custodialNodeAdapter struct{ *core.CustodialNode }
+
+func (a *custodialNodeAdapter) ID() nodes.Address                 { return nodes.Address(a.Node.ID) }
+func (a *custodialNodeAdapter) Start() error                      { return nil }
+func (a *custodialNodeAdapter) Stop() error                       { return nil }
+func (a *custodialNodeAdapter) Peers() []nodes.Address            { return nil }
+func (a *custodialNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
+
+// TestInterfaceCompliance ensures core implementations satisfy the banking node interfaces via adapters.
+func TestInterfaceCompliance(t *testing.T) {
+	ledger := core.NewLedger()
+
+	var _ BankInstitutionalNode = &bankNodeAdapter{core.NewBankInstitutionalNode("id1", "addr1", ledger)}
+	var _ CentralBankingNode = &centralBankNodeAdapter{core.NewCentralBankingNode("id2", "addr2", ledger, "policy")}
+	var _ CustodialNode = &custodialNodeAdapter{core.NewCustodialNode("id3", "addr3", ledger)}
+}


### PR DESCRIPTION
## Summary
- define interfaces for institutional, central banking, and custodial nodes
- add tests proving core implementations satisfy new interfaces

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689145ad3f748320802b1fa18ac14a1c