### PR TITLE
Add DAO and governance token modules and tests

### DIFF
--- a/Tokens/dao_tokens_test.go
+++ b/Tokens/dao_tokens_test.go
@@ -1,0 +1,99 @@
+package tokens
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSYN223TokenTransfer(t *testing.T) {
+	tok := NewSYN223Token("Test", "TST", "alice", 100)
+	tok.AddToWhitelist("bob")
+	if err := tok.Transfer("alice", "bob", 40); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if tok.BalanceOf("bob") != 40 {
+		t.Fatalf("expected bob=40 got %d", tok.BalanceOf("bob"))
+	}
+	if err := tok.Transfer("alice", "carol", 10); err == nil {
+		t.Fatalf("expected error for non-whitelisted recipient")
+	}
+}
+
+func TestSYN300TokenGovernanceFlow(t *testing.T) {
+	tok := NewSYN300Token(map[string]uint64{"alice": 100, "bob": 50})
+	tok.Delegate("bob", "alice")
+	id := tok.CreateProposal("alice", "test proposal")
+	if err := tok.Vote(id, "alice", true); err != nil {
+		t.Fatalf("vote: %v", err)
+	}
+	if err := tok.Execute(id, 120); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	prop, err := tok.ProposalStatus(id)
+	if err != nil || !prop.Executed {
+		t.Fatalf("proposal not executed: %v", err)
+	}
+}
+
+func TestSyn2500Registry(t *testing.T) {
+	reg := NewSyn2500Registry()
+	m := NewSyn2500Member("1", "alice", 10, nil)
+	reg.AddMember(m)
+	got, ok := reg.GetMember("1")
+	if !ok || got.Address != "alice" {
+		t.Fatalf("member retrieval failed")
+	}
+	got.UpdateVotingPower(20)
+	if got.VotingPower != 20 {
+		t.Fatalf("update voting power failed")
+	}
+	reg.RemoveMember("1")
+	if _, ok := reg.GetMember("1"); ok {
+		t.Fatalf("expected member removed")
+	}
+}
+
+func TestSYN3500TokenMintRedeem(t *testing.T) {
+	tok := NewSYN3500Token("Currency", "CUR", "issuer", 1.0)
+	tok.Mint("alice", 100)
+	if err := tok.Redeem("alice", 40); err != nil {
+		t.Fatalf("redeem: %v", err)
+	}
+	if bal := tok.BalanceOf("alice"); bal != 60 {
+		t.Fatalf("unexpected balance %d", bal)
+	}
+}
+
+func TestSYN3700TokenValue(t *testing.T) {
+	tok := NewSYN3700Token("Index", "IDX")
+	tok.AddComponent("AAA", 1.0)
+	tok.AddComponent("BBB", 2.0)
+	prices := map[string]float64{"AAA": 2.0, "BBB": 3.0}
+	if v := tok.Value(prices); v != 8.0 {
+		t.Fatalf("unexpected value %f", v)
+	}
+}
+
+func TestSYN4200TokenDonations(t *testing.T) {
+	tok := NewSYN4200Token()
+	tok.Donate("CHAR", "alice", 10, "help")
+	if prog, ok := tok.CampaignProgress("CHAR"); !ok || prog != 10 {
+		t.Fatalf("unexpected progress %d ok %v", prog, ok)
+	}
+	camp, ok := tok.Campaign("CHAR")
+	if !ok || camp.Raised != 10 {
+		t.Fatalf("unexpected campaign data")
+	}
+}
+
+func TestLegalTokenWorkflow(t *testing.T) {
+	lt := NewLegalToken("1", "Contract", "LGL", "doc", "hash", "owner", time.Now().Add(time.Hour), 1, []string{"alice", "bob"})
+	if err := lt.Sign("alice", "sig1"); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	lt.UpdateStatus(LegalTokenStatusActive)
+	lt.Dispute("challenge", "pending")
+	if lt.Status != LegalTokenStatusDisputed || len(lt.Disputes) != 1 {
+		t.Fatalf("dispute not recorded")
+	}
+}

