### PR TITLE
Stage 5: warfare & biometric modules

### DIFF
--- a/biometric_security_node.go
+++ b/biometric_security_node.go
@@ -26,6 +26,11 @@ func (b *BiometricSecurityNode) Enroll(addr string, biometric []byte) {
 	b.Auth.Enroll(addr, biometric)
 }
 
+// Remove deletes biometric data associated with the address.
+func (b *BiometricSecurityNode) Remove(addr string) {
+	b.Auth.Remove(addr)
+}
+
 // Authenticate verifies biometric data for the address.
 func (b *BiometricSecurityNode) Authenticate(addr string, biometric []byte) bool {
 	return b.Auth.Verify(addr, biometric)

--- a/biometrics_auth.go
+++ b/biometrics_auth.go
@@ -40,3 +40,23 @@ func (b *BiometricsAuth) Remove(addr string) {
 	defer b.mu.Unlock()
 	delete(b.templates, addr)
 }
+
+// Enrolled returns true if biometric data has been enrolled for the address.
+func (b *BiometricsAuth) Enrolled(addr string) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	_, ok := b.templates[addr]
+	return ok
+}
+
+// List returns a snapshot of all addresses that have enrolled biometrics.
+// The returned slice is a copy and safe for the caller to modify.
+func (b *BiometricsAuth) List() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	addrs := make([]string, 0, len(b.templates))
+	for addr := range b.templates {
+		addrs = append(addrs, addr)
+	}
+	return addrs
+}

--- a/core/biometric_security_node.go
+++ b/core/biometric_security_node.go
@@ -31,6 +31,11 @@ func (b *BiometricSecurityNode) Enroll(addr string, biometric []byte) {
 	b.Auth.Enroll(addr, biometric)
 }
 
+// Remove deletes biometric data associated with the address.
+func (b *BiometricSecurityNode) Remove(addr string) {
+	b.Auth.Remove(addr)
+}
+
 // Authenticate verifies biometric data for the address.
 func (b *BiometricSecurityNode) Authenticate(addr string, biometric []byte) bool {
 	return b.Auth.Verify(addr, biometric)
@@ -43,4 +48,17 @@ func (b *BiometricSecurityNode) SecureAddTransaction(addr string, biometric []by
 		return errors.New("biometric verification failed")
 	}
 	return b.AddTransaction(tx)
+}
+
+// SecureExecute runs fn only if biometric verification succeeds for the
+// provided address. It allows callers to wrap arbitrary administrative actions
+// with biometric protection.
+func (b *BiometricSecurityNode) SecureExecute(addr string, biometric []byte, fn func() error) error {
+	if !b.Auth.Verify(addr, biometric) {
+		return errors.New("biometric verification failed")
+	}
+	if fn != nil {
+		return fn()
+	}
+	return nil
 }

--- a/core/biometric_security_node_test.go
+++ b/core/biometric_security_node_test.go
@@ -27,4 +27,24 @@ func TestBiometricSecurityNode(t *testing.T) {
 	if len(base.Mempool) != 1 {
 		t.Fatal("unexpected transaction added")
 	}
+
+	// Test SecureExecute with correct and incorrect biometrics
+	if err := bsn.SecureExecute(admin, bio, func() error {
+		bsn.Node.ID = "updated"
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bsn.Node.ID != "updated" {
+		t.Fatal("secure execute did not run")
+	}
+	if err := bsn.SecureExecute(admin, []byte("bad"), nil); err == nil {
+		t.Fatal("expected verification failure")
+	}
+
+	// Test removal of biometrics
+	bsn.Remove(admin)
+	if bsn.Auth.Enrolled(admin) {
+		t.Fatal("expected biometric data to be removed")
+	}
 }

--- a/core/biometrics_auth.go
+++ b/core/biometrics_auth.go
@@ -40,3 +40,23 @@ func (b *BiometricsAuth) Remove(addr string) {
 	defer b.mu.Unlock()
 	delete(b.templates, addr)
 }
+
+// Enrolled returns true if biometric data has been enrolled for the address.
+func (b *BiometricsAuth) Enrolled(addr string) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	_, ok := b.templates[addr]
+	return ok
+}
+
+// List returns a snapshot of all addresses that have enrolled biometrics.
+// The returned slice is a copy and safe for the caller to modify.
+func (b *BiometricsAuth) List() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	addrs := make([]string, 0, len(b.templates))
+	for addr := range b.templates {
+		addrs = append(addrs, addr)
+	}
+	return addrs
+}

--- a/core/biometrics_auth_test.go
+++ b/core/biometrics_auth_test.go
@@ -15,9 +15,19 @@ func TestBiometricsAuth(t *testing.T) {
 	if !auth.Verify(addr, data) {
 		t.Fatal("expected verification to succeed after enrollment")
 	}
+	if !auth.Enrolled(addr) {
+		t.Fatal("expected address to be enrolled")
+	}
+	list := auth.List()
+	if len(list) != 1 || list[0] != addr {
+		t.Fatalf("unexpected list contents: %#v", list)
+	}
 
 	auth.Remove(addr)
 	if auth.Verify(addr, data) {
 		t.Fatal("expected verification to fail after removal")
+	}
+	if auth.Enrolled(addr) {
+		t.Fatal("expected address to be unenrolled")
 	}
 }

--- a/core/warfare_node.go
+++ b/core/warfare_node.go
@@ -5,22 +5,14 @@ import (
 	"sync"
 	"time"
 
-	militarynodes "synnergy/nodesextra/military_nodes"
+	militarynodes "synnergy/nodes/military_nodes"
 )
