### PR TITLE
Add CLI commands for stage1 modules

### DIFF
--- a/cli/access.go
+++ b/cli/access.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var accessCtrl = core.NewAccessController()
+
+func init() {
+	accessCmd := &cobra.Command{Use: "access", Short: "Role based access control"}
+
+	grantCmd := &cobra.Command{
+		Use:   "grant [role] [addr]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Grant a role to an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			accessCtrl.Grant(args[0], args[1])
+			fmt.Println("granted")
+		},
+	}
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke [role] [addr]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Revoke a role from an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			accessCtrl.Revoke(args[0], args[1])
+			fmt.Println("revoked")
+		},
+	}
+
+	hasCmd := &cobra.Command{
+		Use:   "has [role] [addr]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Check if address has role",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(accessCtrl.HasRole(args[0], args[1]))
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "List roles for an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			roles := accessCtrl.List(args[0])
+			for _, r := range roles {
+				fmt.Println(r)
+			}
+		},
+	}
+
+	accessCmd.AddCommand(grantCmd, revokeCmd, hasCmd, listCmd)
+	rootCmd.AddCommand(accessCmd)
+}

--- a/cli/address.go
+++ b/cli/address.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	addressCmd := &cobra.Command{Use: "address", Short: "Address utilities"}
+
+	parseCmd := &cobra.Command{
+		Use:   "parse [hex]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Validate and normalise an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := core.StringToAddress(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(addr.Hex())
+		},
+	}
+
+	bytesCmd := &cobra.Command{
+		Use:   "bytes [hex]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show raw bytes of an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := core.StringToAddress(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(hex.EncodeToString(addr.Bytes()))
+		},
+	}
+
+	shortCmd := &cobra.Command{
+		Use:   "short [hex]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show shortened form of an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, err := core.StringToAddress(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(addr.Short())
+		},
+	}
+
+	addressCmd.AddCommand(parseCmd, bytesCmd, shortCmd)
+	rootCmd.AddCommand(addressCmd)
+}

--- a/cli/address_zero.go
+++ b/cli/address_zero.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	zeroCmd := &cobra.Command{Use: "addrzero", Short: "Zero address utilities"}
+
+	showCmd := &cobra.Command{
+		Use:   "show",
+		Short: "Display the zero address",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(core.AddressZero)
+		},
+	}
+
+	isCmd := &cobra.Command{
+		Use:   "is [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Check if address is zero address",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(core.IsZeroAddress(args[0]))
+		},
+	}
+
+	zeroCmd.AddCommand(showCmd, isCmd)
+	rootCmd.AddCommand(zeroCmd)
+}

--- a/cli/ai_contract.go
+++ b/cli/ai_contract.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	aiVM       = core.NewSimpleVM()
+	baseReg    = core.NewContractRegistry(aiVM)
+	aiRegistry = core.NewAIContractRegistry(baseReg)
+)
+
+func init() {
+	aiVM.Start()
+
+	aiCmd := &cobra.Command{Use: "ai_contract", Short: "AI enhanced contract operations"}
+
+	deployCmd := &cobra.Command{
+		Use:   "deploy [wasm_file] [model_hash] [manifest] [gas_limit] [owner]",
+		Args:  cobra.ExactArgs(5),
+		Short: "Deploy an AI enhanced contract",
+		Run: func(cmd *cobra.Command, args []string) {
+			wasm, err := ioutil.ReadFile(args[0])
+			if err != nil {
+				fmt.Println("read error:", err)
+				return
+			}
+			gas, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				fmt.Println("gas error:", err)
+				return
+			}
+			addr, err := aiRegistry.DeployAIContract(wasm, args[1], args[2], gas, args[4])
+			if err != nil {
+				fmt.Println("deploy error:", err)
+				return
+			}
+			fmt.Println("contract:", addr)
+		},
+	}
+
+	invokeCmd := &cobra.Command{
+		Use:   "invoke [addr] [input_hex] [gas_limit]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Invoke infer method on AI contract",
+		Run: func(cmd *cobra.Command, args []string) {
+			input, err := hex.DecodeString(args[1])
+			if err != nil {
+				fmt.Println("input error:", err)
+				return
+			}
+			gas, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("gas error:", err)
+				return
+			}
+			out, used, err := aiRegistry.InvokeAIContract(args[0], input, gas)
+			if err != nil {
+				fmt.Println("invoke error:", err)
+				return
+			}
+			fmt.Printf("output=%s gas=%d\n", hex.EncodeToString(out), used)
+		},
+	}
+
+	modelCmd := &cobra.Command{
+		Use:   "model [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show model hash for a contract",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, ok := aiRegistry.ModelHash(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Println(h)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List deployed AI contracts",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, c := range baseReg.List() {
+				h, _ := aiRegistry.ModelHash(c.Address)
+				fmt.Printf("%s %s\n", c.Address, h)
+			}
+		},
+	}
+
+	aiCmd.AddCommand(deployCmd, invokeCmd, modelCmd, listCmd)
+	rootCmd.AddCommand(aiCmd)
+}

--- a/cli/audit.go
+++ b/cli/audit.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var auditManager = core.NewAuditManager()
+
+func init() {
+	auditCmd := &cobra.Command{Use: "audit", Short: "Audit log management"}
+
+	logCmd := &cobra.Command{
+		Use:   "log [address] [event] [key=value]...",
+		Args:  cobra.MinimumNArgs(2),
+		Short: "Record an audit event",
+		Run: func(cmd *cobra.Command, args []string) {
+			meta := make(map[string]string)
+			for _, kv := range args[2:] {
+				parts := strings.SplitN(kv, "=", 2)
+				if len(parts) == 2 {
+					meta[parts[0]] = parts[1]
+				}
+			}
+			if err := auditManager.Log(args[0], args[1], meta); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "List audit events for an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			entries := auditManager.List(args[0])
+			for _, e := range entries {
+				fmt.Printf("%s %s %v\n", e.Timestamp.Format("2006-01-02T15:04:05"), e.Event, e.Metadata)
+			}
+		},
+	}
+
+	auditCmd.AddCommand(logCmd, listCmd)
+	rootCmd.AddCommand(auditCmd)
+}

