### PR TITLE
feat: expand core token framework

### DIFF
--- a/Tokens/base.go
+++ b/Tokens/base.go
@@ -14,28 +14,33 @@ type Token interface {
 	TotalSupply() uint64
 	BalanceOf(addr string) uint64
 	Transfer(from, to string, amount uint64) error
+	TransferFrom(owner, spender, to string, amount uint64) error
 	Mint(to string, amount uint64) error
 	Burn(from string, amount uint64) error
+	Approve(owner, spender string, amount uint64) error
+	Allowance(owner, spender string) uint64
 }
 
 // BaseToken implements the Token interface providing basic accounting.
 type BaseToken struct {
-	id       TokenID
-	name     string
-	symbol   string
-	decimals uint8
-	balances map[string]uint64
-	supply   uint64
+	id         TokenID
+	name       string
+	symbol     string
+	decimals   uint8
+	balances   map[string]uint64
+	supply     uint64
+	allowances map[string]map[string]uint64
 }
 
 // NewBaseToken creates a new base token instance.
 func NewBaseToken(id TokenID, name, symbol string, decimals uint8) *BaseToken {
 	return &BaseToken{
-		id:       id,
-		name:     name,
-		symbol:   symbol,
-		decimals: decimals,
-		balances: make(map[string]uint64),
+		id:         id,
+		name:       name,
+		symbol:     symbol,
+		decimals:   decimals,
+		balances:   make(map[string]uint64),
+		allowances: make(map[string]map[string]uint64),
 	}
 }
 
@@ -69,6 +74,20 @@ func (t *BaseToken) Transfer(from, to string, amount uint64) error {
 	return nil
 }
 