-
-// LogisticsRecord captures movement or status updates for military assets.
-type LogisticsRecord struct {
-	AssetID   string
-	Location  string
-	Status    string
-	Timestamp time.Time
-}
 
 // WarfareNode provides military focused extensions on top of a base Node.
 type WarfareNode struct {
 	*Node
 	mu        sync.RWMutex
-	logistics []LogisticsRecord
+	logistics []militarynodes.LogisticsRecord
 }
 
 // NewWarfareNode wraps a base node with warfare specific functionality.
@@ -49,7 +41,7 @@ func (w *WarfareNode) SecureCommand(cmd string) error {
 func (w *WarfareNode) TrackLogistics(assetID, location, status string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	rec := LogisticsRecord{
+	rec := militarynodes.LogisticsRecord{
 		AssetID:   assetID,
 		Location:  location,
 		Status:    status,
@@ -66,11 +58,27 @@ func (w *WarfareNode) ShareTactical(info string) {
 }
 
 // Logistics returns a copy of stored logistics records.
-func (w *WarfareNode) Logistics() []LogisticsRecord {
+func (w *WarfareNode) Logistics() []militarynodes.LogisticsRecord {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	cp := make([]LogisticsRecord, len(w.logistics))
+	cp := make([]militarynodes.LogisticsRecord, len(w.logistics))
 	copy(cp, w.logistics)
+	return cp
+}
+
+// LogisticsByAsset filters stored logistics records for a specific asset ID.
+// The returned slice is a copy and may be safely modified by the caller.
+func (w *WarfareNode) LogisticsByAsset(assetID string) []militarynodes.LogisticsRecord {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	var res []militarynodes.LogisticsRecord
+	for _, r := range w.logistics {
+		if r.AssetID == assetID {
+			res = append(res, r)
+		}
+	}
+	cp := make([]militarynodes.LogisticsRecord, len(res))
+	copy(cp, res)
 	return cp
 }
 

--- a/core/warfare_node_test.go
+++ b/core/warfare_node_test.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	militarynodes "synnergy/nodesextra/military_nodes"
+	militarynodes "synnergy/nodes/military_nodes"
 	"testing"
 )
 
@@ -18,9 +18,19 @@ func TestWarfareNode(t *testing.T) {
 
 	wn.TrackLogistics("asset1", "locA", "idle")
 	wn.TrackLogistics("asset1", "locB", "moving")
+	wn.TrackLogistics("asset2", "locC", "standby")
 	logs := wn.Logistics()
-	if len(logs) != 2 {
-		t.Fatalf("expected 2 records, got %d", len(logs))
+	if len(logs) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(logs))
+	}
+	// Verify filtering by asset
+	asset1 := wn.LogisticsByAsset("asset1")
+	if len(asset1) != 2 {
+		t.Fatalf("expected 2 records for asset1, got %d", len(asset1))
+	}
+	asset2 := wn.LogisticsByAsset("asset2")
+	if len(asset2) != 1 {
+		t.Fatalf("expected 1 record for asset2, got %d", len(asset2))
 	}
 	// ensure interface satisfaction at compile time
 	var _ militarynodes.WarfareNode = wn

--- a/nodes/military_nodes/index.go
+++ b/nodes/military_nodes/index.go
@@ -1,9 +1,22 @@
 package militarynodes
 
+import "time"
+
 // BaseNode defines minimal functionality expected from a network node.
 type BaseNode interface {
 	// GetID returns the node identifier.
 	GetID() string
+}
+
+// LogisticsRecord captures movement or status updates for military assets.
+// It is declared in the interface package so that both interface definitions
+// and concrete implementations share the same type without introducing
+// circular dependencies.
+type LogisticsRecord struct {
+	AssetID   string
+	Location  string
+	Status    string
+	Timestamp time.Time
 }
 
 // WarfareNode extends a base node with military specific operations.
@@ -19,4 +32,7 @@ type WarfareNode interface {
 	TrackLogistics(assetID, location, status string)
 	// ShareTactical distributes tactical information to allied nodes or systems.
 	ShareTactical(info string)
+	// Logistics returns a copy of stored logistics records for inspection or
+	// auditing purposes.
+	Logistics() []LogisticsRecord
 }

--- a/nodesextra/military_nodes/index.go
+++ b/nodesextra/military_nodes/index.go
@@ -1,9 +1,20 @@
 package militarynodes
 
+import "time"
+
 // BaseNode defines minimal functionality expected from a network node.
 type BaseNode interface {
 	// GetID returns the node identifier.
 	GetID() string
+}
+
+// LogisticsRecord mirrors the structure used by concrete implementations
+// handling military logistics.
+type LogisticsRecord struct {
+	AssetID   string
+	Location  string
+	Status    string
+	Timestamp time.Time
 }
 
 // WarfareNode extends a base node with military specific operations.
@@ -19,4 +30,7 @@ type WarfareNode interface {
 	TrackLogistics(assetID, location, status string)
 	// ShareTactical distributes tactical information to allied nodes or systems.
 	ShareTactical(info string)
+	// Logistics returns a copy of stored logistics records for inspection or
+	// auditing purposes.
+	Logistics() []LogisticsRecord
 }


### PR DESCRIPTION
## Summary
- add shared LogisticsRecord and Logistics accessor for military node interface
- implement asset-scoped logistics tracking in WarfareNode
- extend biometrics auth and security node with enrollment listing, removal and secure execution helpers

## Testing
- `go test ./core -run TestWarfareNode -v | tail -n 20`
- `go test ./core -run TestBiometricSecurityNode -v | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689145c5598083209667e4a2fc61b40c