### PR TITLE
Fix bank node adapter tests and update build error documentation

### DIFF
--- a/errors_list.md
+++ b/errors_list.md
@@ -1,22 +1,24 @@
 # Build Error Tracking
 
+All identified build errors have been resolved.
+
 ### Stage 1
-core/address.go:84:2: syntax error: non-declaration statement outside function body
+`core/address.go` builds successfully.
 
 ### Stage 2
-core/cross_chain_bridge.go:162:1: syntax error: unexpected ==, expected }
+`core/cross_chain_bridge.go` builds successfully.
 
 ### Stage 3
-core/cross_consensus_scaling_networks.go:14:1: syntax error: unexpected keyword type, expected field name or embedded type
+`core/cross_consensus_scaling_networks.go` builds successfully.
 
 ### Stage 4
-Building package `synnergy` fails due to errors in `synnergy/core`.
+Package `synnergy` builds successfully.
 
 ### Stage 5
-Building package `synnergy/cli` fails due to errors in `synnergy/core`.
+Package `synnergy/cli` builds successfully.
 
 ### Stage 6
-Building package `synnergy/cmd/synnergy` fails due to errors in `synnergy/core`.
+Package `synnergy/cmd/synnergy` builds successfully.
 
 ### Stage 7
 Package `synnergy/Tokens` builds successfully.
@@ -25,7 +27,7 @@ Package `synnergy/Tokens` builds successfully.
 Packages under `synnergy/node_ext` build successfully.
 
 ### Stage 9
-Package `synnergy/nodes` builds successfully.
+Packages under `synnergy/nodes` build successfully. Tests now compile after adding missing `IsRunning` methods in banking node adapters.
 
 ### Stage 10
 Packages under `synnergy/nodesextra` build successfully.

--- a/nodes/bank_nodes/index_test.go
+++ b/nodes/bank_nodes/index_test.go
@@ -12,6 +12,7 @@ type bankNodeAdapter struct{ *core.BankInstitutionalNode }
 func (a *bankNodeAdapter) ID() nodes.Address                 { return nodes.Address(a.Node.ID) }
 func (a *bankNodeAdapter) Start() error                      { return nil }
 func (a *bankNodeAdapter) Stop() error                       { return nil }
+func (a *bankNodeAdapter) IsRunning() bool                   { return true }
 func (a *bankNodeAdapter) Peers() []nodes.Address            { return nil }
 func (a *bankNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
 
@@ -20,6 +21,7 @@ type centralBankNodeAdapter struct{ *core.CentralBankingNode }
 func (a *centralBankNodeAdapter) ID() nodes.Address                 { return nodes.Address(a.Node.ID) }
 func (a *centralBankNodeAdapter) Start() error                      { return nil }
 func (a *centralBankNodeAdapter) Stop() error                       { return nil }
+func (a *centralBankNodeAdapter) IsRunning() bool                   { return true }
 func (a *centralBankNodeAdapter) Peers() []nodes.Address            { return nil }
 func (a *centralBankNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
 
@@ -28,6 +30,7 @@ type custodialNodeAdapter struct{ *core.CustodialNode }
 func (a *custodialNodeAdapter) ID() nodes.Address                 { return nodes.Address(a.Node.ID) }
 func (a *custodialNodeAdapter) Start() error                      { return nil }
 func (a *custodialNodeAdapter) Stop() error                       { return nil }
+func (a *custodialNodeAdapter) IsRunning() bool                   { return true }
 func (a *custodialNodeAdapter) Peers() []nodes.Address            { return nil }
 func (a *custodialNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
 


### PR DESCRIPTION
## Summary
- Ensure banking node adapters implement the full `NodeInterface` by adding missing `IsRunning` methods
- Update build error tracking to reflect current successful build status

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68914bdcf2908320891f28b91cebcc4f