### PR TITLE
feat: add networking primitives for p2p stage

### DIFF
--- a/core/connection_pool.go
+++ b/core/connection_pool.go
@@ -54,3 +54,30 @@ func (p *ConnectionPool) Size() int {
 	defer p.mu.Unlock()
 	return len(p.conns)
 }
+
+// Dial is a convenience wrapper around Acquire used by the CLI. It either
+// returns an existing connection for the address or creates a new one if
+// capacity allows.
+func (p *ConnectionPool) Dial(addr string) (*Connection, error) {
+	return p.Acquire(addr)
+}
+
+// Close removes all connections from the pool, effectively resetting it.
+func (p *ConnectionPool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.conns = make(map[string]*Connection)
+}
+
+// PoolStats summarises connection usage and capacity for diagnostic output.
+type PoolStats struct {
+	Active   int
+	Capacity int
+}
+
+// Stats returns a snapshot of the pool's current usage.
+func (p *ConnectionPool) Stats() PoolStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return PoolStats{Active: len(p.conns), Capacity: p.max}
+}

--- a/core/nat_traversal.go
+++ b/core/nat_traversal.go
@@ -5,8 +5,9 @@ import "sync"
 // NATManager tracks port mappings for nodes operating behind NAT devices. It is
 // a lightweight helper to register and discover externally reachable ports.
 type NATManager struct {
-	mu       sync.RWMutex
-	mappings map[string]int // node id -> external port
+	mu         sync.RWMutex
+	mappings   map[string]int // node id -> external port
+	externalIP string
 }
 
 // NewNATManager creates an empty NAT manager.
@@ -34,4 +35,25 @@ func (n *NATManager) RemoveMapping(id string) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	delete(n.mappings, id)
+}
+
+// Map records a port mapping for the local node.
+func (n *NATManager) Map(port int) { n.MapPort("self", port) }
+
+// Unmap removes the port mapping for the local node.
+func (n *NATManager) Unmap() { n.RemoveMapping("self") }
+
+// SetExternalIP stores the externally reachable IP address discovered via NAT
+// traversal techniques.
+func (n *NATManager) SetExternalIP(ip string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.externalIP = ip
+}
+
+// ExternalIP returns the last known external IP address.
+func (n *NATManager) ExternalIP() string {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.externalIP
 }

--- a/core/network.go
+++ b/core/network.go
@@ -1,38 +1,105 @@
 package core
 
+import "sync"
+
 // Network manages communication between nodes and relay nodes. It also queues
 // transactions for asynchronous broadcasting and integrates biometric
-// authentication for secure submission.
-
+// authentication for secure submission. Additional helpers expose a minimal
+// pub‑sub system and lifecycle controls used by the CLI.
 type Network struct {
-	nodes  map[string]*Node
-	relays map[string]*Node
-	auth   *BiometricService
-	queue  chan *Transaction
+	mu      sync.RWMutex
+	nodes   map[string]*Node
+	relays  map[string]*Node
+	auth    *BiometricService
+	queue   chan *Transaction
+	running bool
+	quit    chan struct{}
+	subs    map[string][]chan []byte // topic -> subscriber channels
+	wg      sync.WaitGroup
 }
 
-// NewNetwork creates a network with the provided biometric service. A
-// background goroutine processes the transaction queue to broadcast
-// transactions to peers and relay nodes.
+// NewNetwork creates a network with the provided biometric service. The
+// networking loop starts automatically, but can be stopped and restarted via
+// Start and Stop.
 func NewNetwork(auth *BiometricService) *Network {
 	n := &Network{
 		nodes:  make(map[string]*Node),
 		relays: make(map[string]*Node),
 		auth:   auth,
-		queue:  make(chan *Transaction, 100),
+		subs:   make(map[string][]chan []byte),
 	}
-	go n.processQueue()
+	n.Start()
 	return n
 }
 
+// Start launches background processing if not already running.
+func (n *Network) Start() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.running {
+		return
+	}
+	n.queue = make(chan *Transaction, 100)
+	n.quit = make(chan struct{})
+	n.running = true
+	n.wg.Add(1)
+	go n.processQueue()
+}
+
+// Stop halts background processing and waits for completion.
+func (n *Network) Stop() {
+	n.mu.Lock()
+	if !n.running {
+		n.mu.Unlock()
+		return
+	}
+	close(n.quit)
+	n.mu.Unlock()
+	n.wg.Wait()
+	n.mu.Lock()
+	n.running = false
+	n.queue = nil
+	n.mu.Unlock()
+}
+
 // AddNode adds a regular node to the network.
