### PR TITLE
feat(auth): add RBAC with audit logging

### DIFF
--- a/PRODUCTION_STAGES.md
+++ b/PRODUCTION_STAGES.md
@@ -116,8 +116,8 @@ This document outlines a 20-stage roadmap for reorganizing the repository and pr
     - Encapsulate networking code under `internal/p2p/`.  
     - Support secure transports (TLS, Noise protocol) and peer discovery.
 
-19. **Governance and Access Control**  
-    - Centralize RBAC logic in `internal/auth/`.  
+19. **Governance and Access Control** ✅
+    - Centralize RBAC logic in `internal/auth/`.
     - Implement policy enforcement and audit logging.
 
 20. **Packaging and Distribution**  

--- a/go.sum
+++ b/go.sum
@@ -52,7 +52,6 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-=======
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=

--- a/internal/auth/audit.go
+++ b/internal/auth/audit.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"time"
+)
+
+// AuditLogger records authorization attempts for compliance and forensics.
+type AuditLogger interface {
+	Log(userID string, perm Permission, allowed bool, metadata map[string]any)
+}
+
+// StdAuditLogger is a basic implementation writing JSON entries to a logger.
+type StdAuditLogger struct {
+	logger *log.Logger
+}
+
+// NewStdAuditLogger creates an AuditLogger that writes to the provided writer.
+func NewStdAuditLogger(w io.Writer) *StdAuditLogger {
+	return &StdAuditLogger{logger: log.New(w, "", log.LstdFlags|log.LUTC)}
+}
+
+// Log writes a JSON encoded audit entry.
+func (l *StdAuditLogger) Log(userID string, perm Permission, allowed bool, metadata map[string]any) {
+	entry := map[string]any{
+		"timestamp":  time.Now().UTC().Format(time.RFC3339Nano),
+		"user":       userID,
+		"permission": string(perm),
+		"allowed":    allowed,
+		"metadata":   metadata,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		l.logger.Printf("audit marshal error: %v", err)
+		return
+	}
+	l.logger.Print(string(data))
+}

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"errors"
+	"sync"
+)
+
+// Permission represents an action that can be performed within the system.
+type Permission string
+
+// Role groups a set of permissions under a common name.
+type Role struct {
+	Name        string
+	Permissions map[Permission]struct{}
+}
+
+// RBAC manages roles, permissions and their assignment to users.
+type RBAC struct {
+	mu        sync.RWMutex
+	roles     map[string]*Role
+	userRoles map[string]map[string]struct{}
+}
+
+// NewRBAC creates an empty RBAC instance.
+func NewRBAC() *RBAC {
+	return &RBAC{
+		roles:     make(map[string]*Role),
+		userRoles: make(map[string]map[string]struct{}),
+	}
+}
+
+// AddRole registers a new role.
+func (r *RBAC) AddRole(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.roles[name]; exists {
+		return
+	}
+	r.roles[name] = &Role{Name: name, Permissions: make(map[Permission]struct{})}
+}
+
+// AddPermissionToRole attaches a permission to an existing role.
+func (r *RBAC) AddPermissionToRole(roleName string, perm Permission) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	role, ok := r.roles[roleName]
+	if !ok {
+		return errors.New("role does not exist")
+	}
+	role.Permissions[perm] = struct{}{}
+	return nil
+}
+
+// AssignRole associates a role with a user.
+func (r *RBAC) AssignRole(userID, roleName string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.roles[roleName]; !ok {
+		return errors.New("role does not exist")
+	}
+	if _, ok := r.userRoles[userID]; !ok {
+		r.userRoles[userID] = make(map[string]struct{})
+	}
+	r.userRoles[userID][roleName] = struct{}{}
+	return nil
+}
+
+// hasPermission reports whether the given user has the provided permission.
+func (r *RBAC) hasPermission(userID string, perm Permission) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	roles := r.userRoles[userID]
+	for roleName := range roles {
+		role := r.roles[roleName]
+		if role == nil {
+			continue
+		}
+		if _, ok := role.Permissions[perm]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrUnauthorized is returned when a user does not have the required permission.
+var ErrUnauthorized = errors.New("auth: unauthorized")
+
+// PolicyEnforcer checks user permissions and records audit events.
+type PolicyEnforcer struct {
+	rbac  *RBAC
+	audit AuditLogger
+}
+
+// NewPolicyEnforcer creates a PolicyEnforcer with the provided RBAC store and audit logger.
+func NewPolicyEnforcer(r *RBAC, l AuditLogger) *PolicyEnforcer {
+	return &PolicyEnforcer{rbac: r, audit: l}
+}
+
+// Authorize verifies that the user has the specified permission and records the attempt.
+func (p *PolicyEnforcer) Authorize(userID string, perm Permission, metadata map[string]any) error {
+	allowed := p.rbac.hasPermission(userID, perm)
+	if p.audit != nil {
+		p.audit.Log(userID, perm, allowed, metadata)
+	}
+	if !allowed {
+		return ErrUnauthorized
+	}
+	return nil
+}

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPolicyEnforcerAuthorize(t *testing.T) {
+	rbac := NewRBAC()
+	rbac.AddRole("admin")
+	if err := rbac.AddPermissionToRole("admin", Permission("write")); err != nil {
+		t.Fatalf("AddPermissionToRole: %v", err)
+	}
+	if err := rbac.AssignRole("u1", "admin"); err != nil {
+		t.Fatalf("AssignRole: %v", err)
+	}
+
+	var buf bytes.Buffer
+	logger := NewStdAuditLogger(&buf)
+	enforcer := NewPolicyEnforcer(rbac, logger)
+
+	// authorized request
+	if err := enforcer.Authorize("u1", Permission("write"), map[string]any{"resource": "doc"}); err != nil {
+		t.Fatalf("Authorize allowed returned error: %v", err)
+	}
+
+	// unauthorized request
+	if err := enforcer.Authorize("u1", Permission("delete"), nil); err != ErrUnauthorized {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+
+	// verify audit logs
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit lines, got %d", len(lines))
+	}
+	// first log allowed
+	var e1 map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(lines[0][strings.Index(lines[0], "{"):])), &e1); err != nil {
+		t.Fatalf("unmarshal first entry: %v", err)
+	}
+	if allowed, ok := e1["allowed"].(bool); !ok || !allowed {
+		t.Fatalf("expected first entry allowed=true, got %v", e1["allowed"])
+	}
+	// second log denied
+	var e2 map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(lines[1][strings.Index(lines[1], "{"):])), &e2); err != nil {
+		t.Fatalf("unmarshal second entry: %v", err)
+	}
+	if allowed, ok := e2["allowed"].(bool); !ok || allowed {
+		t.Fatalf("expected second entry allowed=false, got %v", e2["allowed"])
+	}
+}


### PR DESCRIPTION
## Summary
- add centralized RBAC package with role and permission management
- provide audit logger and policy enforcer
- mark governance and access control stage as complete

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891559f9dc883209836e097ecd89c11