--- a/Tokens/syn223_token.go
+++ b/Tokens/syn223_token.go
@@ -1,0 +1,86 @@
+package tokens
+
+import (
+	"errors"
+	"sync"
+)
+
+// SYN223Token implements a secure transfer token with whitelist and blacklist controls.
+type SYN223Token struct {
+	mu        sync.RWMutex
+	Name      string
+	Symbol    string
+	Owner     string
+	balances  map[string]uint64
+	whitelist map[string]bool
+	blacklist map[string]bool
+}
+
+// NewSYN223Token creates a new SYN223 token and assigns the initial supply to the owner.
+func NewSYN223Token(name, symbol, owner string, supply uint64) *SYN223Token {
+	t := &SYN223Token{
+		Name:      name,
+		Symbol:    symbol,
+		Owner:     owner,
+		balances:  map[string]uint64{owner: supply},
+		whitelist: make(map[string]bool),
+		blacklist: make(map[string]bool),
+	}
+	t.whitelist[owner] = true
+	return t
+}
+
+// AddToWhitelist authorises an address to receive tokens.
+func (t *SYN223Token) AddToWhitelist(addr string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.whitelist[addr] = true
+}
+
+// RemoveFromWhitelist removes an address from the whitelist.
+func (t *SYN223Token) RemoveFromWhitelist(addr string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.whitelist, addr)
+}
+
+// AddToBlacklist blocks an address from participating in transfers.
+func (t *SYN223Token) AddToBlacklist(addr string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.blacklist[addr] = true
+}
+
+// RemoveFromBlacklist lifts a previously applied blacklist restriction.
+func (t *SYN223Token) RemoveFromBlacklist(addr string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.blacklist, addr)
+}
+
+// Transfer performs a safe token transfer verifying whitelist and blacklist rules.
+func (t *SYN223Token) Transfer(from, to string, amount uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.blacklist[from] || t.blacklist[to] {
+		return errors.New("address blacklisted")
+	}
+	if !t.whitelist[to] {
+		return errors.New("recipient not whitelisted")
+	}
+	bal := t.balances[from]
+	if bal < amount {
+		return errors.New("insufficient balance")
+	}
+	t.balances[from] = bal - amount
+	t.balances[to] += amount
+	return nil
+}
+
+// BalanceOf returns the current balance of an address.
+func (t *SYN223Token) BalanceOf(addr string) uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.balances[addr]
+}

--- a/Tokens/syn2500_token.go
+++ b/Tokens/syn2500_token.go
@@ -1,0 +1,79 @@
+package tokens
+
+import (
+	"sync"
+	"time"
+)
+
+// Syn2500Member stores metadata about DAO membership.
+type Syn2500Member struct {
+	ID          string
+	Address     string
+	JoinedAt    time.Time
+	VotingPower uint64
+	Metadata    map[string]string
+}
+
+// NewSyn2500Member creates a new DAO member record.
+func NewSyn2500Member(id, addr string, power uint64, meta map[string]string) *Syn2500Member {
+	cp := make(map[string]string, len(meta))
+	for k, v := range meta {
+		cp[k] = v
+	}
+	return &Syn2500Member{
+		ID:          id,
+		Address:     addr,
+		JoinedAt:    time.Now(),
+		VotingPower: power,
+		Metadata:    cp,
+	}
+}
+
+// UpdateVotingPower sets the member's voting power.
+func (m *Syn2500Member) UpdateVotingPower(power uint64) {
+	m.VotingPower = power
+}
+
+// Syn2500Registry manages DAO membership records.
+type Syn2500Registry struct {
+	mu      sync.RWMutex
+	members map[string]*Syn2500Member
+}
+
+// NewSyn2500Registry returns an empty membership registry.
+func NewSyn2500Registry() *Syn2500Registry {
+	return &Syn2500Registry{members: make(map[string]*Syn2500Member)}
+}
+
+// AddMember inserts or replaces a member entry.
+func (r *Syn2500Registry) AddMember(m *Syn2500Member) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.members[m.ID] = m
+}
+
+// GetMember retrieves a member by ID.
+func (r *Syn2500Registry) GetMember(id string) (*Syn2500Member, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	m, ok := r.members[id]
+	return m, ok
+}
+
+// RemoveMember deletes a member from the registry.
+func (r *Syn2500Registry) RemoveMember(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.members, id)
+}
+
+// ListMembers returns all members of the registry.
+func (r *Syn2500Registry) ListMembers() []*Syn2500Member {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	list := make([]*Syn2500Member, 0, len(r.members))
+	for _, m := range r.members {
+		list = append(list, m)
+	}
+	return list
+}

