### PR TITLE
feat: add rollup sidechain plasma and sharding modules

### DIFF
--- a/core/plasma.go
+++ b/core/plasma.go
@@ -1,0 +1,25 @@
+package core
+
+import "sync"
+
+// PlasmaExit represents a pending withdrawal from a Plasma bridge.
+type PlasmaExit struct {
+	Nonce     uint64
+	Owner     string
+	Token     string
+	Amount    uint64
+	Finalized bool
+}
+
+// PlasmaBridge tracks deposits and exits for a Plasma chain.
+type PlasmaBridge struct {
+	mu     sync.RWMutex
+	seq    uint64
+	exits  map[uint64]*PlasmaExit
+	paused bool
+}
+
+// NewPlasmaBridge creates a new Plasma bridge instance.
+func NewPlasmaBridge() *PlasmaBridge {
+	return &PlasmaBridge{exits: make(map[uint64]*PlasmaExit)}
+}

--- a/core/plasma_management.go
+++ b/core/plasma_management.go
@@ -1,0 +1,22 @@
+package core
+
+// Pause suspends Plasma bridge operations.
+func (b *PlasmaBridge) Pause() {
+	b.mu.Lock()
+	b.paused = true
+	b.mu.Unlock()
+}
+
+// Resume resumes Plasma bridge operations.
+func (b *PlasmaBridge) Resume() {
+	b.mu.Lock()
+	b.paused = false
+	b.mu.Unlock()
+}
+
+// Status reports whether the Plasma bridge is paused.
+func (b *PlasmaBridge) Status() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.paused
+}

--- a/core/plasma_management_test.go
+++ b/core/plasma_management_test.go
@@ -1,0 +1,15 @@
+package core
+
+import "testing"
+
+func TestPlasmaManagement(t *testing.T) {
+	b := NewPlasmaBridge()
+	b.Pause()
+	if !b.Status() {
+		t.Fatalf("expected paused")
+	}
+	b.Resume()
+	if b.Status() {
+		t.Fatalf("expected running")
+	}
+}

--- a/core/plasma_operations.go
+++ b/core/plasma_operations.go
@@ -1,0 +1,62 @@
+package core
+
+import "fmt"
+
+// Deposit records a deposit into the Plasma bridge. For this simplified
+// implementation deposits are acknowledged without additional state.
+func (b *PlasmaBridge) Deposit(owner, token string, amount uint64) error {
+	if b.Status() {
+		return fmt.Errorf("plasma bridge paused")
+	}
+	// Deposits would normally update on-chain state; here we just accept them.
+	return nil
+}
+
+// StartExit initiates an exit and returns its nonce.
+func (b *PlasmaBridge) StartExit(owner, token string, amount uint64) (uint64, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.paused {
+		return 0, fmt.Errorf("plasma bridge paused")
+	}
+	b.seq++
+	nonce := b.seq
+	b.exits[nonce] = &PlasmaExit{Nonce: nonce, Owner: owner, Token: token, Amount: amount}
+	return nonce, nil
+}
+
+// FinalizeExit finalizes a pending exit.
+func (b *PlasmaBridge) FinalizeExit(nonce uint64) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	exit, ok := b.exits[nonce]
+	if !ok {
+		return fmt.Errorf("exit %d not found", nonce)
+	}
+	exit.Finalized = true
+	return nil
+}
+
+// GetExit retrieves details of an exit.
+func (b *PlasmaBridge) GetExit(nonce uint64) (*PlasmaExit, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	exit, ok := b.exits[nonce]
+	if !ok {
+		return nil, fmt.Errorf("exit %d not found", nonce)
+	}
+	return exit, nil
+}
+
+// ListExits lists exits initiated by an owner. If owner is empty all exits are returned.
+func (b *PlasmaBridge) ListExits(owner string) []*PlasmaExit {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	out := []*PlasmaExit{}
+	for _, ex := range b.exits {
+		if owner == "" || ex.Owner == owner {
+			out = append(out, ex)
+		}
+	}
+	return out
+}

