### PR TITLE
Add Stage16 blockchain operations ledger enhancements

### DIFF
--- a/core/blockchain_compression.go
+++ b/core/blockchain_compression.go
@@ -1,52 +1,65 @@
 package core
 
 import (
-        "bytes"
-        "compress/gzip"
-        "encoding/json"
-        "os"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"os"
 )
 
 // ledgerSnapshot is a helper type used for serializing the ledger. It exposes
 // only the fields that need to be persisted.
 type ledgerSnapshot struct {
-        Balances map[string]uint64 `json:"balances"`
-        Blocks   []*Block          `json:"blocks"`
+	Balances map[string]uint64  `json:"balances"`
+	Blocks   []*Block           `json:"blocks"`
+	UTXOs    map[string][]*UTXO `json:"utxos,omitempty"`
+	Mempool  []*Transaction     `json:"mempool,omitempty"`
 }
 
 // CompressLedger returns the gzip-compressed JSON encoding of the provided ledger.
 func CompressLedger(l *Ledger) ([]byte, error) {
-        l.mu.RLock()
-        defer l.mu.RUnlock()
-        snap := ledgerSnapshot{Balances: l.balances, Blocks: l.blocks}
-        var buf bytes.Buffer
-        gz := gzip.NewWriter(&buf)
-        if err := json.NewEncoder(gz).Encode(&snap); err != nil {
-                _ = gz.Close()
-                return nil, err
-        }
-        if err := gz.Close(); err != nil {
-                return nil, err
-        }
-        return buf.Bytes(), nil
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	snap := ledgerSnapshot{Balances: l.balances, Blocks: l.blocks, UTXOs: l.utxos, Mempool: l.mempool}
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if err := json.NewEncoder(gz).Encode(&snap); err != nil {
+		_ = gz.Close()
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // DecompressLedger converts a gzip-compressed JSON blob back into a ledger.
 func DecompressLedger(data []byte) (*Ledger, error) {
-        gz, err := gzip.NewReader(bytes.NewReader(data))
-        if err != nil {
-                return nil, err
-        }
-        defer gz.Close()
-        var snap ledgerSnapshot
-        if err := json.NewDecoder(gz).Decode(&snap); err != nil {
-                return nil, err
-        }
-        l := &Ledger{balances: snap.Balances, blocks: snap.Blocks}
-        if l.balances == nil {
-                l.balances = make(map[string]uint64)
-        }
-        return l, nil
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	var snap ledgerSnapshot
+	if err := json.NewDecoder(gz).Decode(&snap); err != nil {
+		return nil, err
+	}
+	l := &Ledger{
+		balances: snap.Balances,
+		blocks:   snap.Blocks,
+		utxos:    snap.UTXOs,
+		mempool:  snap.Mempool,
+	}
+	if l.balances == nil {
+		l.balances = make(map[string]uint64)
+	}
+	if l.utxos == nil {
+		l.utxos = make(map[string][]*UTXO)
+	}
+	if l.mempool == nil {
+		l.mempool = []*Transaction{}
+	}
+	return l, nil
 }
 
 // SaveCompressedSnapshot writes a compressed snapshot of the ledger to the given path.

--- a/core/ledger_test.go
+++ b/core/ledger_test.go
@@ -20,3 +20,25 @@ func TestLedgerApplyTransaction(t *testing.T) {
 		t.Fatalf("expected insufficient funds error")
 	}
 }
+
+func TestLedgerUTXOAndPool(t *testing.T) {
+	l := NewLedger()
+	l.Mint("alice", 50)
+	if utxos := l.GetUTXOs("alice"); len(utxos) != 1 || utxos[0].Amount != 50 {
+		t.Fatalf("unexpected utxo state: %+v", utxos)
+	}
+	tx := NewTransaction("alice", "bob", 20, 0, 0)
+	l.AddToPool(tx)
+	if pool := l.Pool(); len(pool) != 1 {
+		t.Fatalf("expected pool size 1 got %d", len(pool))
+	}
+	if err := l.ApplyTransaction(tx); err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if utxos := l.GetUTXOs("alice"); len(utxos) != 1 || utxos[0].Amount != 30 {
+		t.Fatalf("unexpected alice utxo: %+v", utxos)
+	}
+	if utxos := l.GetUTXOs("bob"); len(utxos) != 1 || utxos[0].Amount != 20 {
+		t.Fatalf("unexpected bob utxo: %+v", utxos)
+	}
+}


### PR DESCRIPTION
## Summary
- extend ledger with UTXO set and mempool tracking
- snapshot and restore UTXOs and mempool in blockchain compression utilities
- verify UTXO and mempool behaviour with new tests

## Testing
- `go test ./core`
- `go test ./...` *(fails: bank_nodes adapters missing IsRunning methods)*

------
https://chatgpt.com/codex/tasks/task_e_68914924cf348320906416741efa9776