### PR TITLE
feat: add watchtower monitoring modules

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -1,0 +1,104 @@
+package synnergy
+
+import "sync"
+
+// Firewall manages block lists for wallet addresses, token identifiers and
+// peer IP addresses. It is intentionally lightweight and safe for concurrent
+// use by multiple goroutines.
+type Firewall struct {
+	mu            sync.RWMutex
+	blockedAddrs  map[string]struct{}
+	blockedTokens map[string]struct{}
+	blockedIPs    map[string]struct{}
+}
+
+// NewFirewall creates an empty Firewall instance.
+func NewFirewall() *Firewall {
+	return &Firewall{
+		blockedAddrs:  make(map[string]struct{}),
+		blockedTokens: make(map[string]struct{}),
+		blockedIPs:    make(map[string]struct{}),
+	}
+}
+
+// BlockAddress adds an address to the block list.
+func (f *Firewall) BlockAddress(addr string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.blockedAddrs[addr] = struct{}{}
+}
+
+// UnblockAddress removes an address from the block list.
+func (f *Firewall) UnblockAddress(addr string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.blockedAddrs, addr)
+}
+
+// IsAddressBlocked returns true if the address is currently blocked.
+func (f *Firewall) IsAddressBlocked(addr string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	_, ok := f.blockedAddrs[addr]
+	return ok
+}
+
+// BlockToken adds a token identifier to the block list.
+func (f *Firewall) BlockToken(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.blockedTokens[id] = struct{}{}
+}
+
+// UnblockToken removes a token identifier from the block list.
+func (f *Firewall) UnblockToken(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.blockedTokens, id)
+}
+
+// IsTokenBlocked returns true if the token identifier is blocked.
+func (f *Firewall) IsTokenBlocked(id string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	_, ok := f.blockedTokens[id]
+	return ok
+}
+
+// BlockIP adds a peer IP address to the block list.
+func (f *Firewall) BlockIP(ip string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.blockedIPs[ip] = struct{}{}
+}
+
+// UnblockIP removes a peer IP address from the block list.
+func (f *Firewall) UnblockIP(ip string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.blockedIPs, ip)
+}
+
+// IsIPBlocked returns true if the IP address is blocked.
+func (f *Firewall) IsIPBlocked(ip string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	_, ok := f.blockedIPs[ip]
+	return ok
+}
+
+// Rules returns slices of currently blocked addresses, tokens and IPs.
+func (f *Firewall) Rules() (addrs, tokens, ips []string) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for a := range f.blockedAddrs {
+		addrs = append(addrs, a)
+	}
+	for t := range f.blockedTokens {
+		tokens = append(tokens, t)
+	}
+	for ip := range f.blockedIPs {
+		ips = append(ips, ip)
+	}
+	return
+}

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -1,0 +1,37 @@
+package synnergy
+
+import "testing"
+
+func TestFirewall(t *testing.T) {
+	f := NewFirewall()
+
+	f.BlockAddress("addr1")
+	if !f.IsAddressBlocked("addr1") {
+		t.Fatalf("address should be blocked")
+	}
+	f.UnblockAddress("addr1")
+	if f.IsAddressBlocked("addr1") {
+		t.Fatalf("address should be unblocked")
+	}
+
+	f.BlockToken("token1")
+	if !f.IsTokenBlocked("token1") {
+		t.Fatalf("token should be blocked")
+	}
+
+	f.BlockIP("1.2.3.4")
+	if !f.IsIPBlocked("1.2.3.4") {
+		t.Fatalf("ip should be blocked")
+	}
+
+	addrs, tokens, ips := f.Rules()
+	if len(addrs) != 0 {
+		t.Fatalf("expected no blocked addresses, got %d", len(addrs))
+	}
+	if len(tokens) != 1 || tokens[0] != "token1" {
+		t.Fatalf("unexpected tokens list: %v", tokens)
+	}
+	if len(ips) != 1 || ips[0] != "1.2.3.4" {
+		t.Fatalf("unexpected ips list: %v", ips)
+	}
+}