--- a/core/plasma_operations_test.go
+++ b/core/plasma_operations_test.go
@@ -1,0 +1,24 @@
+package core
+
+import "testing"
+
+func TestPlasmaBridgeOperations(t *testing.T) {
+	b := NewPlasmaBridge()
+	if err := b.Deposit("alice", "token", 100); err != nil {
+		t.Fatalf("deposit: %v", err)
+	}
+	nonce, err := b.StartExit("alice", "token", 50)
+	if err != nil {
+		t.Fatalf("start exit: %v", err)
+	}
+	if err := b.FinalizeExit(nonce); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	ex, err := b.GetExit(nonce)
+	if err != nil || !ex.Finalized {
+		t.Fatalf("exit not finalized")
+	}
+	if len(b.ListExits("alice")) != 1 {
+		t.Fatalf("list exits failed")
+	}
+}

--- a/core/rollup_management.go
+++ b/core/rollup_management.go
@@ -1,0 +1,26 @@
+package core
+
+// RollupManager provides administrative controls for a RollupAggregator.
+type RollupManager struct {
+	agg *RollupAggregator
+}
+
+// NewRollupManager binds management utilities to an aggregator.
+func NewRollupManager(agg *RollupAggregator) *RollupManager {
+	return &RollupManager{agg: agg}
+}
+
+// Pause halts the underlying aggregator.
+func (m *RollupManager) Pause() {
+	m.agg.Pause()
+}
+
+// Resume restarts the aggregator.
+func (m *RollupManager) Resume() {
+	m.agg.Resume()
+}
+
+// Status returns whether the aggregator is paused.
+func (m *RollupManager) Status() bool {
+	return m.agg.Status()
+}

--- a/core/rollup_management_test.go
+++ b/core/rollup_management_test.go
@@ -1,0 +1,16 @@
+package core
+
+import "testing"
+
+func TestRollupManager(t *testing.T) {
+	agg := NewRollupAggregator()
+	mgr := NewRollupManager(agg)
+	mgr.Pause()
+	if !mgr.Status() {
+		t.Fatalf("expected paused")
+	}
+	mgr.Resume()
+	if mgr.Status() {
+		t.Fatalf("expected running")
+	}
+}

--- a/core/rollups.go
+++ b/core/rollups.go
@@ -1,0 +1,126 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// RollupBatch represents a batch of L2 transactions submitted to L1.
+type RollupBatch struct {
+	ID           string
+	Transactions []string
+	Status       string // pending, challenged, finalized, reverted
+}
+
+// RollupAggregator coordinates rollup batch submission and state.
+type RollupAggregator struct {
+	mu      sync.RWMutex
+	seq     int
+	batches map[string]*RollupBatch
+	paused  bool
+}
+
+// NewRollupAggregator constructs an empty RollupAggregator.
+func NewRollupAggregator() *RollupAggregator {
+	return &RollupAggregator{batches: make(map[string]*RollupBatch)}
+}
+
+// SubmitBatch records a new rollup batch. Returns the batch ID.
+func (a *RollupAggregator) SubmitBatch(txs []string) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.paused {
+		return "", errors.New("rollup aggregator paused")
+	}
+	a.seq++
+	id := fmt.Sprintf("batch-%d", a.seq)
+	a.batches[id] = &RollupBatch{ID: id, Transactions: append([]string(nil), txs...), Status: "pending"}
+	return id, nil
+}
+
+// ChallengeBatch marks a batch as challenged.
+func (a *RollupAggregator) ChallengeBatch(id string, txIdx int, proof []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	b, ok := a.batches[id]
+	if !ok {
+		return fmt.Errorf("batch %s not found", id)
+	}
+	if txIdx < 0 || txIdx >= len(b.Transactions) {
+		return fmt.Errorf("invalid transaction index")
+	}
+	// Proof verification is out of scope for this lightweight module.
+	b.Status = "challenged"
+	return nil
+}
+
+// FinalizeBatch finalizes a batch as valid or reverts it.
+func (a *RollupAggregator) FinalizeBatch(id string, valid bool) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	b, ok := a.batches[id]
+	if !ok {
+		return fmt.Errorf("batch %s not found", id)
+	}
+	if valid {
+		b.Status = "finalized"
+	} else {
+		b.Status = "reverted"
+	}
+	return nil
+}
+
+// BatchInfo retrieves a batch by ID.
+func (a *RollupAggregator) BatchInfo(id string) (RollupBatch, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	b, ok := a.batches[id]
+	if !ok {
+		return RollupBatch{}, false
+	}
+	return *b, true
+}
+
+// ListBatches lists all recorded batches.
+func (a *RollupAggregator) ListBatches() []RollupBatch {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	res := make([]RollupBatch, 0, len(a.batches))
+	for _, b := range a.batches {
+		res = append(res, *b)
+	}
+	return res
+}
+
+// BatchTransactions returns transactions included in a batch.
+func (a *RollupAggregator) BatchTransactions(id string) ([]string, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	b, ok := a.batches[id]
+	if !ok {
+		return nil, fmt.Errorf("batch %s not found", id)
+	}
+	return append([]string(nil), b.Transactions...), nil
+}
+
+// Pause halts new batch submissions.
+func (a *RollupAggregator) Pause() {
+	a.mu.Lock()
+	a.paused = true
+	a.mu.Unlock()
+}
+
+// Resume allows batch submissions.
+func (a *RollupAggregator) Resume() {
+	a.mu.Lock()
+	a.paused = false
+	a.mu.Unlock()
+}
+
+// Status reports whether the aggregator is paused.
+func (a *RollupAggregator) Status() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.paused
+}

