### PR TITLE
Add mining and staking modules

### DIFF
--- a/faucet.go
+++ b/faucet.go
@@ -1,0 +1,54 @@
+package synnergy
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// Faucet dispenses small amounts of test funds to users while enforcing a
+// cooldown period between requests.
+type Faucet struct {
+	mu       sync.Mutex
+	balance  uint64
+	amount   uint64
+	cooldown time.Duration
+	lastReq  map[string]time.Time
+}
+
+// NewFaucet creates a faucet with an initial balance, dispense amount and
+// cooldown period.
+func NewFaucet(balance, amount uint64, cooldown time.Duration) *Faucet {
+	return &Faucet{balance: balance, amount: amount, cooldown: cooldown, lastReq: make(map[string]time.Time)}
+}
+
+// Request dispenses funds to the given address if enough balance remains and the
+// cooldown period has elapsed.  The amount granted is returned.
+func (f *Faucet) Request(addr string, now time.Time) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.balance < f.amount {
+		return 0, errors.New("faucet empty")
+	}
+	if t, ok := f.lastReq[addr]; ok && now.Sub(t) < f.cooldown {
+		return 0, errors.New("cooldown period not met")
+	}
+	f.balance -= f.amount
+	f.lastReq[addr] = now
+	return f.amount, nil
+}
+
+// Balance returns the remaining faucet balance.
+func (f *Faucet) Balance() uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.balance
+}
+
+// Configure updates the dispense amount and cooldown duration.
+func (f *Faucet) Configure(amount uint64, cooldown time.Duration) {
+	f.mu.Lock()
+	f.amount = amount
+	f.cooldown = cooldown
+	f.mu.Unlock()
+}

--- a/mining_node.go
+++ b/mining_node.go
@@ -1,0 +1,130 @@
+package synnergy
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MiningNode represents a basic proof-of-work miner that can generate block
+// candidates and submit mined blocks to the network.  The node intentionally
+// keeps state lightweight so that it can operate independently from the rest of
+// the system for tests or simulations.
+type MiningNode struct {
+	id        string
+	mu        sync.RWMutex
+	running   bool
+	hashRate  float64 // hashes per second
+	lastBlock string
+}
+
+// NewMiningNode constructs a mining node with the supplied identifier and
+// nominal hash rate.
+func NewMiningNode(id string, hashRate float64) *MiningNode {
+	return &MiningNode{id: id, hashRate: hashRate}
+}
+
+// ID returns the miner identifier.
+func (m *MiningNode) ID() string {
+	return m.id
+}
+
+// Start begins the mining process.  It is safe to call Start multiple times; the
+// mining loop will only run once until Stop is invoked.
+func (m *MiningNode) Start() {
+	m.mu.Lock()
+	if m.running {
+		m.mu.Unlock()
+		return
+	}
+	m.running = true
+	m.mu.Unlock()
+
+	go m.mineLoop()
+}
+
+// Stop signals the miner to halt work.
+func (m *MiningNode) Stop() {
+	m.mu.Lock()
+	m.running = false
+	m.mu.Unlock()
+}
+
+// IsRunning reports whether the miner is actively hashing.
+func (m *MiningNode) IsRunning() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.running
+}
+
+// HashRate returns the configured hash rate for the miner.
+func (m *MiningNode) HashRate() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.hashRate
+}
+
+// SubmitBlock records the hash of a mined block.  In a full implementation this
+// would broadcast the block to peers.  Here we simply store the hash for tests.
+func (m *MiningNode) SubmitBlock(hash string) {
+	m.mu.Lock()
+	m.lastBlock = hash
+	m.mu.Unlock()
+}
+
+// LastBlock returns the most recently submitted block hash.
+func (m *MiningNode) LastBlock() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.lastBlock
+}
+
+// mineLoop simulates mining by periodically generating random block hashes at
+// the configured hash rate.
+func (m *MiningNode) mineLoop() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		m.mu.RLock()
+		running := m.running
+		rate := m.hashRate
+		m.mu.RUnlock()
+		if !running {
+			return
+		}
+		hashes := int(rate)
+		for i := 0; i < hashes; i++ {
+			// simulate a mined block
+			hash := randomHash()
+			m.SubmitBlock(hash)
+		}
+	}
+}
+
+// randomHash is a helper that returns a pseudo-random hexadecimal string.
+func randomHash() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// MineBlock performs a synchronous mining attempt with the given difficulty.
+// A valid block hash with a number of leading zero bits equal to difficulty will
+// be returned.  This method is primarily intended for tests and does not perform
+// any network operations.
+func (m *MiningNode) MineBlock(difficulty int) (string, error) {
+	if difficulty < 0 || difficulty > 256 {
+		return "", errors.New("invalid difficulty")
+	}
+	prefix := strings.Repeat("0", difficulty/4)
+	for {
+		hash := randomHash()
+		if strings.HasPrefix(hash, prefix) {
+			m.SubmitBlock(hash)
+			return hash, nil
+		}
+	}
+}

