### PR TITLE
Add CI/CD pipeline workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Cache modules and build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build binaries
+        run: |
+          mkdir -p dist
+          for dir in ./cmd/*; do
+            if [ -d "$dir" ]; then
+              for os in linux windows darwin; do
+                ext=""
+                if [ "$os" = "windows" ]; then
+                  ext=".exe"
+                fi
+                GOOS=$os GOARCH=amd64 go build -o dist/$(basename $dir)-$os-amd64$ext $dir
+              done
+            fi
+          done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: synnergy-binaries
+          path: dist

--- a/PRODUCTION_STAGES.md
+++ b/PRODUCTION_STAGES.md
@@ -42,9 +42,9 @@ This document outlines a 20-stage roadmap for reorganizing the repository and pr
    - Add integration tests for cross-chain and token flows.  
    - Use GitHub Actions to run tests on each push.
 
-10. **CI/CD Pipeline**  
-    - Implement a GitHub Actions workflow that builds, tests, lints, and packages binaries.  
-    - Enable caching for modules and test results to speed up builds.
+10. **CI/CD Pipeline (Completed)**
+    - Implemented a GitHub Actions workflow that builds, tests, lints, and packages binaries.
+    - Enabled caching for modules and test results to speed up builds.
 
 11. **Documentation Standardization**  
     - Move guides into a `docs/` directory.  


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, test, build, and package binaries with caching
- mark CI/CD pipeline stage as completed in production stages

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689151df941483208250547093fce54d