--- a/core/rollups_test.go
+++ b/core/rollups_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestRollupAggregator(t *testing.T) {
+	agg := NewRollupAggregator()
+	id, err := agg.SubmitBatch([]string{"tx1", "tx2"})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if id == "" {
+		t.Fatalf("expected batch id")
+	}
+	txs, err := agg.BatchTransactions(id)
+	if err != nil || len(txs) != 2 {
+		t.Fatalf("unexpected transactions")
+	}
+	agg.Pause()
+	if !agg.Status() {
+		t.Fatalf("expected paused")
+	}
+	agg.Resume()
+	if agg.Status() {
+		t.Fatalf("expected resumed")
+	}
+}

--- a/core/sharding.go
+++ b/core/sharding.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"sync"
+)
+
+// ShardManager maintains shard leaders and cross-shard transaction receipts.
+type ShardManager struct {
+	mu         sync.RWMutex
+	leaders    map[int]string
+	receipts   map[int][]string // shardID -> tx hashes destined for shard
+	shardBits  uint8
+	shardLoads map[int]int
+}
+
+// NewShardManager creates an empty shard manager.
+func NewShardManager(shardBits uint8) *ShardManager {
+	return &ShardManager{
+		leaders:    make(map[int]string),
+		receipts:   make(map[int][]string),
+		shardBits:  shardBits,
+		shardLoads: make(map[int]int),
+	}
+}
+
+// GetLeader returns the leader address for a shard.
+func (m *ShardManager) GetLeader(shardID int) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	addr, ok := m.leaders[shardID]
+	return addr, ok
+}
+
+// SetLeader sets the leader address for a shard.
+func (m *ShardManager) SetLeader(shardID int, addr string) {
+	m.mu.Lock()
+	m.leaders[shardID] = addr
+	m.mu.Unlock()
+}
+
+// LeaderMap returns the mapping of shards to leaders.
+func (m *ShardManager) LeaderMap() map[int]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[int]string, len(m.leaders))
+	for id, addr := range m.leaders {
+		out[id] = addr
+	}
+	return out
+}
+
+// SubmitCrossShardTx records a cross-shard transaction header.
+func (m *ShardManager) SubmitCrossShardTx(fromShard, toShard int, txHash string) {
+	m.mu.Lock()
+	m.receipts[toShard] = append(m.receipts[toShard], txHash)
+	m.shardLoads[toShard]++
+	m.mu.Unlock()
+}
+
+// PullReceipts retrieves receipts for a shard and clears them.
+func (m *ShardManager) PullReceipts(shardID int) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	txs := m.receipts[shardID]
+	m.receipts[shardID] = nil
+	m.shardLoads[shardID] = 0
+	return txs
+}
+
+// Reshard updates the shard bit-size (i.e., number of shards = 2^bits).
+func (m *ShardManager) Reshard(newBits uint8) {
+	m.mu.Lock()
+	m.shardBits = newBits
+	m.mu.Unlock()
+}
+
+// Rebalance returns shard IDs exceeding the load threshold.
+func (m *ShardManager) Rebalance(threshold int) []int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var heavy []int
+	for id, load := range m.shardLoads {
+		if load > threshold {
+			heavy = append(heavy, id)
+		}
+	}
+	return heavy
+}
+
+// ShardCount returns the current number of shards.
+func (m *ShardManager) ShardCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return 1 << m.shardBits
+}

