### PR TITLE
Add Stage 4 consensus and contract CLI commands

### DIFF
--- a/cli/consensus_adaptive_management.go
+++ b/cli/consensus_adaptive_management.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+// adaptiveManager tunes consensus weights using network metrics.
+var adaptiveManager = core.NewAdaptiveManager(consensus)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "consensus-adaptive",
+		Short: "Adaptive consensus weight management",
+	}
+
+	adjustCmd := &cobra.Command{
+		Use:   "adjust [demand] [stake]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Adjust weights and show result",
+		Run: func(cmd *cobra.Command, args []string) {
+			d, _ := strconv.ParseFloat(args[0], 64)
+			s, _ := strconv.ParseFloat(args[1], 64)
+			w := adaptiveManager.Adjust(d, s)
+			fmt.Printf("PoW: %.2f PoS: %.2f PoH: %.2f\n", w.PoW, w.PoS, w.PoH)
+		},
+	}
+
+	thresholdCmd := &cobra.Command{
+		Use:   "threshold [demand] [stake]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Compute switching threshold",
+		Run: func(cmd *cobra.Command, args []string) {
+			d, _ := strconv.ParseFloat(args[0], 64)
+			s, _ := strconv.ParseFloat(args[1], 64)
+			fmt.Println(adaptiveManager.Threshold(d, s))
+		},
+	}
+
+	weightsCmd := &cobra.Command{
+		Use:   "weights",
+		Short: "Show current consensus weights",
+		Run: func(cmd *cobra.Command, args []string) {
+			w := adaptiveManager.Weights()
+			fmt.Printf("PoW: %.2f PoS: %.2f PoH: %.2f\n", w.PoW, w.PoS, w.PoH)
+		},
+	}
+
+	cmd.AddCommand(adjustCmd, thresholdCmd, weightsCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/consensus_difficulty.go
+++ b/cli/consensus_difficulty.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+// difficultyMgr adjusts PoW difficulty from block time samples.
+var difficultyMgr = core.NewDifficultyManager(consensus, 10, 1, 10)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "consensus-difficulty",
+		Short: "Manage PoW difficulty",
+	}
+
+	sampleCmd := &cobra.Command{
+		Use:   "sample [seconds]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Add block time sample and show new difficulty",
+		Run: func(cmd *cobra.Command, args []string) {
+			d, _ := strconv.ParseFloat(args[0], 64)
+			fmt.Println(difficultyMgr.AddSample(d))
+		},
+	}
+
+	valueCmd := &cobra.Command{
+		Use:   "value",
+		Short: "Show current difficulty",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(difficultyMgr.Difficulty())
+		},
+	}
+
+	configCmd := &cobra.Command{
+		Use:   "config [window] [initial] [target]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Reconfigure difficulty manager",
+		Run: func(cmd *cobra.Command, args []string) {
+			w, _ := strconv.Atoi(args[0])
+			initDiff, _ := strconv.ParseFloat(args[1], 64)
+			target, _ := strconv.ParseFloat(args[2], 64)
+			difficultyMgr = core.NewDifficultyManager(consensus, w, initDiff, target)
+		},
+	}
+
+	cmd.AddCommand(sampleCmd, valueCmd, configCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/consensus_mode.go
+++ b/cli/consensus_mode.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var switcher = core.NewConsensusSwitcher(core.ModePoW)
+
+func parseMode(m string) core.ConsensusMode {
+	switch strings.ToLower(m) {
+	case "pos":
+		return core.ModePoS
+	case "poh":
+		return core.ModePoH
+	default:
+		return core.ModePoW
+	}
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "consensus-mode",
+		Short: "Evaluate and view consensus mode",
+	}
+
+	evaluateCmd := &cobra.Command{
+		Use:   "evaluate",
+		Short: "Evaluate mode based on current weights",
+		Run: func(cmd *cobra.Command, args []string) {
+			mode := switcher.Evaluate(consensus)
+			fmt.Println(mode)
+		},
+	}
+
+	showCmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show last evaluated mode",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(switcher.Mode())
+		},
+	}
+
+	setCmd := &cobra.Command{
+		Use:   "set [mode]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Set initial mode (pow|pos|poh)",
+		Run: func(cmd *cobra.Command, args []string) {
+			switcher = core.NewConsensusSwitcher(parseMode(args[0]))
+		},
+	}
+
+	cmd.AddCommand(evaluateCmd, showCmd, setCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/consensus_service.go
+++ b/cli/consensus_service.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var consensusService = core.NewConsensusService(currentNode)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "consensus-service",
+		Short: "Run consensus mining service",
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start [ms]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Start mining loop with interval milliseconds",
+		Run: func(cmd *cobra.Command, args []string) {
+			ms, _ := time.ParseDuration(args[0] + "ms")
+			consensusService.Start(ms)
+		},
+	}
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the mining loop",
+		Run: func(cmd *cobra.Command, args []string) {
+			consensusService.Stop()
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show service info",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, running := consensusService.Info()
+			fmt.Printf("height: %d running: %v\n", h, running)
+		},
+	}
+
+	cmd.AddCommand(startCmd, stopCmd, infoCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/consensus_specific_node.go
+++ b/cli/consensus_specific_node.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var csNode *core.ConsensusSpecificNode
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "consensus-node",
+		Short: "Consensus specific node operations",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create [mode] [id] [addr]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Create a node locked to a consensus mode",
+		Run: func(cmd *cobra.Command, args []string) {
+			mode := parseMode(args[0])
+			csNode = core.NewConsensusSpecificNode(mode, args[1], args[2], ledger)
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show node information",
+		Run: func(cmd *cobra.Command, args []string) {
+			if csNode == nil {
+				fmt.Println("no node")
+				return
+			}
+			fmt.Printf("ID: %s\nAddr: %s\nMode: %s\nHeight: %d\n", csNode.ID, csNode.Addr, csNode.Mode, len(csNode.Blockchain))
+		},
+	}
+
+	mineCmd := &cobra.Command{
+		Use:   "mine",
+		Short: "Mine a block with current node",
+		Run: func(cmd *cobra.Command, args []string) {
+			if csNode == nil {
+				fmt.Println("no node")
+				return
+			}
+			b := csNode.MineBlock()
+			if b != nil {
+				fmt.Printf("mined block %s with nonce %d\n", b.Hash, b.Nonce)
+			}
+		},
+	}
+
+	stakeCmd := &cobra.Command{
+		Use:   "stake [address] [amount]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Assign stake on node ledger",
+		Run: func(cmd *cobra.Command, args []string) {
+			if csNode == nil {
+				fmt.Println("no node")
+				return
+			}
+			amt, _ := strconv.ParseUint(args[1], 10, 64)
+			if err := csNode.SetStake(args[0], amt); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	cmd.AddCommand(createCmd, infoCmd, mineCmd, stakeCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/contract_management.go
+++ b/cli/contract_management.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	contractVM       = core.NewSimpleVM()
+	contractRegistry = core.NewContractRegistry(contractVM)
+	contractMgr      = core.NewContractManager(contractRegistry)
+)
+
+func init() {
+	contractVM.Start()
+	cmd := &cobra.Command{
+		Use:   "contract-mgr",
+		Short: "Administrative contract management",
+	}
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer [addr] [newOwner]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Transfer contract ownership",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := contractMgr.Transfer(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	pauseCmd := &cobra.Command{
+		Use:   "pause [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Pause a contract",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := contractMgr.Pause(args[0]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	resumeCmd := &cobra.Command{
+		Use:   "resume [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Resume a paused contract",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := contractMgr.Resume(args[0]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	upgradeCmd := &cobra.Command{
+		Use:   "upgrade [addr] [wasmHex] [gasLimit]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Upgrade contract bytecode",
+		Run: func(cmd *cobra.Command, args []string) {
+			bytes, err := hex.DecodeString(args[1])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			gas, _ := strconv.ParseUint(args[2], 10, 64)
+			if err := contractMgr.Upgrade(args[0], bytes, gas); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show contract metadata",
+		Run: func(cmd *cobra.Command, args []string) {
+			c, err := contractMgr.Info(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Printf("owner:%s paused:%v gas:%d\n", c.Owner, c.Paused, c.GasLimit)
+		},
+	}
+
+	cmd.AddCommand(transferCmd, pauseCmd, resumeCmd, upgradeCmd, infoCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/validator_management.go
+++ b/cli/validator_management.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var validatorMgr = core.NewValidatorManager(100)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "validator",
+		Short: "Manage consensus validators",
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add [addr] [stake]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Register validator with stake",
+		Run: func(cmd *cobra.Command, args []string) {
+			stake, _ := strconv.ParseUint(args[1], 10, 64)
+			if err := validatorMgr.Add(args[0], stake); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove validator",
+		Run: func(cmd *cobra.Command, args []string) {
+			validatorMgr.Remove(args[0])
+		},
+	}
+
+	slashCmd := &cobra.Command{
+		Use:   "slash [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Slash validator stake",
+		Run: func(cmd *cobra.Command, args []string) {
+			validatorMgr.Slash(args[0])
+		},
+	}
+
+	eligibleCmd := &cobra.Command{
+		Use:   "eligible",
+		Short: "List eligible validators",
+		Run: func(cmd *cobra.Command, args []string) {
+			for addr, stake := range validatorMgr.Eligible() {
+				fmt.Printf("%s:%d\n", addr, stake)
+			}
+		},
+	}
+
+	stakeCmd := &cobra.Command{
+		Use:   "stake [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show validator stake",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(validatorMgr.Stake(args[0]))
+		},
+	}
+
+	setMinCmd := &cobra.Command{
+		Use:   "set-min [stake]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Set minimum stake requirement",
+		Run: func(cmd *cobra.Command, args []string) {
+			s, _ := strconv.ParseUint(args[0], 10, 64)
+			validatorMgr = core.NewValidatorManager(s)
+		},
+	}
+
+	cmd.AddCommand(addCmd, removeCmd, slashCmd, eligibleCmd, stakeCmd, setMinCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/go.sum
+++ b/go.sum
@@ -43,24 +43,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ========
-
-
-github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
-github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
-github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=


### PR DESCRIPTION
## Summary
- add CLI support for adaptive consensus management, difficulty tuning, mode selection, and node/service control
- provide validator management and contract administration commands
- fix go.sum checksum issue

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915bbb223c832088d73fcadf24454d