### PR TITLE
Add redemption support for SYN1401 investments

### DIFF
--- a/core/syn1401.go
+++ b/core/syn1401.go
@@ -52,6 +52,27 @@ func (r *InvestmentRegistry) Accrue(id string, now time.Time) (uint64, error) {
 	return interest, nil
 }
 
+// Redeem settles a matured investment and removes it from the registry.
+// It returns the principal plus any accrued interest.
+func (r *InvestmentRegistry) Redeem(id, to string, now time.Time) (uint64, error) {
+	rec, ok := r.investments[id]
+	if !ok {
+		return 0, errors.New("investment not found")
+	}
+	if rec.Owner != to {
+		return 0, errors.New("unauthorised redeemer")
+	}
+	if now.Before(rec.Maturity) {
+		return 0, errors.New("investment not matured")
+	}
+	if _, err := r.Accrue(id, now); err != nil {
+		return 0, err
+	}
+	total := rec.Principal + rec.Accrued
+	delete(r.investments, id)
+	return total, nil
+}
+
 // Get returns an investment record.
 func (r *InvestmentRegistry) Get(id string) (*InvestmentRecord, bool) {
 	rec, ok := r.investments[id]

--- a/core/syn1401_test.go
+++ b/core/syn1401_test.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInvestmentRedeem(t *testing.T) {
+	reg := NewInvestmentRegistry()
+	rec, err := reg.Issue("inv1", "alice", 1000, 0.10, time.Now().Add(365*24*time.Hour))
+	if err != nil {
+		t.Fatalf("issue failed: %v", err)
+	}
+	maturity := rec.LastAccrued.Add(365 * 24 * time.Hour)
+	payout, err := reg.Redeem("inv1", "alice", maturity)
+	if err != nil {
+		t.Fatalf("redeem failed: %v", err)
+	}
+	if payout != 1100 {
+		t.Fatalf("expected payout 1100 got %d", payout)
+	}
+	if _, ok := reg.Get("inv1"); ok {
+		t.Fatalf("record should be removed after redemption")
+	}
+}


### PR DESCRIPTION
## Summary
- implement investment redemption in SYN1401 registry
- add unit test covering investment lifecycle

## Testing
- `go test ./core -count=1`
- `go test ./...` *(fails: nodes/bank_nodes/index_test.go:38:32: cannot use &bankNodeAdapter{…} as BankInstitutionalNode value in variable declaration: *bankNodeAdapter does not implement BankInstitutionalNode (missing method IsRunning))*

------
https://chatgpt.com/codex/tasks/task_e_68914980044c8320823508a8aa43291a