### PR TITLE
feat: implement content and data node utilities

### DIFF
--- a/content_node.go
+++ b/content_node.go
@@ -29,6 +29,13 @@ func (n *ContentNetworkNode) Register(meta ContentMeta) {
 	n.mu.Unlock()
 }
 
+// Unregister removes a content item from this node's registry.
+func (n *ContentNetworkNode) Unregister(id string) {
+	n.mu.Lock()
+	delete(n.contents, id)
+	n.mu.Unlock()
+}
+
 // Content returns metadata for a hosted content item.
 func (n *ContentNetworkNode) Content(id string) (ContentMeta, bool) {
 	n.mu.RLock()

--- a/content_node_impl.go
+++ b/content_node_impl.go
@@ -96,3 +96,11 @@ func (n *ContentNode) Meta(id string) (ContentMeta, bool) {
 	n.mu.RUnlock()
 	return meta, ok
 }
+
+// DeleteContent removes the stored ciphertext and metadata for the given id.
+func (n *ContentNode) DeleteContent(id string) {
+	n.mu.Lock()
+	delete(n.contents, id)
+	delete(n.metas, id)
+	n.mu.Unlock()
+}

--- a/data_distribution.go
+++ b/data_distribution.go
@@ -32,6 +32,30 @@ func (d *DataDistribution) Offer(nodeID string, meta ContentMeta) {
 	d.mu.Unlock()
 }
 
+// Revoke removes a node's offering for the dataset. When no nodes remain,
+// the dataset entry is deleted from the registry.
+func (d *DataDistribution) Revoke(nodeID, contentID string) {
+	d.mu.Lock()
+	if ds, ok := d.sets[contentID]; ok {
+		delete(ds.Nodes, nodeID)
+		if len(ds.Nodes) == 0 {
+			delete(d.sets, contentID)
+		}
+	}
+	d.mu.Unlock()
+}
+
+// Meta returns the ContentMeta associated with the contentID.
+func (d *DataDistribution) Meta(contentID string) (ContentMeta, bool) {
+	d.mu.RLock()
+	ds, ok := d.sets[contentID]
+	d.mu.RUnlock()
+	if !ok {
+		return ContentMeta{}, false
+	}
+	return ds.Meta, true
+}
+
 // Locations returns the ids of nodes currently hosting the specified dataset.
 func (d *DataDistribution) Locations(contentID string) []string {
 	d.mu.RLock()

--- a/data_operations.go
+++ b/data_operations.go
@@ -36,6 +36,27 @@ func (f *DataFeed) Get(key string) (string, bool) {
 	return val, ok
 }
 
+// Delete removes a key from the feed and records the update time if the key existed.
+func (f *DataFeed) Delete(key string) {
+	f.mu.Lock()
+	if _, ok := f.data[key]; ok {
+		delete(f.data, key)
+		f.updated = time.Now().UTC()
+	}
+	f.mu.Unlock()
+}
+
+// Keys returns a snapshot of all keys stored in the feed.
+func (f *DataFeed) Keys() []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	keys := make([]string, 0, len(f.data))
+	for k := range f.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // Snapshot returns a copy of the feed's current data map.
 func (f *DataFeed) Snapshot() map[string]string {
 	f.mu.RLock()

--- a/data_resource_management.go
+++ b/data_resource_management.go
@@ -51,6 +51,17 @@ func (m *DataResourceManager) Delete(key string) {
 	m.mu.Unlock()
 }
 
+// Keys returns a slice of all keys currently stored.
+func (m *DataResourceManager) Keys() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	keys := make([]string, 0, len(m.store))
+	for k := range m.store {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // Usage returns the total number of bytes currently stored.
 func (m *DataResourceManager) Usage() int64 {
 	m.mu.RLock()

--- a/indexing_node.go
+++ b/indexing_node.go
@@ -52,3 +52,10 @@ func (n *IndexingNode) Keys() []string {
 	}
 	return keys
 }
+
+// Count returns the number of entries currently indexed.
+func (n *IndexingNode) Count() int {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return len(n.index)
+}

--- a/stage12_content_data_test.go
+++ b/stage12_content_data_test.go
@@ -1,0 +1,131 @@
+package synnergy
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestContentNetworkNode(t *testing.T) {
+	n := NewContentNetworkNode("node1", "addr")
+	meta := NewContentMeta("cid", "name", 4, "hash")
+	n.Register(meta)
+	if got, ok := n.Content("cid"); !ok || got.Name != "name" {
+		t.Fatalf("content not registered: %v %v", got, ok)
+	}
+	if len(n.List()) != 1 {
+		t.Fatalf("expected one item")
+	}
+	n.Unregister("cid")
+	if _, ok := n.Content("cid"); ok {
+		t.Fatalf("unregister failed")
+	}
+}
+
+func TestContentNode(t *testing.T) {
+	key := make([]byte, 32)
+	node, err := NewContentNode(key)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+	meta, err := node.StoreContent("greet", []byte("hello"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if meta.Name != "greet" {
+		t.Fatalf("unexpected meta name")
+	}
+	plain, ok, err := node.RetrieveContent(meta.ID)
+	if err != nil || !ok || string(plain) != "hello" {
+		t.Fatalf("retrieve mismatch")
+	}
+	node.DeleteContent(meta.ID)
+	if _, ok, _ := node.RetrieveContent(meta.ID); ok {
+		t.Fatalf("content not deleted")
+	}
+}
+
+func TestDataDistribution(t *testing.T) {
+	d := NewDataDistribution()
+	meta := NewContentMeta("id", "file", 1, "hash")
+	d.Offer("n1", meta)
+	d.Offer("n2", meta)
+	if len(d.Locations("id")) != 2 {
+		t.Fatalf("expected two locations")
+	}
+	if m, ok := d.Meta("id"); !ok || m.Name != "file" {
+		t.Fatalf("meta lookup failed")
+	}
+	d.Revoke("n1", "id")
+	if len(d.Locations("id")) != 1 {
+		t.Fatalf("expected one location after revoke")
+	}
+	d.Revoke("n2", "id")
+	if locs := d.Locations("id"); len(locs) != 0 {
+		t.Fatalf("expected dataset removed: %v", locs)
+	}
+}
+
+func TestDataFeed(t *testing.T) {
+	f := NewDataFeed("feed")
+	f.Update("k1", "v1")
+	if v, ok := f.Get("k1"); !ok || v != "v1" {
+		t.Fatalf("get returned %v %v", v, ok)
+	}
+	if len(f.Keys()) != 1 {
+		t.Fatalf("expected one key")
+	}
+	snap := f.Snapshot()
+	if snap["k1"] != "v1" {
+		t.Fatalf("snapshot mismatch")
+	}
+	if f.LastUpdated().IsZero() {
+		t.Fatalf("last updated not set")
+	}
+	f.Delete("k1")
+	if _, ok := f.Get("k1"); ok {
+		t.Fatalf("delete failed")
+	}
+}
+
+func TestDataResourceManager(t *testing.T) {
+	m := NewDataResourceManager()
+	m.Put("a", []byte{1, 2})
+	m.Put("b", []byte{3})
+	if m.Usage() != 3 {
+		t.Fatalf("unexpected usage: %d", m.Usage())
+	}
+	if len(m.Keys()) != 2 {
+		t.Fatalf("expected two keys")
+	}
+	if v, ok := m.Get("a"); !ok || !bytes.Equal(v, []byte{1, 2}) {
+		t.Fatalf("get mismatch")
+	}
+	m.Delete("a")
+	if _, ok := m.Get("a"); ok {
+		t.Fatalf("delete failed")
+	}
+	if m.Usage() != 1 {
+		t.Fatalf("usage not updated")
+	}
+}
+
+func TestIndexingNode(t *testing.T) {
+	n := NewIndexingNode()
+	n.Index("k", []byte("v"))
+	if c := n.Count(); c != 1 {
+		t.Fatalf("count %d", c)
+	}
+	if v, ok := n.Query("k"); !ok || !bytes.Equal(v, []byte("v")) {
+		t.Fatalf("query mismatch")
+	}
+	if len(n.Keys()) != 1 {
+		t.Fatalf("keys mismatch")
+	}
+	n.Remove("k")
+	if _, ok := n.Query("k"); ok {
+		t.Fatalf("remove failed")
+	}
+	if n.Count() != 0 {
+		t.Fatalf("count mismatch after remove")
+	}
+}


### PR DESCRIPTION
## Summary
- allow content network nodes to unregister items
- add encrypted content deletion and dataset revocation helpers
- expose key and count operations across data modules with tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689146455b808320b4e8a63174b8562a