### PR TITLE
feat: enhance specialized token registries

### DIFF
--- a/core/syn1600.go
+++ b/core/syn1600.go
@@ -1,13 +1,16 @@
 package core
 
-import "errors"
+import (
+	"errors"
+	"sync"
+)
 
 // MusicToken represents metadata and royalty distribution for a SYN1600 token.
 type MusicToken struct {
-	Title  string
-	Artist string
-	Album  string
-
+	Title         string
+	Artist        string
+	Album         string
+	mu            sync.RWMutex
 	royaltySplits map[string]uint64
 	totalShares   uint64
 }
@@ -24,11 +27,15 @@ func NewMusicToken(title, artist, album string) *MusicToken {
 
 // Info returns the music metadata.
 func (m *MusicToken) Info() (string, string, string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.Title, m.Artist, m.Album
 }
 
 // Update modifies the music metadata. Empty values are ignored.
 func (m *MusicToken) Update(title, artist, album string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if title != "" {
 		m.Title = title
 	}
@@ -42,6 +49,8 @@ func (m *MusicToken) Update(title, artist, album string) {
 
 // SetRoyaltyShare sets the royalty share for an address.
 func (m *MusicToken) SetRoyaltyShare(addr string, share uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.totalShares -= m.royaltySplits[addr]
 	m.royaltySplits[addr] = share
 	m.totalShares += share
@@ -49,6 +58,8 @@ func (m *MusicToken) SetRoyaltyShare(addr string, share uint64) {
 
 // Distribute calculates payouts for each royalty recipient based on shares.
 func (m *MusicToken) Distribute(amount uint64) (map[string]uint64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if m.totalShares == 0 {
 		return nil, errors.New("no royalty recipients")
 	}


### PR DESCRIPTION
## Summary
- add thread-safe management to MusicToken, EventMetadata, TradeFinanceToken, GrantRegistry, BenefitRegistry and SYN5000Token
- safeguard issue, transfer, liquidity, disburse and betting operations with mutexes

## Testing
- `go test ./core -v`


------
https://chatgpt.com/codex/tasks/task_e_6891498df3b48320bf0f5f4210dd8e11