### PR TITLE
Add geospatial and holographic node modules with tests

### DIFF
--- a/environmental_monitoring_node_test.go
+++ b/environmental_monitoring_node_test.go
@@ -1,0 +1,15 @@
+package synnergy
+
+import "testing"
+
+func TestEnvironmentalMonitoringNodeTrigger(t *testing.T) {
+	n := NewEnvironmentalMonitoringNode()
+	cond := EnvCondition{SensorID: "temp1", Operator: ">", Threshold: 50}
+	n.SetCondition(cond)
+	if !n.Trigger("temp1", []byte("55")) {
+		t.Fatal("expected trigger for value above threshold")
+	}
+	if n.Trigger("temp1", []byte("45")) {
+		t.Fatal("did not expect trigger for value below threshold")
+	}
+}

--- a/geospatial_node_test.go
+++ b/geospatial_node_test.go
@@ -1,0 +1,20 @@
+package synnergy
+
+import "testing"
+
+func TestGeospatialNodeRecordAndHistory(t *testing.T) {
+	n := NewGeospatialNode()
+	n.Record("asset1", 1.23, 4.56)
+	hist := n.History("asset1")
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(hist))
+	}
+	if hist[0].Latitude != 1.23 || hist[0].Longitude != 4.56 {
+		t.Fatalf("unexpected record %#v", hist[0])
+	}
+	// ensure returned slice is a copy
+	hist[0].Latitude = 9.0
+	if n.History("asset1")[0].Latitude == 9.0 {
+		t.Fatalf("modifying history should not affect stored data")
+	}
+}

--- a/holographic_test.go
+++ b/holographic_test.go
@@ -1,0 +1,19 @@
+package synnergy
+
+import "testing"
+
+func TestSplitAndReconstructHolographic(t *testing.T) {
+	data := []byte("hello world")
+	frame := SplitHolographic("id", data, 3)
+	if len(frame.Shards) != 3 {
+		t.Fatalf("expected 3 shards, got %d", len(frame.Shards))
+	}
+	recon := ReconstructHolographic(frame)
+	if string(recon) != string(data) {
+		t.Fatalf("reconstructed data mismatch: %s", string(recon))
+	}
+	empty := SplitHolographic("id2", data, 0)
+	if len(empty.Shards) != 0 {
+		t.Fatalf("expected no shards for n<=0")
+	}
+}

--- a/nodes/geospatial.go
+++ b/nodes/geospatial.go
@@ -1,0 +1,20 @@
+package nodes
+
+import "time"
+
+// GeoRecord represents a single geospatial data point captured by the network.
+type GeoRecord struct {
+	Subject   string    // entity the record relates to
+	Latitude  float64   // decimal degrees
+	Longitude float64   // decimal degrees
+	Timestamp time.Time // time the reading was taken
+}
+
+// GeospatialNodeInterface extends NodeInterface with geospatial capabilities.
+type GeospatialNodeInterface interface {
+	NodeInterface
+	// Record stores a latitude/longitude pair for the given subject.
+	Record(subject string, lat, lon float64) error
+	// History returns the recorded locations for a subject ordered by time.
+	History(subject string) []GeoRecord
+}

--- a/nodes/holographic_node.go
+++ b/nodes/holographic_node.go
@@ -1,0 +1,70 @@
+package nodes
+
+import (
+	"sync"
+
+	"synnergy"
+)
+
+// HolographicNode provides holographic data distribution and redundancy.
+type HolographicNode struct {
+	id    Address
+	mu    sync.RWMutex
+	store map[string]synnergy.HolographicFrame
+	peers map[Address]struct{}
+}
+
+// NewHolographicNode creates a new HolographicNode with the given identifier.
+func NewHolographicNode(id Address) *HolographicNode {
+	return &HolographicNode{
+		id:    id,
+		store: make(map[string]synnergy.HolographicFrame),
+		peers: make(map[Address]struct{}),
+	}
+}
+
+// ID returns the node identifier.
+func (n *HolographicNode) ID() Address { return n.id }
+
+// Start implements the NodeInterface; holographic nodes currently have no
+// background processes so Start is a no-op.
+func (n *HolographicNode) Start() error { return nil }
+
+// Stop implements the NodeInterface; holographic nodes currently have no
+// background processes so Stop is a no-op.
+func (n *HolographicNode) Stop() error { return nil }
+
+// Peers returns all known peer addresses.
+func (n *HolographicNode) Peers() []Address {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	out := make([]Address, 0, len(n.peers))
+	for p := range n.peers {
+		out = append(out, p)
+	}
+	return out
+}
+
+// DialSeed adds the provided address to the peer list.
+func (n *HolographicNode) DialSeed(addr Address) error {
+	n.mu.Lock()
+	n.peers[addr] = struct{}{}
+	n.mu.Unlock()
+	return nil
+}
+
+// Store saves a holographic frame in the node's internal storage.
+func (n *HolographicNode) Store(frame synnergy.HolographicFrame) {
+	n.mu.Lock()
+	n.store[frame.ID] = frame
+	n.mu.Unlock()
+}
+
+// Retrieve fetches a holographic frame by ID. The returned boolean indicates
+// whether the frame was found.
+func (n *HolographicNode) Retrieve(id string) (synnergy.HolographicFrame, bool) {
+	n.mu.RLock()
+	frame, ok := n.store[id]
+	n.mu.RUnlock()
+	return frame, ok
+}

--- a/nodes/holographic_node_test.go
+++ b/nodes/holographic_node_test.go
@@ -1,0 +1,26 @@
+package nodes
+
+import (
+	"testing"
+
+	"synnergy"
+)
+
+func TestHolographicNodeStoreRetrieve(t *testing.T) {
+	n := NewHolographicNode(Address("node1"))
+	frame := synnergy.HolographicFrame{ID: "f1", Shards: [][]byte{{1, 2, 3}}}
+	n.Store(frame)
+	got, ok := n.Retrieve("f1")
+	if !ok || got.ID != "f1" {
+		t.Fatalf("expected to retrieve frame f1")
+	}
+}
+
+func TestHolographicNodePeers(t *testing.T) {
+	n := NewHolographicNode(Address("node1"))
+	n.DialSeed(Address("peer1"))
+	peers := n.Peers()
+	if len(peers) != 1 || peers[0] != Address("peer1") {
+		t.Fatalf("unexpected peers: %#v", peers)
+	}
+}


### PR DESCRIPTION
## Summary
- define GeoRecord and GeospatialNodeInterface for location tracking nodes
- implement HolographicNode with peer management and holographic frame storage
- add tests for geospatial recording, environmental triggers, and holographic frame reconstruction

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689145e73a648320b41812fc99d2be0e