--- a/high_availability.go
+++ b/high_availability.go
@@ -1,0 +1,70 @@
+package synnergy
+
+import (
+	"sync"
+	"time"
+)
+
+// FailoverManager tracks node heartbeats to provide high availability through
+// automatic promotion of backup nodes when the primary becomes unresponsive.
+type FailoverManager struct {
+	mu      sync.RWMutex
+	primary string
+	nodes   map[string]time.Time // last heartbeat for each node
+	timeout time.Duration
+}
+
+// NewFailoverManager creates a FailoverManager with a primary node identifier
+// and a timeout indicating how long a node may miss heartbeats before being
+// considered offline.
+func NewFailoverManager(primary string, timeout time.Duration) *FailoverManager {
+	return &FailoverManager{
+		primary: primary,
+		nodes:   map[string]time.Time{primary: time.Now()},
+		timeout: timeout,
+	}
+}
+
+// RegisterBackup adds a new backup node to the manager.
+func (m *FailoverManager) RegisterBackup(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nodes[id] = time.Now()
+}
+
+// Heartbeat records a heartbeat for the specified node.
+func (m *FailoverManager) Heartbeat(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nodes[id] = time.Now()
+}
+
+// Active returns the identifier of the node currently acting as primary. If the
+// existing primary has not sent a heartbeat within the timeout, the most recent
+// backup node is promoted.
+func (m *FailoverManager) Active() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if hb, ok := m.nodes[m.primary]; ok {
+		if time.Since(hb) <= m.timeout {
+			return m.primary
+		}
+	}
+
+	var candidate string
+	var latest time.Time
+	for id, hb := range m.nodes {
+		if id == m.primary {
+			continue
+		}
+		if hb.After(latest) {
+			candidate = id
+			latest = hb
+		}
+	}
+	if candidate != "" {
+		m.primary = candidate
+	}
+	return m.primary
+}

--- a/high_availability_test.go
+++ b/high_availability_test.go
@@ -1,0 +1,22 @@
+package synnergy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFailoverManager(t *testing.T) {
+	timeout := 10 * time.Millisecond
+	m := NewFailoverManager("primary", timeout)
+	m.RegisterBackup("backup")
+
+	// Simulate primary missing heartbeats.
+	m.mu.Lock()
+	m.nodes["primary"] = time.Now().Add(-2 * timeout)
+	m.mu.Unlock()
+
+	active := m.Active()
+	if active != "backup" {
+		t.Fatalf("expected failover to backup, got %s", active)
+	}
+}

--- a/nodes/watchtower/index.go
+++ b/nodes/watchtower/index.go
@@ -1,0 +1,41 @@
+package watchtower
+
+import (
+	"context"
+	"time"
+)
+
+// BaseNode defines minimal behaviour required by all node implementations.
+type BaseNode interface {
+	// ID returns the unique identifier of the node.
+	ID() string
+}
+
+// Metrics captures a snapshot of node health statistics. Values are intended
+// to be lightweight and easily serialisable for remote reporting.
+type Metrics struct {
+	CPUUsage        float64   // Percentage of CPU utilised by the node process
+	MemoryUsage     uint64    // Bytes of RAM in use by the process
+	PeerCount       int       // Number of peers currently connected
+	LastBlockHeight uint64    // Height of the most recently observed block
+	Timestamp       time.Time // Time the metrics were captured
+}
+
+// WatchtowerNode defines the operations exposed by a watchtower node. These
+// nodes observe the network, report forks and make system health metrics
+// available to operators.
+type WatchtowerNode interface {
+	BaseNode
+
+	// Start begins monitoring routines for the node.
+	Start(ctx context.Context) error
+
+	// Stop gracefully shuts down monitoring routines.
+	Stop() error
+
+	// ReportFork records details of a detected fork for later analysis.
+	ReportFork(height uint64, hash string)
+
+	// Metrics returns the latest snapshot of system health data.
+	Metrics() Metrics
+}

--- a/system_health_logging.go
+++ b/system_health_logging.go
@@ -1,0 +1,48 @@
+package synnergy
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	watchtower "synnergy/nodes/watchtower"
+)
+
+// SystemHealthLogger collects runtime metrics for a node and exposes snapshots
+// for external consumption. It is safe for concurrent use by multiple goroutines.
+type SystemHealthLogger struct {
+	mu   sync.RWMutex
+	last watchtower.Metrics
+}
+
+// NewSystemHealthLogger returns an initialised SystemHealthLogger instance.
+func NewSystemHealthLogger() *SystemHealthLogger {
+	return &SystemHealthLogger{}
+}
+
+// Collect gathers metrics from the runtime and records them as the latest snapshot.
+// Caller may supply optional peer count and block height information.
+func (l *SystemHealthLogger) Collect(peerCount int, height uint64) watchtower.Metrics {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	m := watchtower.Metrics{
+		CPUUsage:        float64(runtime.NumGoroutine()),
+		MemoryUsage:     ms.Alloc,
+		PeerCount:       peerCount,
+		LastBlockHeight: height,
+		Timestamp:       time.Now(),
+	}
+
+	l.mu.Lock()
+	l.last = m
+	l.mu.Unlock()
+	return m
+}
+
+// Snapshot returns the most recently recorded metrics.
+func (l *SystemHealthLogger) Snapshot() watchtower.Metrics {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.last
+}