--- a/core/sharding_test.go
+++ b/core/sharding_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestShardManager(t *testing.T) {
+	m := NewShardManager(2) // 4 shards
+	m.SetLeader(0, "leader0")
+	if l, ok := m.GetLeader(0); !ok || l != "leader0" {
+		t.Fatalf("get leader")
+	}
+	m.SubmitCrossShardTx(0, 1, "tx1")
+	m.SubmitCrossShardTx(0, 1, "tx2")
+	receipts := m.PullReceipts(1)
+	if len(receipts) != 2 {
+		t.Fatalf("pull receipts")
+	}
+	m.Reshard(3)
+	if m.ShardCount() != 8 {
+		t.Fatalf("shard count")
+	}
+	m.SubmitCrossShardTx(0, 2, "tx3")
+	heavy := m.Rebalance(0)
+	if len(heavy) == 0 {
+		t.Fatalf("expected heavy shard")
+	}
+}

--- a/core/sidechain_ops.go
+++ b/core/sidechain_ops.go
@@ -1,0 +1,55 @@
+package core
+
+import "fmt"
+
+// SidechainOps provides deposit and withdrawal helpers for side-chains.
+type SidechainOps struct {
+	registry *SidechainRegistry
+}
+
+// NewSidechainOps creates operations bound to a registry.
+func NewSidechainOps(reg *SidechainRegistry) *SidechainOps {
+	return &SidechainOps{registry: reg}
+}
+
+// Deposit credits escrow balance for an address on a side-chain.
+func (o *SidechainOps) Deposit(chainID, from string, amount uint64) error {
+	o.registry.mu.Lock()
+	defer o.registry.mu.Unlock()
+	sc, ok := o.registry.chains[chainID]
+	if !ok {
+		return fmt.Errorf("sidechain %s not found", chainID)
+	}
+	sc.Deposits[from] += amount
+	return nil
+}
+
+// Withdraw debits escrow balance if sufficient and a dummy proof is provided.
+func (o *SidechainOps) Withdraw(chainID, from string, amount uint64, proof string) error {
+	if proof == "" {
+		return fmt.Errorf("missing proof")
+	}
+	o.registry.mu.Lock()
+	defer o.registry.mu.Unlock()
+	sc, ok := o.registry.chains[chainID]
+	if !ok {
+		return fmt.Errorf("sidechain %s not found", chainID)
+	}
+	bal := sc.Deposits[from]
+	if bal < amount {
+		return fmt.Errorf("insufficient balance")
+	}
+	sc.Deposits[from] = bal - amount
+	return nil
+}
+
+// EscrowBalance returns the escrowed balance for an address on a side-chain.
+func (o *SidechainOps) EscrowBalance(chainID, addr string) (uint64, error) {
+	o.registry.mu.RLock()
+	defer o.registry.mu.RUnlock()
+	sc, ok := o.registry.chains[chainID]
+	if !ok {
+		return 0, fmt.Errorf("sidechain %s not found", chainID)
+	}
+	return sc.Deposits[addr], nil
+}

--- a/core/sidechain_ops_test.go
+++ b/core/sidechain_ops_test.go
@@ -1,0 +1,23 @@
+package core
+
+import "testing"
+
+func TestSidechainOps(t *testing.T) {
+	reg := NewSidechainRegistry()
+	reg.Register("chain1", "meta", nil)
+	ops := NewSidechainOps(reg)
+	if err := ops.Deposit("chain1", "alice", 100); err != nil {
+		t.Fatalf("deposit: %v", err)
+	}
+	bal, err := ops.EscrowBalance("chain1", "alice")
+	if err != nil || bal != 100 {
+		t.Fatalf("balance: %d %v", bal, err)
+	}
+	if err := ops.Withdraw("chain1", "alice", 60, "proof"); err != nil {
+		t.Fatalf("withdraw: %v", err)
+	}
+	bal, _ = ops.EscrowBalance("chain1", "alice")
+	if bal != 40 {
+		t.Fatalf("unexpected balance %d", bal)
+	}
+}