--- a/Tokens/syn300_token.go
+++ b/Tokens/syn300_token.go
@@ -1,0 +1,176 @@
+package tokens
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// GovernanceProposal represents a proposal created using SYN300 tokens.
+type GovernanceProposal struct {
+	ID          uint64
+	Creator     string
+	Description string
+	Approvals   map[string]bool
+	Rejections  map[string]bool
+	Executed    bool
+	CreatedAt   time.Time
+}
+
+// SYN300Token provides governance features like delegation and on-chain proposals.
+type SYN300Token struct {
+	mu          sync.RWMutex
+	balances    map[string]uint64
+	delegations map[string]string
+	proposals   map[uint64]*GovernanceProposal
+	nextPropID  uint64
+}
+
+// NewSYN300Token initialises a SYN300 token with an optional map of starting balances.
+func NewSYN300Token(initial map[string]uint64) *SYN300Token {
+	cpy := make(map[string]uint64, len(initial))
+	for k, v := range initial {
+		cpy[k] = v
+	}
+	return &SYN300Token{
+		balances:    cpy,
+		delegations: make(map[string]string),
+		proposals:   make(map[uint64]*GovernanceProposal),
+		nextPropID:  1,
+	}
+}
+
+// Delegate assigns the owner's voting power to another address.
+func (t *SYN300Token) Delegate(owner, delegate string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if delegate == "" {
+		delete(t.delegations, owner)
+	} else {
+		t.delegations[owner] = delegate
+	}
+}
+
+// RevokeDelegation removes an existing delegation for the owner.
+func (t *SYN300Token) RevokeDelegation(owner string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.delegations, owner)
+}
+
+// VotingPower returns the voting power of the specified address including delegated tokens.
+func (t *SYN300Token) VotingPower(addr string) uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.votingPowerLocked(addr)
+}
+
+func (t *SYN300Token) votingPowerLocked(addr string) uint64 {
+	power := t.balances[addr]
+	for owner, delegate := range t.delegations {
+		if delegate == addr {
+			power += t.balances[owner]
+		}
+	}
+	return power
+}
+
+// CreateProposal registers a new governance proposal and returns its ID.
+func (t *SYN300Token) CreateProposal(creator, description string) uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	id := t.nextPropID
+	t.nextPropID++
+	t.proposals[id] = &GovernanceProposal{
+		ID:          id,
+		Creator:     creator,
+		Description: description,
+		Approvals:   make(map[string]bool),
+		Rejections:  make(map[string]bool),
+		CreatedAt:   time.Now(),
+	}
+	return id
+}
+
+// Vote records a vote on a proposal from a given address.
+func (t *SYN300Token) Vote(id uint64, voter string, approve bool) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	p, ok := t.proposals[id]
+	if !ok {
+		return errors.New("proposal not found")
+	}
+	if p.Executed {
+		return errors.New("proposal already executed")
+	}
+	if approve {
+		p.Approvals[voter] = true
+		delete(p.Rejections, voter)
+	} else {
+		p.Rejections[voter] = true
+		delete(p.Approvals, voter)
+	}
+	return nil
+}
+
+// Execute finalises a proposal if the approval voting power meets the quorum.
+func (t *SYN300Token) Execute(id uint64, quorum uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	p, ok := t.proposals[id]
+	if !ok {
+		return errors.New("proposal not found")
+	}
+	if p.Executed {
+		return errors.New("proposal already executed")
+	}
+	var power uint64
+	for voter := range p.Approvals {
+		power += t.votingPowerLocked(voter)
+	}
+	if power < quorum {
+		return errors.New("quorum not reached")
+	}
+	p.Executed = true
+	return nil
+}
+
+// ProposalStatus returns a copy of the proposal for external inspection.
+func (t *SYN300Token) ProposalStatus(id uint64) (*GovernanceProposal, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	p, ok := t.proposals[id]
+	if !ok {
+		return nil, errors.New("proposal not found")
+	}
+	cp := *p
+	cp.Approvals = make(map[string]bool, len(p.Approvals))
+	for k, v := range p.Approvals {
+		cp.Approvals[k] = v
+	}
+	cp.Rejections = make(map[string]bool, len(p.Rejections))
+	for k, v := range p.Rejections {
+		cp.Rejections[k] = v
+	}
+	return &cp, nil
+}
+
+// ListProposals returns all proposals currently registered.
+func (t *SYN300Token) ListProposals() []*GovernanceProposal {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	list := make([]*GovernanceProposal, 0, len(t.proposals))
+	for _, p := range t.proposals {
+		cp := *p
+		cp.Approvals = make(map[string]bool, len(p.Approvals))
+		for k, v := range p.Approvals {
+			cp.Approvals[k] = v
+		}
+		cp.Rejections = make(map[string]bool, len(p.Rejections))
+		for k, v := range p.Rejections {
+			cp.Rejections[k] = v
+		}
+		list = append(list, &cp)
+	}
+	return list
+}

