### PR TITLE
Implement forensic and historical node interfaces

### DIFF
--- a/core/forensic_node.go
+++ b/core/forensic_node.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"sync"
+	nodes "synnergy/nodes"
+)
+
+// ForensicNode captures lightweight transaction data and network traces for
+// later inspection. It stores entries in memory; a production implementation
+// would persist this information to durable storage.
+type ForensicNode struct {
+	mu     sync.RWMutex
+	txs    []nodes.TransactionLite
+	traces []nodes.NetworkTrace
+}
+
+// Ensure ForensicNode implements nodes.ForensicNodeInterface.
+var _ nodes.ForensicNodeInterface = (*ForensicNode)(nil)
+
+// NewForensicNode creates a ForensicNode with empty buffers.
+func NewForensicNode() *ForensicNode {
+	return &ForensicNode{}
+}
+
+// RecordTransaction stores a minimal representation of a transaction.
+func (f *ForensicNode) RecordTransaction(tx nodes.TransactionLite) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.txs = append(f.txs, tx)
+	return nil
+}
+
+// RecordNetworkTrace stores a network level event for later analysis.
+func (f *ForensicNode) RecordNetworkTrace(trace nodes.NetworkTrace) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.traces = append(f.traces, trace)
+	return nil
+}
+
+// Transactions returns a copy of recorded transactions.
+func (f *ForensicNode) Transactions() []nodes.TransactionLite {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	out := make([]nodes.TransactionLite, len(f.txs))
+	copy(out, f.txs)
+	return out
+}
+
+// NetworkTraces returns a copy of captured network traces.
+func (f *ForensicNode) NetworkTraces() []nodes.NetworkTrace {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	out := make([]nodes.NetworkTrace, len(f.traces))
+	copy(out, f.traces)
+	return out
+}

--- a/core/forensic_node_test.go
+++ b/core/forensic_node_test.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	nodes "synnergy/nodes"
+	"testing"
+	"time"
+)
+
+func TestForensicNode_RecordAndRetrieve(t *testing.T) {
+	fn := NewForensicNode()
+	tx := nodes.TransactionLite{Hash: "tx1", From: "a", To: "b", Value: 10, Timestamp: time.Now()}
+	trace := nodes.NetworkTrace{PeerID: "peer1", Event: "connect", Timestamp: time.Now()}
+	if err := fn.RecordTransaction(tx); err != nil {
+		t.Fatalf("record tx: %v", err)
+	}
+	if err := fn.RecordNetworkTrace(trace); err != nil {
+		t.Fatalf("record trace: %v", err)
+	}
+	if len(fn.Transactions()) != 1 {
+		t.Fatalf("expected 1 tx, got %d", len(fn.Transactions()))
+	}
+	if len(fn.NetworkTraces()) != 1 {
+		t.Fatalf("expected 1 trace, got %d", len(fn.NetworkTraces()))
+	}
+}

--- a/core/historical_node.go
+++ b/core/historical_node.go
@@ -3,7 +3,7 @@ package core
 import (
 	"errors"
 	"sync"
-	nodes "synnergy/nodesextra"
+	nodes "synnergy/nodes"
 )
 
 // HistoricalNode provides archival functionality for serving historical

--- a/core/historical_node_test.go
+++ b/core/historical_node_test.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	nodes "synnergy/nodesextra"
+	nodes "synnergy/nodes"
 	"testing"
 	"time"
 )

--- a/functions_list.txt
+++ b/functions_list.txt
@@ -358,6 +358,11 @@ core/firewall.go:23:func (f *Firewall) Allow(ip string) {
 core/firewall.go:32:func (f *Firewall) Block(ip string) {
 core/firewall.go:42:func (f *Firewall) IsAllowed(ip string) bool {
 core/firewall.go:56:func (f *Firewall) Rules() (allowed []string, blocked []string) {
+core/forensic_node.go:21:func NewForensicNode() *ForensicNode {
+core/forensic_node.go:26:func (f *ForensicNode) RecordTransaction(tx nodes.TransactionLite) error {
+core/forensic_node.go:34:func (f *ForensicNode) RecordNetworkTrace(trace nodes.NetworkTrace) error {
+core/forensic_node.go:42:func (f *ForensicNode) Transactions() []nodes.TransactionLite {
+core/forensic_node.go:51:func (f *ForensicNode) NetworkTraces() []nodes.NetworkTrace {
 core/idwallet_registration.go:15:func NewIDRegistry() *IDRegistry {
 core/idwallet_registration.go:20:func (r *IDRegistry) Register(addr, info string) error {
 core/idwallet_registration.go:31:func (r *IDRegistry) Info(addr string) (string, bool) {

--- a/nodes/forensic_node.go
+++ b/nodes/forensic_node.go
@@ -1,0 +1,35 @@
+package nodes
+
+import "time"
+
+// TransactionLite represents the minimal transaction information captured by
+// a forensic node without requiring full ledger access.
+type TransactionLite struct {
+	Hash      string
+	From      string
+	To        string
+	Value     uint64
+	Timestamp time.Time
+}
+
+// NetworkTrace captures a single network level event for later forensic
+// analysis.
+type NetworkTrace struct {
+	PeerID    string
+	Event     string
+	Timestamp time.Time
+}
+
+// ForensicNodeInterface defines behaviour for nodes that record lightweight
+// transaction details and network traces for offline analysis.
+type ForensicNodeInterface interface {
+	// RecordTransaction stores a minimal representation of a transaction for
+	// later inspection.
+	RecordTransaction(tx TransactionLite) error
+	// RecordNetworkTrace stores a network trace or event for later analysis.
+	RecordNetworkTrace(trace NetworkTrace) error
+	// Transactions returns the list of recorded transactions.
+	Transactions() []TransactionLite
+	// NetworkTraces returns the list of captured network traces.
+	NetworkTraces() []NetworkTrace
+}

--- a/nodes/historical_node.go
+++ b/nodes/historical_node.go
@@ -1,0 +1,24 @@
+package nodes
+
+import "time"
+
+// BlockSummary provides minimal metadata required to reference a block in
+// archival storage.
+type BlockSummary struct {
+	Height    uint64
+	Hash      string
+	Timestamp time.Time
+}
+
+// HistoricalNodeInterface defines archival functionality for serving historical
+// chain data.
+type HistoricalNodeInterface interface {
+	// ArchiveBlock stores a block summary for long term retrieval.
+	ArchiveBlock(summary BlockSummary) error
+	// GetBlockByHeight retrieves a stored block by its height.
+	GetBlockByHeight(height uint64) (BlockSummary, bool)
+	// GetBlockByHash retrieves a stored block by its hash.
+	GetBlockByHash(hash string) (BlockSummary, bool)
+	// TotalBlocks returns the number of archived blocks.
+	TotalBlocks() int
+}


### PR DESCRIPTION
## Summary
- add forensic and historical node interfaces for transaction tracing and block archival
- implement core forensic node for recording transactions and network traces
- refactor historical node to use shared node interfaces and update function list

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689145dc3d6c83208db18ed6b8ed3a8f