--- a/system_health_logging_test.go
+++ b/system_health_logging_test.go
@@ -1,0 +1,15 @@
+package synnergy
+
+import "testing"
+
+func TestSystemHealthLogger(t *testing.T) {
+	l := NewSystemHealthLogger()
+	m := l.Collect(5, 10)
+	if m.PeerCount != 5 || m.LastBlockHeight != 10 {
+		t.Fatalf("unexpected metrics: %+v", m)
+	}
+	snap := l.Snapshot()
+	if snap.PeerCount != 5 || snap.LastBlockHeight != 10 {
+		t.Fatalf("snapshot mismatch: %+v", snap)
+	}
+}

--- a/watchtower_node.go
+++ b/watchtower_node.go
@@ -1,0 +1,98 @@
+package synnergy
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+	"time"
+
+	watchtower "synnergy/nodes/watchtower"
+)
+
+// WatchtowerNode observes the network, records system health metrics and reports
+// detected forks.
+type WatchtowerNode struct {
+	id       string
+	firewall *Firewall
+	health   *SystemHealthLogger
+	logger   *log.Logger
+
+	mu      sync.RWMutex
+	running bool
+	cancel  context.CancelFunc
+}
+
+// NewWatchtowerNode constructs a WatchtowerNode with the provided identifier.
+func NewWatchtowerNode(id string, logger *log.Logger) *WatchtowerNode {
+	return &WatchtowerNode{
+		id:       id,
+		firewall: NewFirewall(),
+		health:   NewSystemHealthLogger(),
+		logger:   logger,
+	}
+}
+
+// ID returns the unique identifier of the node.
+func (w *WatchtowerNode) ID() string { return w.id }
+
+// Start begins monitoring routines for the watchtower node.
+func (w *WatchtowerNode) Start(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.running {
+		return errors.New("watchtower already running")
+	}
+	var c context.Context
+	c, w.cancel = context.WithCancel(ctx)
+	w.running = true
+	go w.monitorLoop(c)
+	return nil
+}
+
+// monitorLoop periodically collects system health metrics.
+func (w *WatchtowerNode) monitorLoop(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m := w.health.Collect(0, 0)
+			if w.logger != nil {
+				w.logger.Printf("watchtower metrics: %+v", m)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop halts monitoring routines for the watchtower node.
+func (w *WatchtowerNode) Stop() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.running {
+		return nil
+	}
+	w.cancel()
+	w.running = false
+	return nil
+}
+
+// ReportFork records details of a detected fork event.
+func (w *WatchtowerNode) ReportFork(height uint64, hash string) {
+	if w.logger != nil {
+		w.logger.Printf("fork detected at height %d hash %s", height, hash)
+	}
+}
+
+// Metrics returns the latest snapshot of system health data.
+func (w *WatchtowerNode) Metrics() watchtower.Metrics {
+	return w.health.Snapshot()
+}
+
+// Firewall exposes the internal firewall instance for rule management.
+func (w *WatchtowerNode) Firewall() *Firewall { return w.firewall }
+
+// ensure interface compliance
+var _ watchtower.WatchtowerNode = (*WatchtowerNode)(nil)

--- a/watchtower_node_test.go
+++ b/watchtower_node_test.go
@@ -1,0 +1,34 @@
+package synnergy
+
+import (
+	"context"
+	"io"
+	"log"
+	"testing"
+)
+
+func TestWatchtowerNode(t *testing.T) {
+	w := NewWatchtowerNode("wt1", log.New(io.Discard, "", 0))
+	if w.ID() != "wt1" {
+		t.Fatalf("unexpected id: %s", w.ID())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := w.Start(ctx); err == nil {
+		t.Fatalf("expected error on double start")
+	}
+
+	w.health.Collect(1, 1)
+	if w.Metrics().PeerCount != 1 {
+		t.Fatalf("metrics not recorded")
+	}
+	w.ReportFork(5, "hash")
+
+	if err := w.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add watchtower node implementation with firewall and health logging
- introduce firewall, health logger, and failover manager utilities
- define watchtower interface for node packages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689145d066a88320a0fd0eacebb8d465