--- a/Tokens/syn3500_token.go
+++ b/Tokens/syn3500_token.go
@@ -1,0 +1,67 @@
+package tokens
+
+import (
+	"errors"
+	"sync"
+)
+
+// SYN3500Token represents a currency or stablecoin token.
+type SYN3500Token struct {
+	mu       sync.RWMutex
+	Name     string
+	Symbol   string
+	Issuer   string
+	Rate     float64
+	Balances map[string]uint64
+}
+
+// NewSYN3500Token creates a new currency token instance.
+func NewSYN3500Token(name, symbol, issuer string, rate float64) *SYN3500Token {
+	return &SYN3500Token{
+		Name:     name,
+		Symbol:   symbol,
+		Issuer:   issuer,
+		Rate:     rate,
+		Balances: make(map[string]uint64),
+	}
+}
+
+// SetRate updates the fiat exchange rate of the token.
+func (t *SYN3500Token) SetRate(rate float64) {
+	t.mu.Lock()
+	t.Rate = rate
+	t.mu.Unlock()
+}
+
+// Info returns token symbol, issuer and current rate.
+func (t *SYN3500Token) Info() (string, string, float64) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.Symbol, t.Issuer, t.Rate
+}
+
+// Mint creates new tokens for the specified address.
+func (t *SYN3500Token) Mint(to string, amt uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Balances[to] += amt
+}
+
+// Redeem removes tokens from circulation for the given address.
+func (t *SYN3500Token) Redeem(from string, amt uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	bal := t.Balances[from]
+	if bal < amt {
+		return errors.New("insufficient balance")
+	}
+	t.Balances[from] = bal - amt
+	return nil
+}
+
+// BalanceOf returns the balance of the specified address.
+func (t *SYN3500Token) BalanceOf(addr string) uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.Balances[addr]
+}