-func (n *Network) AddNode(node *Node) { n.nodes[node.ID] = node }
+func (n *Network) AddNode(node *Node) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.nodes[node.ID] = node
+}
 
 // AddRelay adds a relay node used for extended propagation and redundancy.
-func (n *Network) AddRelay(node *Node) { n.relays[node.ID] = node }
+func (n *Network) AddRelay(node *Node) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.relays[node.ID] = node
+}
+
+// Peers returns the identifiers for all known nodes and relays.
+func (n *Network) Peers() []string {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	out := make([]string, 0, len(n.nodes)+len(n.relays))
+	for id := range n.nodes {
+		out = append(out, id)
+	}
+	for id := range n.relays {
+		out = append(out, id)
+	}
+	return out
+}
 
 // EnqueueTransaction places a transaction into the broadcast queue.
-func (n *Network) EnqueueTransaction(tx *Transaction) { n.queue <- tx }
+func (n *Network) EnqueueTransaction(tx *Transaction) {
+	n.mu.RLock()
+	running := n.running
+	ch := n.queue
+	n.mu.RUnlock()
+	if running {
+		ch <- tx
+	}
+}
 
 // Broadcast verifies biometric data, attaches it to the transaction, and enqueues
 // the transaction for network propagation. If biometric verification fails an
@@ -45,21 +112,63 @@ func (n *Network) Broadcast(tx *Transaction, userID string, biometric []byte) er
 	return nil
 }
 
+// Subscribe registers a listener for the given topic and returns a receive-only
+// channel. Each call creates an independent buffered channel.
+func (n *Network) Subscribe(topic string) <-chan []byte {
+	ch := make(chan []byte, 1)
+	n.mu.Lock()
+	n.subs[topic] = append(n.subs[topic], ch)
+	n.mu.Unlock()
+	return ch
+}
+
+// Publish broadcasts arbitrary data to all subscribers of the provided topic.
+// Messages are delivered on a best-effort basis.
+func (n *Network) Publish(topic string, data []byte) {
+	n.mu.RLock()
+	subs := append([]chan []byte(nil), n.subs[topic]...)
+	n.mu.RUnlock()
+	for _, ch := range subs {
+		select {
+		case ch <- append([]byte(nil), data...):
+		default:
+		}
+	}
+}
+
 // processQueue processes queued transactions and broadcasts them to all peers
 // and relay nodes. Transactions are propagated in a simple fan-out manner to all
 // known nodes.
 func (n *Network) processQueue() {
-	for tx := range n.queue {
-		n.broadcast(tx)
+	defer n.wg.Done()
+	for {
+		select {
+		case tx := <-n.queue:
+			if tx != nil {
+				n.broadcast(tx)
+			}
+		case <-n.quit:
+			return
+		}
 	}
 }
 
 // broadcast sends a transaction to all nodes and relay nodes.
 func (n *Network) broadcast(tx *Transaction) {
+	n.mu.RLock()
+	nodes := make([]*Node, 0, len(n.nodes))
 	for _, node := range n.nodes {
+		nodes = append(nodes, node)
+	}
+	relays := make([]*Node, 0, len(n.relays))
+	for _, node := range n.relays {
+		relays = append(relays, node)
+	}
+	n.mu.RUnlock()
+	for _, node := range nodes {
 		_ = node.AddTransaction(tx)
 	}
-	for _, node := range n.relays {
+	for _, node := range relays {
 		_ = node.AddTransaction(tx)
 	}
 }

--- a/core/swarm.go
+++ b/core/swarm.go
@@ -46,3 +46,27 @@ func (s *Swarm) Broadcast(tx *Transaction) {
 		_ = n.AddTransaction(tx)
 	}
 }
+
+// Peers returns the identifiers of nodes in the swarm.
+func (s *Swarm) Peers() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]string, 0, len(s.nodes))
+	for id := range s.nodes {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// StartConsensus triggers block production on all swarm members and returns the
+// mined blocks. Nodes without pending transactions simply skip mining.
+func (s *Swarm) StartConsensus() []*Block {
+	members := s.Members()
+	blocks := make([]*Block, 0, len(members))
+	for _, n := range members {
+		if b := n.MineBlock(); b != nil {
+			blocks = append(blocks, b)
+		}
+	}
+	return blocks
+}


### PR DESCRIPTION
## Summary
- implement lifecycle hooks and pub-sub for network module
- expand connection pool, NAT manager, peer manager, swarm and kademlia for CLI support

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68914662a7ec83209cc28e0d70619696