### PR TITLE
Add consensus lifecycle tests

### DIFF
--- a/core/consensus_specific_node_test.go
+++ b/core/consensus_specific_node_test.go
@@ -1,0 +1,16 @@
+package core
+
+import "testing"
+
+// TestNewConsensusSpecificNode ensures the node locks to a single consensus mode.
+
+func TestNewConsensusSpecificNode(t *testing.T) {
+	ledger := NewLedger()
+	n := NewConsensusSpecificNode(ModePoS, "n1", "addr", ledger)
+	if !n.Consensus.PoSAvailable || n.Consensus.Weights.PoS != 1 {
+		t.Fatalf("expected PoS only mode")
+	}
+	if n.Consensus.PoWAvailable || n.Consensus.PoHAvailable {
+		t.Fatalf("other modes should be disabled")
+	}
+}

--- a/core/consensus_start_test.go
+++ b/core/consensus_start_test.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+// TestConsensusServiceStartStop verifies the start-stop lifecycle of the consensus service.
+func TestConsensusServiceStartStop(t *testing.T) {
+	ledger := NewLedger()
+	node := NewNode("n1", "addr", ledger)
+	if err := node.SetStake("n1", 1); err != nil {
+		t.Fatalf("set stake: %v", err)
+	}
+	ledger.Mint("alice", 100)
+	tx := NewTransaction("alice", "bob", 10, 1, 0)
+	if err := node.AddTransaction(tx); err != nil {
+		t.Fatalf("add tx: %v", err)
+	}
+	svc := NewConsensusService(node)
+	svc.Start(10 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+	svc.Stop()
+	height, running := svc.Info()
+	if running {
+		t.Fatalf("service should be stopped")
+	}
+	if height == 0 {
+		t.Fatalf("expected block to be mined")
+	}
+}

--- a/core/consensus_validator_management_test.go
+++ b/core/consensus_validator_management_test.go
@@ -1,0 +1,33 @@
+package core
+
+import "testing"
+
+// TestValidatorManagerLifecycle verifies basic validator operations.
+
+func TestValidatorManagerLifecycle(t *testing.T) {
+	vm := NewValidatorManager(10)
+	if err := vm.Add("v1", 5); err == nil {
+		t.Fatalf("expected error for stake below minimum")
+	}
+	if err := vm.Add("v1", 20); err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+	if vm.Stake("v1") != 20 {
+		t.Fatalf("unexpected stake")
+	}
+	elig := vm.Eligible()
+	if _, ok := elig["v1"]; !ok {
+		t.Fatalf("validator not eligible")
+	}
+	vm.Slash("v1")
+	if vm.Stake("v1") != 10 {
+		t.Fatalf("stake not halved after slash")
+	}
+	if _, ok := vm.Eligible()["v1"]; ok {
+		t.Fatalf("slashed validator should not be eligible")
+	}
+	vm.Remove("v1")
+	if vm.Stake("v1") != 0 {
+		t.Fatalf("validator not removed")
+	}
+}


### PR DESCRIPTION
## Summary
- add ValidatorManager lifecycle unit tests
- verify ConsensusService start/stop and mining behaviour
- ensure ConsensusSpecificNode locks to a single mode

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689145b9c12483209ac47dfd1b203317