### PR TITLE
feat: expand node interfaces and add tests

### DIFF
--- a/core/base_node_test.go
+++ b/core/base_node_test.go
@@ -7,17 +7,26 @@ import (
 )
 
 func TestBaseNodeLifecycle(t *testing.T) {
-	bn := NewBaseNode(nodes.Address("node1"))
-	if err := bn.Start(); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-	if err := bn.DialSeed(nodes.Address("peer1")); err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-	if len(bn.Peers()) != 1 {
-		t.Fatalf("expected 1 peer, got %d", len(bn.Peers()))
-	}
-	if err := bn.Stop(); err != nil {
-		t.Fatalf("stop: %v", err)
-	}
+        bn := NewBaseNode(nodes.Address("node1"))
+       if bn.IsRunning() {
+               t.Fatalf("expected node to be stopped initially")
+       }
+       if err := bn.Start(); err != nil {
+               t.Fatalf("start: %v", err)
+       }
+       if !bn.IsRunning() {
+               t.Fatalf("expected node to be running after start")
+       }
+        if err := bn.DialSeed(nodes.Address("peer1")); err != nil {
+                t.Fatalf("dial: %v", err)
+        }
+        if len(bn.Peers()) != 1 {
+                t.Fatalf("expected 1 peer, got %d", len(bn.Peers()))
+        }
+       if err := bn.Stop(); err != nil {
+               t.Fatalf("stop: %v", err)
+       }
+       if bn.IsRunning() {
+               t.Fatalf("expected node to be stopped after Stop")
+       }
 }

--- a/core/full_node_test.go
+++ b/core/full_node_test.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+    "testing"
+
+    "synnergy/nodes"
+)
+
+func TestFullNodeModes(t *testing.T) {
+    fn := NewFullNode(nodes.Address("f1"), FullNodeModeArchive)
+    if !fn.IsArchive() {
+        t.Fatalf("expected archive mode")
+    }
+    if fn.CurrentMode() != FullNodeModeArchive {
+        t.Fatalf("unexpected mode: %v", fn.CurrentMode())
+    }
+    fn.SetMode(FullNodeModePruned)
+    if fn.IsArchive() {
+        t.Fatalf("expected pruned mode after SetMode")
+    }
+    if fn.CurrentMode() != FullNodeModePruned {
+        t.Fatalf("mode not updated")
+    }
+}
+

--- a/core/gateway_node_test.go
+++ b/core/gateway_node_test.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+    "testing"
+
+    "synnergy/nodes"
+)
+
+func TestGatewayNodeEndpoints(t *testing.T) {
+    gn := NewGatewayNode(nodes.Address("g1"), GatewayConfig{})
+    called := false
+    gn.RegisterEndpoint("ping", func(b []byte) error {
+        called = true
+        return nil
+    })
+    if err := gn.Handle("ping", nil); err != nil {
+        t.Fatalf("handle: %v", err)
+    }
+    if !called {
+        t.Fatalf("endpoint not invoked")
+    }
+    if len(gn.Endpoints()) != 1 || gn.Endpoints()[0] != "ping" {
+        t.Fatalf("unexpected endpoints list")
+    }
+    gn.RemoveEndpoint("ping")
+    if len(gn.Endpoints()) != 0 {
+        t.Fatalf("endpoint not removed")
+    }
+    if err := gn.Handle("ping", nil); err == nil {
+        t.Fatalf("expected error for unknown endpoint")
+    }
+}
+

--- a/core/light_node_test.go
+++ b/core/light_node_test.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+    "testing"
+
+    "synnergy/nodes"
+)
+
+func TestLightNodeHeaders(t *testing.T) {
+    ln := NewLightNode(nodes.Address("l1"))
+    h := nodes.BlockHeader{Hash: "h1", Height: 1}
+    ln.AddHeader(h)
+    if latest, ok := ln.LatestHeader(); !ok || latest.Hash != "h1" {
+        t.Fatalf("unexpected latest header: %+v", latest)
+    }
+    headers := ln.Headers()
+    if len(headers) != 1 || headers[0].Hash != "h1" {
+        t.Fatalf("unexpected headers slice")
+    }
+    // Ensure returned slice is a copy
+    headers[0].Hash = "modified"
+    if latest, _ := ln.LatestHeader(); latest.Hash != "h1" {
+        t.Fatalf("internal headers modified via returned slice")
+    }
+}
+

--- a/nodes/consensus_specific_test.go
+++ b/nodes/consensus_specific_test.go
@@ -6,6 +6,7 @@ type dummyConsensusNode struct{}
 func (d dummyConsensusNode) ID() Address                 { return "dummy" }
 func (d dummyConsensusNode) Start() error                { return nil }
 func (d dummyConsensusNode) Stop() error                 { return nil }
+func (d dummyConsensusNode) IsRunning() bool             { return false }
 func (d dummyConsensusNode) Peers() []Address            { return nil }
 func (d dummyConsensusNode) DialSeed(addr Address) error { return nil }
 func (d dummyConsensusNode) ConsensusType() string       { return "pow" }

--- a/nodes/index.go
+++ b/nodes/index.go
@@ -2,14 +2,16 @@ package nodes
 
 // NodeInterface defines minimal node behaviour independent from core types.
 type NodeInterface interface {
-	// ID returns the node identifier.
-	ID() Address
-	// Start begins node operations such as networking routines.
-	Start() error
-	// Stop gracefully halts node operations.
-	Stop() error
-	// Peers returns identifiers for all known peers.
-	Peers() []Address
-	// DialSeed connects the node to a seed peer by address.
-	DialSeed(addr Address) error
+        // ID returns the node identifier.
+        ID() Address
+        // Start begins node operations such as networking routines.
+        Start() error
+        // Stop gracefully halts node operations.
+        Stop() error
+       // IsRunning reports whether the node is currently active.
+       IsRunning() bool
+        // Peers returns identifiers for all known peers.
+        Peers() []Address
+        // DialSeed connects the node to a seed peer by address.
+        DialSeed(addr Address) error
 }


### PR DESCRIPTION
## Summary
- expose runtime state via `IsRunning` in the node interface
- tighten BaseNode lifecycle logic and cover full, light and gateway nodes with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68914598b0288320ac4a834d40664915