--- a/mobile_mining_node.go
+++ b/mobile_mining_node.go
@@ -1,0 +1,65 @@
+package synnergy
+
+import (
+	"errors"
+	"sync"
+)
+
+// MobileMiningNode wraps a MiningNode with additional resource management suited
+// for battery powered devices.  Mining automatically pauses when the battery
+// level drops below a configurable threshold.
+type MobileMiningNode struct {
+	*MiningNode
+	mu        sync.RWMutex
+	battery   float64
+	threshold float64
+}
+
+// NewMobileMiningNode constructs a mobile miner with an initial battery level
+// and threshold at which mining should pause.
+func NewMobileMiningNode(id string, hashRate, battery, threshold float64) *MobileMiningNode {
+	return &MobileMiningNode{MiningNode: NewMiningNode(id, hashRate), battery: battery, threshold: threshold}
+}
+
+// UpdateBattery records the latest battery level for the device.
+func (m *MobileMiningNode) UpdateBattery(level float64) {
+	m.mu.Lock()
+	m.battery = level
+	if m.battery < m.threshold {
+		m.MiningNode.Stop()
+	}
+	m.mu.Unlock()
+}
+
+// Start begins mining if the battery level is above the configured threshold.
+func (m *MobileMiningNode) Start() error {
+	m.mu.RLock()
+	ok := m.battery >= m.threshold
+	m.mu.RUnlock()
+	if !ok {
+		return errors.New("battery level too low for mining")
+	}
+	m.MiningNode.Start()
+	return nil
+}
+
+// Battery returns the current battery level.
+func (m *MobileMiningNode) Battery() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.battery
+}
+
+// Threshold returns the minimum battery level required to mine.
+func (m *MobileMiningNode) Threshold() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.threshold
+}
+
+// SetThreshold updates the minimum battery level required to mine.
+func (m *MobileMiningNode) SetThreshold(th float64) {
+	m.mu.Lock()
+	m.threshold = th
+	m.mu.Unlock()
+}

--- a/stake_penalty.go
+++ b/stake_penalty.go
@@ -1,0 +1,62 @@
+package synnergy
+
+import (
+	"sync"
+	"time"
+)
+
+// PenaltyRecord captures information about a stake penalty applied to a
+// validator.
+type PenaltyRecord struct {
+	Points int
+	Reason string
+	Time   time.Time
+}
+
+// StakePenaltyManager tracks validator stake levels and penalty points.  It
+// provides helper methods used by the CLI to adjust stake, record penalties and
+// fetch information for a validator.
+type StakePenaltyManager struct {
+	mu        sync.RWMutex
+	stakes    map[string]uint64
+	penalties map[string]int
+	history   map[string][]PenaltyRecord
+}
+
+// NewStakePenaltyManager creates an empty manager instance.
+func NewStakePenaltyManager() *StakePenaltyManager {
+	return &StakePenaltyManager{
+		stakes:    make(map[string]uint64),
+		penalties: make(map[string]int),
+		history:   make(map[string][]PenaltyRecord),
+	}
+}
+
+// AdjustStake increases or decreases stake for a validator by delta.  Delta may
+// be negative to reduce stake.
+func (m *StakePenaltyManager) AdjustStake(addr string, delta int64) {
+	m.mu.Lock()
+	current := int64(m.stakes[addr]) + delta
+	if current < 0 {
+		current = 0
+	}
+	m.stakes[addr] = uint64(current)
+	m.mu.Unlock()
+}
+
+// Penalize records penalty points against the validator with an optional reason.
+func (m *StakePenaltyManager) Penalize(addr string, points int, reason string) {
+	m.mu.Lock()
+	m.penalties[addr] += points
+	rec := PenaltyRecord{Points: points, Reason: reason, Time: time.Now().UTC()}
+	m.history[addr] = append(m.history[addr], rec)
+	m.mu.Unlock()
+}
+
+// Info returns the current stake amount, total penalty points and history for
+// the given validator address.
+func (m *StakePenaltyManager) Info(addr string) (stake uint64, penalty int, history []PenaltyRecord) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.stakes[addr], m.penalties[addr], append([]PenaltyRecord(nil), m.history[addr]...)
+}

--- a/staking_node.go
+++ b/staking_node.go
@@ -1,0 +1,51 @@
+package synnergy
+
+import "sync"
+
+// StakingNode tracks token stakes from multiple participants.  It provides
+// methods for staking, unstaking and querying balances, enabling the CLI staking
+// commands to operate without needing a full ledger implementation.
+type StakingNode struct {
+	mu    sync.RWMutex
+	stake map[string]uint64
+	total uint64
+}
+
+// NewStakingNode creates an empty staking node instance.
+func NewStakingNode() *StakingNode {
+	return &StakingNode{stake: make(map[string]uint64)}
+}
+
+// Stake locks the specified amount for the given address.
+func (s *StakingNode) Stake(addr string, amt uint64) {
+	s.mu.Lock()
+	s.stake[addr] += amt
+	s.total += amt
+	s.mu.Unlock()
+}
+
+// Unstake releases previously staked tokens for the address.
+func (s *StakingNode) Unstake(addr string, amt uint64) {
+	s.mu.Lock()
+	current := s.stake[addr]
+	if amt > current {
+		amt = current
+	}
+	s.stake[addr] = current - amt
+	s.total -= amt
+	s.mu.Unlock()
+}
+
+// Balance returns the staked balance for the provided address.
+func (s *StakingNode) Balance(addr string) uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.stake[addr]
+}
+
+// TotalStaked returns the total amount staked across all addresses.
+func (s *StakingNode) TotalStaked() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.total
+}


### PR DESCRIPTION
## Summary
- add modular mining node with start/stop and simulated hash submissions
- support mobile miners with battery-aware controls
- implement staking node, penalty manager, and faucet for governance utilities

## Testing
- `go build ./...`
- `go test ./...` *(fails: bank_node adapters missing IsRunning)*

------
https://chatgpt.com/codex/tasks/task_e_6891463b9c888320a426f0c7f7cae8c8