+// TransferFrom moves tokens on behalf of an owner using an approved allowance.
+func (t *BaseToken) TransferFrom(owner, spender, to string, amount uint64) error {
+	if t.allowances[owner][spender] < amount {
+		return fmt.Errorf("allowance exceeded")
+	}
+	if t.balances[owner] < amount {
+		return fmt.Errorf("insufficient balance")
+	}
+	t.allowances[owner][spender] -= amount
+	t.balances[owner] -= amount
+	t.balances[to] += amount
+	return nil
+}
+
 // Mint creates new tokens for the specified address.
 func (t *BaseToken) Mint(to string, amount uint64) error {
 	t.balances[to] += amount
@@ -84,4 +103,18 @@ func (t *BaseToken) Burn(from string, amount uint64) error {
 	t.balances[from] -= amount
 	t.supply -= amount
 	return nil
+}
+
+// Approve sets the allowance for a spender on behalf of an owner.
+func (t *BaseToken) Approve(owner, spender string, amount uint64) error {
+	if t.allowances[owner] == nil {
+		t.allowances[owner] = make(map[string]uint64)
+	}
+	t.allowances[owner][spender] = amount
+	return nil
+}
+
+// Allowance returns the remaining approved amount a spender can use from an owner.
+func (t *BaseToken) Allowance(owner, spender string) uint64 {
+	return t.allowances[owner][spender]
 }

--- a/Tokens/base_test.go
+++ b/Tokens/base_test.go
@@ -3,6 +3,7 @@ package tokens
 import (
 	"encoding/hex"
 	"testing"
+	"time"
 )
 
 func TestBaseTokenMintTransferBurn(t *testing.T) {
@@ -21,6 +22,25 @@ func TestBaseTokenMintTransferBurn(t *testing.T) {
 	}
 	if tok.TotalSupply() != 90 {
 		t.Fatalf("unexpected supply %d", tok.TotalSupply())
+	}
+}
+
+func TestBaseTokenAllowance(t *testing.T) {
+	tok := NewBaseToken(10, "Allow", "ALL", 0)
+	if err := tok.Mint("alice", 100); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if err := tok.Approve("alice", "bob", 50); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if tok.Allowance("alice", "bob") != 50 {
+		t.Fatalf("allowance wrong")
+	}
+	if err := tok.TransferFrom("alice", "bob", "carol", 30); err != nil {
+		t.Fatalf("transferFrom: %v", err)
+	}
+	if tok.BalanceOf("carol") != 30 || tok.Allowance("alice", "bob") != 20 {
+		t.Fatalf("post transfer state incorrect")
 	}
 }
 
@@ -47,6 +67,73 @@ func TestSYN1000ReserveValue(t *testing.T) {
 	val, err := idx.TotalValue(id)
 	if err != nil || val != 100 {
 		t.Fatalf("unexpected value %f err %v", val, err)
+	}
+}
+
+func TestSYN12Metadata(t *testing.T) {
+	meta := SYN12Metadata{BillID: "TB1", Issuer: "Treasury", IssueDate: time.Now(), Maturity: time.Now().Add(24 * time.Hour), Discount: 0.02, FaceValue: 1000}
+	tkn := NewSYN12Token(3, "TBill", "TB", meta, 2)
+	if tkn.Metadata.Issuer != "Treasury" || tkn.Metadata.FaceValue != 1000 {
+		t.Fatalf("unexpected metadata: %+v", tkn.Metadata)
+	}
+}
+
+func TestSYN20PauseFreeze(t *testing.T) {
+	tok := NewSYN20Token(4, "Token", "S20", 0)
+	if err := tok.Mint("alice", 10); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	tok.Freeze("alice")
+	if err := tok.Transfer("alice", "bob", 1); err == nil {
+		t.Fatalf("expected frozen error")
+	}
+	tok.Unfreeze("alice")
+	tok.Pause()
+	if err := tok.Transfer("alice", "bob", 1); err == nil {
+		t.Fatalf("expected paused error")
+	}
+	tok.Unpause()
+	if err := tok.Transfer("alice", "bob", 1); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+}
+
+func TestSYN70AssetLifecycle(t *testing.T) {
+	tok := NewSYN70Token(5, "Game", "G70", 0)
+	if err := tok.RegisterAsset("a1", "alice", "Sword", "RPG"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := tok.SetAttribute("a1", "damage", "10"); err != nil {
+		t.Fatalf("setattr: %v", err)
+	}
+	if err := tok.AddAchievement("a1", "FirstBlood"); err != nil {
+		t.Fatalf("achievement: %v", err)
+	}
+	if err := tok.TransferAsset("a1", "bob"); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	info, err := tok.AssetInfo("a1")
+	if err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if info.Owner != "bob" || info.Attributes["damage"] != "10" || len(info.Achievements) != 1 {
+		t.Fatalf("unexpected asset info: %+v", info)
+	}
+	if len(tok.ListAssets()) != 1 {
+		t.Fatalf("expected one asset")
+	}
+}
+
+func TestRegistryInfoList(t *testing.T) {
+	reg := NewRegistry()
+	tok := NewBaseToken(reg.NextID(), "Tkn", "TK", 0)
+	reg.Register(tok)
+	if len(reg.List()) != 1 {
+		t.Fatalf("expected one token in list")
+	}
+	info, ok := reg.Info(tok.ID())
+	if !ok || info.Symbol != "TK" {
+		t.Fatalf("unexpected info %+v", info)
 	}
 }
 

--- a/Tokens/index.go
+++ b/Tokens/index.go
@@ -27,3 +27,61 @@ func (r *Registry) Get(id TokenID) (Token, bool) {
 	t, ok := r.tokens[id]
 	return t, ok
 }
+
+// GetBySymbol retrieves a token by its symbol.
+func (r *Registry) GetBySymbol(symbol string) (Token, bool) {
+	for _, t := range r.tokens {
+		if t.Symbol() == symbol {
+			return t, true
+		}
+	}
+	return nil, false
+}
+
+// TokenInfo summarises metadata for a registered token.
+type TokenInfo struct {
+	ID          TokenID
+	Name        string
+	Symbol      string
+	Decimals    uint8
+	TotalSupply uint64
+}
+
+// Info returns metadata for a token by ID.
+func (r *Registry) Info(id TokenID) (TokenInfo, bool) {
+	t, ok := r.tokens[id]
+	if !ok {
+		return TokenInfo{}, false
+	}
+	return TokenInfo{
+		ID:          t.ID(),
+		Name:        t.Name(),
+		Symbol:      t.Symbol(),
+		Decimals:    t.Decimals(),
+		TotalSupply: t.TotalSupply(),
+	}, true
+}
+
+// InfoBySymbol returns metadata for a token using its symbol.
+func (r *Registry) InfoBySymbol(symbol string) (TokenInfo, bool) {
+	t, ok := r.GetBySymbol(symbol)
+	if !ok {
+		return TokenInfo{}, false
+	}
+	return r.Info(t.ID())
+}
+
+// List returns metadata for all registered tokens.
+func (r *Registry) List() []TokenInfo {
+	infos := make([]TokenInfo, 0, len(r.tokens))
+	for _, t := range r.tokens {
+		infos = append(infos, TokenInfo{
+			ID:          t.ID(),
+			Name:        t.Name(),
+			Symbol:      t.Symbol(),
+			Decimals:    t.Decimals(),
+			TotalSupply: t.TotalSupply(),
+		})
+	}
+	return infos
+}

--- a/Tokens/syn70.go
+++ b/Tokens/syn70.go
@@ -4,53 +4,84 @@ import "fmt"
 
 // SYN70Asset represents a single game asset tracked by the SYN70 token standard.
 type SYN70Asset struct {
-	ID       string
-	Owner    string
-	Metadata string
+	ID           string
+	Owner        string
+	Name         string
+	Game         string
+	Attributes   map[string]string
+	Achievements []string
 }
 
 // SYN70Token manages in-game assets.
 type SYN70Token struct {
 	*BaseToken
-	assets map[string]SYN70Asset
+	assets map[string]*SYN70Asset
 }
 
 // NewSYN70Token constructs a SYN70 token instance.
 func NewSYN70Token(id TokenID, name, symbol string, decimals uint8) *SYN70Token {
 	return &SYN70Token{
 		BaseToken: NewBaseToken(id, name, symbol, decimals),
-		assets:    make(map[string]SYN70Asset),
+		assets:    make(map[string]*SYN70Asset),
 	}
 }
 
-// MintAsset creates a new asset and assigns it to the owner.
-func (t *SYN70Token) MintAsset(owner, assetID, metadata string) error {
-	if _, exists := t.assets[assetID]; exists {
+// RegisterAsset creates a new asset and assigns it to the owner.
+func (t *SYN70Token) RegisterAsset(id, owner, name, game string) error {
+	if _, exists := t.assets[id]; exists {
 		return fmt.Errorf("asset already exists")
 	}
-	t.assets[assetID] = SYN70Asset{ID: assetID, Owner: owner, Metadata: metadata}
+	t.assets[id] = &SYN70Asset{ID: id, Owner: owner, Name: name, Game: game, Attributes: map[string]string{}}
 	return t.BaseToken.Mint(owner, 1)
 }
 
-// TransferAsset moves an asset from one owner to another.
-func (t *SYN70Token) TransferAsset(assetID, from, to string) error {
-	asset, ok := t.assets[assetID]
+// TransferAsset moves an asset to a new owner.
+func (t *SYN70Token) TransferAsset(id, newOwner string) error {
+	asset, ok := t.assets[id]
 	if !ok {
 		return fmt.Errorf("asset not found")
 	}
-	if asset.Owner != from {
-		return fmt.Errorf("not asset owner")
-	}
-	if err := t.BaseToken.Transfer(from, to, 1); err != nil {
+	if err := t.BaseToken.Transfer(asset.Owner, newOwner, 1); err != nil {
 		return err
 	}
-	asset.Owner = to
-	t.assets[assetID] = asset
+	asset.Owner = newOwner
 	return nil
 }
 
-// GetAsset returns asset information if present.
-func (t *SYN70Token) GetAsset(assetID string) (SYN70Asset, bool) {
-	a, ok := t.assets[assetID]
-	return a, ok
+// SetAttribute sets a custom attribute on an asset.
+func (t *SYN70Token) SetAttribute(id, key, value string) error {
+	asset, ok := t.assets[id]
+	if !ok {
+		return fmt.Errorf("asset not found")
+	}
+	asset.Attributes[key] = value
+	return nil
+}
+
+// AddAchievement records an achievement for an asset.
+func (t *SYN70Token) AddAchievement(id, name string) error {
+	asset, ok := t.assets[id]
+	if !ok {
+		return fmt.Errorf("asset not found")
+	}
+	asset.Achievements = append(asset.Achievements, name)
+	return nil
+}
+
+// AssetInfo returns asset information if present.
+func (t *SYN70Token) AssetInfo(id string) (SYN70Asset, error) {
+	asset, ok := t.assets[id]
+	if !ok {
+		return SYN70Asset{}, fmt.Errorf("asset not found")
+	}
+	return *asset, nil
+}
+
+// ListAssets returns all registered assets.
+func (t *SYN70Token) ListAssets() []SYN70Asset {
+	out := make([]SYN70Asset, 0, len(t.assets))
+	for _, a := range t.assets {
+		out = append(out, *a)
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
- support allowances and delegated transfers in core token base
- expose registry helpers for listing and metadata queries
- enhance SYN70 token with asset attributes and achievements
- broaden token test coverage

## Testing
- `go test ./Tokens`
- `go test ./...` *(fails: missing IsRunning implementations in bank_nodes tests)*

------
https://chatgpt.com/codex/tasks/task_e_6891495e1e1883209ba08dcce0808466