--- a/cli/audit_node.go
+++ b/cli/audit_node.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+type dummyBootstrap struct{}
+
+func (dummyBootstrap) Start() error {
+	fmt.Println("bootstrap started")
+	return nil
+}
+
+var auditNode = core.NewAuditNode(dummyBootstrap{}, auditManager)
+
+func init() {
+	nodeCmd := &cobra.Command{Use: "audit_node", Short: "Audit node operations"}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start bootstrap node",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := auditNode.Start(); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	logCmd := &cobra.Command{
+		Use:   "log [address] [event] [key=value]...",
+		Args:  cobra.MinimumNArgs(2),
+		Short: "Log event through audit node",
+		Run: func(cmd *cobra.Command, args []string) {
+			meta := make(map[string]string)
+			for _, kv := range args[2:] {
+				parts := strings.SplitN(kv, "=", 2)
+				if len(parts) == 2 {
+					meta[parts[0]] = parts[1]
+				}
+			}
+			if err := auditNode.LogEvent(args[0], args[1], meta); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "List events via audit node",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, e := range auditNode.ListEvents(args[0]) {
+				fmt.Printf("%s %s %v\n", e.Timestamp.Format("2006-01-02T15:04:05"), e.Event, e.Metadata)
+			}
+		},
+	}
+
+	nodeCmd.AddCommand(startCmd, logCmd, listCmd)
+	rootCmd.AddCommand(nodeCmd)
+}

--- a/cli/authority_apply.go
+++ b/cli/authority_apply.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	authorityRegistry = core.NewAuthorityNodeRegistry()
+	applyManager      = core.NewAuthorityApplicationManager(authorityRegistry, time.Hour)
+)
+
+func init() {
+	applyCmd := &cobra.Command{Use: "authority_apply", Short: "Authority node applications"}
+
+	submitCmd := &cobra.Command{
+		Use:   "submit [candidate] [role] [desc]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Submit an authority node application",
+		Run: func(cmd *cobra.Command, args []string) {
+			id := applyManager.Submit(args[0], args[1], args[2])
+			fmt.Println("application:", id)
+		},
+	}
+
+	voteCmd := &cobra.Command{
+		Use:   "vote [voter] [id] [approve]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Vote on an application",
+		Run: func(cmd *cobra.Command, args []string) {
+			approve, _ := strconv.ParseBool(args[2])
+			if err := applyManager.Vote(args[0], args[1], approve); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	finalizeCmd := &cobra.Command{
+		Use:   "finalize [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Finalize an application",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := applyManager.Finalize(args[0]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get application details",
+		Run: func(cmd *cobra.Command, args []string) {
+			app, err := applyManager.Get(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Printf("%s %s approvals:%d rejections:%d finalized:%v\n", app.ID, app.Candidate, len(app.Approvals), len(app.Rejections), app.Finalized)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List applications",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, app := range applyManager.List() {
+				fmt.Printf("%s %s finalized:%v\n", app.ID, app.Candidate, app.Finalized)
+			}
+		},
+	}
+
+	tickCmd := &cobra.Command{
+		Use:   "tick",
+		Short: "Remove expired applications",
+		Run: func(cmd *cobra.Command, args []string) {
+			applyManager.Tick(time.Now())
+		},
+	}
+
+	applyCmd.AddCommand(submitCmd, voteCmd, finalizeCmd, getCmd, listCmd, tickCmd)
+	rootCmd.AddCommand(applyCmd)
+}

--- a/cli/authority_node_index.go
+++ b/cli/authority_node_index.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var authorityIndex = core.NewAuthorityNodeIndex()
+
+func init() {
+	idxCmd := &cobra.Command{Use: "authority_index", Short: "Authority node index"}
+
+	addCmd := &cobra.Command{
+		Use:   "add [address] [role]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Add authority node to index",
+		Run: func(cmd *cobra.Command, args []string) {
+			node := &core.AuthorityNode{Address: args[0], Role: args[1], Votes: make(map[string]bool)}
+			authorityIndex.Add(node)
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get authority node details",
+		Run: func(cmd *cobra.Command, args []string) {
+			n, ok := authorityIndex.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%s role:%s votes:%d\n", n.Address, n.Role, len(n.Votes))
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove authority node from index",
+		Run: func(cmd *cobra.Command, args []string) {
+			authorityIndex.Remove(args[0])
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List authority nodes",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, n := range authorityIndex.List() {
+				fmt.Printf("%s role:%s votes:%d\n", n.Address, n.Role, len(n.Votes))
+			}
+		},
+	}
+
+	idxCmd.AddCommand(addCmd, getCmd, removeCmd, listCmd)
+	rootCmd.AddCommand(idxCmd)
+}


### PR DESCRIPTION
## Summary
- add access control command group with grant, revoke, query, and list operations
- expose address utilities including parsing, byte and short forms, and zero address checks
- support AI enhanced contract deployment and invocation alongside model hash inspection
- provide audit log management, audit node interaction, authority application, and authority index commands

## Testing
- `go test ./...` *(fails: github.com/sirupsen/logrus checksum mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_68915b94fc148320bc4b8a10bd918c4f