### PR TITLE
stage13: add build tags and environment configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-.PHONY: staticcheck gosec govulncheck security
+.PHONY: staticcheck gosec govulncheck security build build-experimental build-dev build-test build-prod
 
 staticcheck:
 	staticcheck ./...
@@ -11,4 +10,19 @@ govulncheck:
 	govulncheck ./...
 
 security: staticcheck gosec govulncheck
+
+build:
+	go build ./...
+
+build-experimental:
+	go build -tags experimental ./...
+
+build-dev:
+	go build -tags dev ./...
+
+build-test:
+	go build -tags test ./...
+
+build-prod:
+	go build -tags prod ./...
 

--- a/PRODUCTION_STAGES.md
+++ b/PRODUCTION_STAGES.md
@@ -88,9 +88,9 @@ This document outlines a 20-stage roadmap for reorganizing the repository and pr
     - Define gRPC/REST interfaces for node communication.  
     - Use protobuf definitions under `api/` and auto-generate stubs.
 
-13. **Configuration of Build Tags and Environments**  
-    - Use build tags for optional features (e.g., experimental nodes).  
-    - Provide separate configs for dev/test/production environments.
+13. **Configuration of Build Tags and Environments** ✅
+    - Use build tags for optional features (e.g., experimental nodes). *(completed)*
+    - Provide separate configs for dev/test/production environments. *(completed)*
 
 14. **Containerization**  
     - Create Dockerfiles for each binary.  

--- a/cmd/synnergy/main.go
+++ b/cmd/synnergy/main.go
@@ -9,7 +9,12 @@ import (
 )
 
 func main() {
-	cfg, err := config.Load(os.Getenv("SYN_CONFIG"))
+	cfgPath := os.Getenv("SYN_CONFIG")
+	if cfgPath == "" {
+		cfgPath = config.DefaultConfigPath
+	}
+
+	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/configs/dev.yaml
+++ b/configs/dev.yaml
@@ -1,0 +1,7 @@
+environment: development
+log_level: debug
+server:
+  host: "127.0.0.1"
+  port: 8080
+database:
+  url: "https://dev-db.example.com"

--- a/configs/prod.yaml
+++ b/configs/prod.yaml
@@ -1,0 +1,7 @@
+environment: production
+log_level: info
+server:
+  host: "0.0.0.0"
+  port: 80
+database:
+  url: "https://prod-db.example.com"

--- a/configs/test.yaml
+++ b/configs/test.yaml
@@ -1,0 +1,7 @@
+environment: staging
+log_level: info
+server:
+  host: "127.0.0.1"
+  port: 8081
+database:
+  url: "https://test-db.example.com"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,29 +39,14 @@ github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsF
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-
-github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
-github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
-github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-=======
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
 github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
-github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
-github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -1,0 +1,7 @@
+//go:build !dev && !test && !prod
+
+package config
+
+// DefaultConfigPath specifies the configuration file used when no build tags are provided.
+// It points to the development configuration as a sensible fallback.
+const DefaultConfigPath = "configs/dev.yaml"

--- a/internal/config/default_default_test.go
+++ b/internal/config/default_default_test.go
@@ -1,0 +1,11 @@
+//go:build !dev && !test && !prod
+
+package config
+
+import "testing"
+
+func TestDefaultConfigPath(t *testing.T) {
+	if DefaultConfigPath != "configs/dev.yaml" {
+		t.Fatalf("expected default config path to be configs/dev.yaml, got %s", DefaultConfigPath)
+	}
+}

--- a/internal/config/default_dev.go
+++ b/internal/config/default_dev.go
@@ -1,0 +1,6 @@
+//go:build dev
+
+package config
+
+// DefaultConfigPath points to the development configuration file.
+const DefaultConfigPath = "configs/dev.yaml"

--- a/internal/config/default_prod.go
+++ b/internal/config/default_prod.go
@@ -1,0 +1,6 @@
+//go:build prod
+
+package config
+
+// DefaultConfigPath points to the production configuration file.
+const DefaultConfigPath = "configs/prod.yaml"

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -1,0 +1,6 @@
+//go:build test
+
+package config
+
+// DefaultConfigPath points to the staging/test configuration file.
+const DefaultConfigPath = "configs/test.yaml"

--- a/internal/nodes/experimental_node.go
+++ b/internal/nodes/experimental_node.go
@@ -1,0 +1,41 @@
+//go:build experimental
+
+package nodes
+
+// ExperimentalNode demonstrates a feature that is only compiled when the
+// "experimental" build tag is supplied. It implements NodeInterface but
+// performs no real networking; the functionality can evolve independently of
+// stable releases.
+type ExperimentalNode struct {
+	id      Address
+	running bool
+}
+
+// NewExperimentalNode constructs a new experimental node with the provided identifier.
+func NewExperimentalNode(id Address) *ExperimentalNode {
+	return &ExperimentalNode{id: id}
+}
+
+// ID returns the node identifier.
+func (n *ExperimentalNode) ID() Address { return n.id }
+
+// Start marks the node as running.
+func (n *ExperimentalNode) Start() error {
+	n.running = true
+	return nil
+}
+
+// Stop halts the node.
+func (n *ExperimentalNode) Stop() error {
+	n.running = false
+	return nil
+}
+
+// IsRunning reports whether the node is active.
+func (n *ExperimentalNode) IsRunning() bool { return n.running }
+
+// Peers returns an empty slice as the node does not connect to peers yet.
+func (n *ExperimentalNode) Peers() []Address { return nil }
+
+// DialSeed is a stub for connecting to a seed peer.
+func (n *ExperimentalNode) DialSeed(addr Address) error { return nil }


### PR DESCRIPTION
## Summary
- mark Stage 13 complete with build tags and environment-specific configs
- add build tag defaults and sample dev/test/prod YAML files
- introduce experimental node behind `experimental` build tag and build targets for tagged builds

## Testing
- `go test ./...` *(hangs; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6891556a858083209da0dc83a49df05e