--- a/Tokens/syn3700_token.go
+++ b/Tokens/syn3700_token.go
@@ -1,0 +1,66 @@
+package tokens
+
+import (
+	"errors"
+	"sync"
+)
+
+// IndexComponent defines a single asset within an index token.
+type IndexComponent struct {
+	Token  string
+	Weight float64
+}
+
+// SYN3700Token aggregates multiple assets into a single index token.
+type SYN3700Token struct {
+	mu         sync.RWMutex
+	Name       string
+	Symbol     string
+	Components []IndexComponent
+}
+
+// NewSYN3700Token creates a new empty index token.
+func NewSYN3700Token(name, symbol string) *SYN3700Token {
+	return &SYN3700Token{Name: name, Symbol: symbol}
+}
+
+// AddComponent adds an asset and its weight to the index.
+func (t *SYN3700Token) AddComponent(token string, weight float64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Components = append(t.Components, IndexComponent{Token: token, Weight: weight})
+}
+
+// RemoveComponent removes an asset from the index by token symbol.
+func (t *SYN3700Token) RemoveComponent(token string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i, c := range t.Components {
+		if c.Token == token {
+			t.Components = append(t.Components[:i], t.Components[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("component not found")
+}
+
+// ListComponents returns a snapshot of the current index components.
+func (t *SYN3700Token) ListComponents() []IndexComponent {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	comps := make([]IndexComponent, len(t.Components))
+	copy(comps, t.Components)
+	return comps
+}
+
+// Value computes the weighted index value using the provided price map.
+func (t *SYN3700Token) Value(prices map[string]float64) float64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var sum float64
+	for _, c := range t.Components {
+		price := prices[c.Token]
+		sum += price * c.Weight
+	}
+	return sum
+}

--- a/Tokens/syn4200_token.go
+++ b/Tokens/syn4200_token.go
@@ -1,0 +1,67 @@
+package tokens
+
+import "sync"
+
+// CharityCampaign tracks donations and progress for a specific symbol.
+type CharityCampaign struct {
+	Symbol    string
+	Purpose   string
+	Goal      uint64
+	Raised    uint64
+	Donations map[string]uint64
+}
+
+// SYN4200Token implements charity token functionality supporting donations and progress checks.
+type SYN4200Token struct {
+	mu        sync.RWMutex
+	campaigns map[string]*CharityCampaign
+}
+
+// NewSYN4200Token creates an empty charity token registry.
+func NewSYN4200Token() *SYN4200Token {
+	return &SYN4200Token{campaigns: make(map[string]*CharityCampaign)}
+}
+
+// Donate records a donation to a campaign. Creating the campaign if it does not exist.
+func (t *SYN4200Token) Donate(symbol, from string, amount uint64, purpose string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	c, ok := t.campaigns[symbol]
+	if !ok {
+		c = &CharityCampaign{
+			Symbol:    symbol,
+			Purpose:   purpose,
+			Donations: make(map[string]uint64),
+		}
+		t.campaigns[symbol] = c
+	}
+	c.Raised += amount
+	c.Donations[from] += amount
+}
+
+// CampaignProgress returns the amount raised for a campaign.
+func (t *SYN4200Token) CampaignProgress(symbol string) (uint64, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	c, ok := t.campaigns[symbol]
+	if !ok {
+		return 0, false
+	}
+	return c.Raised, true
+}
+
+// Campaign returns a copy of the campaign data for inspection.
+func (t *SYN4200Token) Campaign(symbol string) (*CharityCampaign, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	c, ok := t.campaigns[symbol]
+	if !ok {
+		return nil, false
+	}
+	cp := *c
+	cp.Donations = make(map[string]uint64, len(c.Donations))
+	for k, v := range c.Donations {
+		cp.Donations[k] = v
+	}
+	return &cp, true
+}

--- a/Tokens/syn4700.go
+++ b/Tokens/syn4700.go
@@ -1,0 +1,146 @@
+package tokens
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// LegalTokenStatus enumerates the status values for a legal token.
+type LegalTokenStatus string
+
+const (
+	LegalTokenStatusPending   LegalTokenStatus = "pending"
+	LegalTokenStatusActive    LegalTokenStatus = "active"
+	LegalTokenStatusCompleted LegalTokenStatus = "completed"
+	LegalTokenStatusDisputed  LegalTokenStatus = "disputed"
+)
+
+// Dispute records dispute actions and optional results.
+type Dispute struct {
+	Action    string
+	Result    string
+	Timestamp time.Time
+}
+
+// LegalToken represents a SYN4700 legal token tied to a legal document.
+type LegalToken struct {
+	mu           sync.RWMutex
+	ID           string
+	Name         string
+	Symbol       string
+	DocumentType string
+	DocumentHash string
+	Expiry       time.Time
+	Owner        string
+	Supply       uint64
+	Parties      []string
+	Signatures   map[string]string
+	Status       LegalTokenStatus
+	Disputes     []Dispute
+}
+
+// NewLegalToken creates a new legal token instance.
+func NewLegalToken(id, name, symbol, docType, hash, owner string, expiry time.Time, supply uint64, parties []string) *LegalToken {
+	cp := make([]string, len(parties))
+	copy(cp, parties)
+	return &LegalToken{
+		ID:           id,
+		Name:         name,
+		Symbol:       symbol,
+		DocumentType: docType,
+		DocumentHash: hash,
+		Expiry:       expiry,
+		Owner:        owner,
+		Supply:       supply,
+		Parties:      cp,
+		Signatures:   make(map[string]string),
+		Status:       LegalTokenStatusPending,
+	}
+}
+
+// Sign records a party signature on the legal token.
+func (t *LegalToken) Sign(party, sig string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.partyExists(party) {
+		return errors.New("unknown party")
+	}
+	t.Signatures[party] = sig
+	return nil
+}
+
+// RevokeSignature removes a party's signature.
+func (t *LegalToken) RevokeSignature(party string) {
+	t.mu.Lock()
+	delete(t.Signatures, party)
+	t.mu.Unlock()
+}
+
+// UpdateStatus sets the current status of the legal token.
+func (t *LegalToken) UpdateStatus(status LegalTokenStatus) {
+	t.mu.Lock()
+	t.Status = status
+	t.mu.Unlock()
+}
+
+// Dispute records a dispute action and optional result. Status becomes disputed.
+func (t *LegalToken) Dispute(action, result string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Status = LegalTokenStatusDisputed
+	t.Disputes = append(t.Disputes, Dispute{Action: action, Result: result, Timestamp: time.Now()})
+}
+
+func (t *LegalToken) partyExists(party string) bool {
+	for _, p := range t.Parties {
+		if p == party {
+			return true
+		}
+	}
+	return false
+}
+
+// LegalTokenRegistry manages legal tokens by ID.
+type LegalTokenRegistry struct {
+	mu     sync.RWMutex
+	tokens map[string]*LegalToken
+}
+
+// NewLegalTokenRegistry creates an empty registry.
+func NewLegalTokenRegistry() *LegalTokenRegistry {
+	return &LegalTokenRegistry{tokens: make(map[string]*LegalToken)}
+}
+
+// Add inserts or replaces a legal token in the registry.
+func (r *LegalTokenRegistry) Add(t *LegalToken) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tokens[t.ID] = t
+}
+
+// Get retrieves a legal token by ID.
+func (r *LegalTokenRegistry) Get(id string) (*LegalToken, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tokens[id]
+	return t, ok
+}
+
+// Remove deletes a legal token from the registry.
+func (r *LegalTokenRegistry) Remove(id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tokens, id)
+}
+
+// List returns all legal tokens in the registry.
+func (r *LegalTokenRegistry) List() []*LegalToken {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	list := make([]*LegalToken, 0, len(r.tokens))
+	for _, t := range r.tokens {
+		list = append(list, t)
+	}
+	return list
+}


### PR DESCRIPTION
## Summary
- implement SYN223 secure transfer token with whitelist/blacklist controls
- add SYN300 governance token with delegation, proposals, voting
- provide additional DAO/governance token modules and comprehensive tests

## Testing
- `go test ./Tokens`
- `go test ./...` *(fails: nodes/bank_nodes index test build error)*

------
https://chatgpt.com/codex/tasks/task_e_68914974a9248320bb4c37f0d28d6886