### PR TITLE
Add watchtower command and stabilize consensus test

### DIFF
--- a/cmd/watchtower/main.go
+++ b/cmd/watchtower/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	synnergy "synnergy"
+)
+
+// main launches a standalone watchtower node. The node periodically
+// collects system metrics and logs them. Shutdown is handled gracefully
+// on SIGINT/SIGTERM signals.
+func main() {
+	logger := log.New(os.Stdout, "watchtower: ", log.LstdFlags|log.Lmicroseconds)
+	node := synnergy.NewWatchtowerNode("watchtower-1", logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// capture OS signals for graceful shutdown
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		logger.Println("shutdown signal received")
+		cancel()
+	}()
+
+	if err := node.Start(ctx); err != nil {
+		logger.Fatalf("failed to start watchtower node: %v", err)
+	}
+
+	// block until context is cancelled
+	<-ctx.Done()
+
+	// allow some time for clean shutdown
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+
+	done := make(chan struct{})
+	go func() {
+		if err := node.Stop(); err != nil {
+			logger.Printf("error stopping watchtower node: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		logger.Println("watchtower node stopped")
+	case <-shutdownCtx.Done():
+		logger.Println("timeout waiting for watchtower node to stop")
+	}
+}

--- a/core/consensus_start_test.go
+++ b/core/consensus_start_test.go
@@ -19,7 +19,16 @@ func TestConsensusServiceStartStop(t *testing.T) {
 	}
 	svc := NewConsensusService(node)
 	svc.Start(10 * time.Millisecond)
-	time.Sleep(50 * time.Millisecond)
+
+	// wait up to one second for a block to be mined
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if h, _ := svc.Info(); h > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	svc.Stop()
 	height, running := svc.Info()
 	if running {


### PR DESCRIPTION
## Summary
- add standalone watchtower node entrypoint under `cmd/watchtower`
- make consensus service test deterministic by waiting until a block is mined before stopping

## Testing
- `go build ./cmd/watchtower`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891518c0e348320ad6cef13c1989cd9