--- a/core/sidechains.go
+++ b/core/sidechains.go
@@ -1,0 +1,131 @@
+package core
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Sidechain represents a registered side-chain with metadata and state.
+type Sidechain struct {
+	ID         string
+	Metadata   string
+	Header     string
+	Validators []string
+	Paused     bool
+	Deposits   map[string]uint64 // escrow balances per address
+}
+
+// SidechainRegistry tracks registered side-chains.
+type SidechainRegistry struct {
+	mu     sync.RWMutex
+	chains map[string]*Sidechain
+}
+
+// NewSidechainRegistry creates an empty registry.
+func NewSidechainRegistry() *SidechainRegistry {
+	return &SidechainRegistry{chains: make(map[string]*Sidechain)}
+}
+
+// Register registers a new side-chain.
+func (r *SidechainRegistry) Register(id, meta string, validators []string) (*Sidechain, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.chains[id]; exists {
+		return nil, fmt.Errorf("sidechain %s exists", id)
+	}
+	sc := &Sidechain{ID: id, Metadata: meta, Validators: validators, Deposits: make(map[string]uint64)}
+	r.chains[id] = sc
+	return sc, nil
+}
+
+// SubmitHeader records the latest header for a side-chain.
+func (r *SidechainRegistry) SubmitHeader(id, header string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sc, ok := r.chains[id]
+	if !ok {
+		return fmt.Errorf("sidechain %s not found", id)
+	}
+	sc.Header = header
+	return nil
+}
+
+// GetHeader retrieves the latest header for a side-chain.
+func (r *SidechainRegistry) GetHeader(id string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	sc, ok := r.chains[id]
+	if !ok {
+		return "", false
+	}
+	return sc.Header, true
+}
+
+// Meta returns metadata for a side-chain.
+func (r *SidechainRegistry) Meta(id string) (Sidechain, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	sc, ok := r.chains[id]
+	if !ok {
+		return Sidechain{}, false
+	}
+	return *sc, true
+}
+
+// List returns all registered side-chains.
+func (r *SidechainRegistry) List() []Sidechain {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Sidechain, 0, len(r.chains))
+	for _, sc := range r.chains {
+		out = append(out, *sc)
+	}
+	return out
+}
+
+// Pause suspends a side-chain.
+func (r *SidechainRegistry) Pause(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sc, ok := r.chains[id]
+	if !ok {
+		return fmt.Errorf("sidechain %s not found", id)
+	}
+	sc.Paused = true
+	return nil
+}
+
+// Resume resumes a paused side-chain.
+func (r *SidechainRegistry) Resume(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sc, ok := r.chains[id]
+	if !ok {
+		return fmt.Errorf("sidechain %s not found", id)
+	}
+	sc.Paused = false
+	return nil
+}
+
+// UpdateValidators updates the validator set for a side-chain.
+func (r *SidechainRegistry) UpdateValidators(id string, validators []string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	sc, ok := r.chains[id]
+	if !ok {
+		return fmt.Errorf("sidechain %s not found", id)
+	}
+	sc.Validators = validators
+	return nil
+}
+
+// Remove deletes a side-chain and its data.
+func (r *SidechainRegistry) Remove(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.chains[id]; !ok {
+		return fmt.Errorf("sidechain %s not found", id)
+	}
+	delete(r.chains, id)
+	return nil
+}

--- a/core/sidechains_test.go
+++ b/core/sidechains_test.go
@@ -1,0 +1,37 @@
+package core
+
+import "testing"
+
+func TestSidechainRegistry(t *testing.T) {
+	reg := NewSidechainRegistry()
+	if _, err := reg.Register("chain1", "meta", []string{"val1"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := reg.SubmitHeader("chain1", "h1"); err != nil {
+		t.Fatalf("submit header: %v", err)
+	}
+	if h, ok := reg.GetHeader("chain1"); !ok || h != "h1" {
+		t.Fatalf("get header failed")
+	}
+	if err := reg.Pause("chain1"); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if err := reg.Resume("chain1"); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if err := reg.UpdateValidators("chain1", []string{"val2"}); err != nil {
+		t.Fatalf("update validators: %v", err)
+	}
+	if reg.chains["chain1"].Validators[0] != "val2" {
+		t.Fatalf("validators not updated")
+	}
+	if len(reg.List()) != 1 {
+		t.Fatalf("list length")
+	}
+	if err := reg.Remove("chain1"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if len(reg.List()) != 0 {
+		t.Fatalf("remove failed")
+	}
+}


### PR DESCRIPTION
## Summary
- add rollup aggregator with batch management and admin controls
- introduce sidechain registry and operations for deposits and withdrawals
- implement plasma bridge and sharding manager for off-chain scaling

## Testing
- `go test ./...` (fails: nodes/bank_nodes missing IsRunning)
- `go test ./core -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689149300c1483208c28c55bb121d4bb