### PR TITLE
Add CLI interfaces for DAO and cross-consensus operations

### DIFF
--- a/cli/cross_consensus_scaling_networks.go
+++ b/cli/cross_consensus_scaling_networks.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var consensusNetMgr = core.NewConsensusNetworkManager()
+
+func init() {
+	ccsnCmd := &cobra.Command{
+		Use:   "cross-consensus",
+		Short: "Manage cross-consensus scaling networks",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <source> <target>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Register a new network",
+		Run: func(cmd *cobra.Command, args []string) {
+			id := consensusNetMgr.RegisterNetwork(args[0], args[1])
+			fmt.Println(id)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List networks",
+		Run: func(cmd *cobra.Command, args []string) {
+			nets := consensusNetMgr.ListNetworks()
+			for _, n := range nets {
+				fmt.Printf("%d %s->%s\n", n.ID, n.SourceConsensus, n.TargetConsensus)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get network by ID",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				fmt.Println("invalid id")
+				return
+			}
+			n, err := consensusNetMgr.GetNetwork(id)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Printf("%d %s->%s\n", n.ID, n.SourceConsensus, n.TargetConsensus)
+		},
+	}
+
+	ccsnCmd.AddCommand(registerCmd, listCmd, getCmd)
+	rootCmd.AddCommand(ccsnCmd)
+}

--- a/cli/custodial_node.go
+++ b/cli/custodial_node.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var custodialLedger = core.NewLedger()
+var custodialNode = core.NewCustodialNode("custodian", "custodian_addr", custodialLedger)
+
+func init() {
+	custCmd := &cobra.Command{
+		Use:   "custodial",
+		Short: "Operate a custodial node",
+	}
+
+	custodyCmd := &cobra.Command{
+		Use:   "custody <user> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Custody assets for a user",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			custodialNode.Custody(args[0], amt)
+			fmt.Println("recorded")
+		},
+	}
+
+	releaseCmd := &cobra.Command{
+		Use:   "release <user> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Release assets to a user",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			ok := custodialNode.Release(args[0], amt)
+			fmt.Println(ok)
+		},
+	}
+
+	holdingsCmd := &cobra.Command{
+		Use:   "holdings [user]",
+		Args:  cobra.RangeArgs(0, 1),
+		Short: "Show holdings",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 1 {
+				fmt.Println(custodialNode.Holdings[args[0]])
+				return
+			}
+			for u, amt := range custodialNode.Holdings {
+				fmt.Printf("%s: %d\n", u, amt)
+			}
+		},
+	}
+
+	custCmd.AddCommand(custodyCmd, releaseCmd, holdingsCmd)
+	rootCmd.AddCommand(custCmd)
+}

--- a/cli/dao.go
+++ b/cli/dao.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var daoMgr = core.NewDAOManager()
+
+func init() {
+	daoCmd := &cobra.Command{
+		Use:   "dao",
+		Short: "Manage decentralised autonomous organisations",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create <name> <creator>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Create a new DAO",
+		Run: func(cmd *cobra.Command, args []string) {
+			dao := daoMgr.Create(args[0], args[1])
+			fmt.Println(dao.ID)
+		},
+	}
+
+	joinCmd := &cobra.Command{
+		Use:   "join <id> <addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Join a DAO",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := daoMgr.Join(args[0], args[1]); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	leaveCmd := &cobra.Command{
+		Use:   "leave <id> <addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Leave a DAO",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := daoMgr.Leave(args[0], args[1]); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show DAO information",
+		Run: func(cmd *cobra.Command, args []string) {
+			dao, err := daoMgr.Info(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Printf("%s %s\n", dao.ID, dao.Name)
+			fmt.Printf("creator: %s\n", dao.Creator)
+			fmt.Printf("members: %d\n", len(dao.Members))
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all DAOs",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, d := range daoMgr.List() {
+				fmt.Printf("%s %s\n", d.ID, d.Name)
+			}
+		},
+	}
+
+	daoCmd.AddCommand(createCmd, joinCmd, leaveCmd, infoCmd, listCmd)
+	rootCmd.AddCommand(daoCmd)
+}

--- a/cli/dao_access_control.go
+++ b/cli/dao_access_control.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	memberCmd := &cobra.Command{
+		Use:   "dao-members",
+		Short: "Manage DAO membership roles",
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add <daoID> <addr> <role>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Add member with role",
+		Run: func(cmd *cobra.Command, args []string) {
+			dao, err := daoMgr.Info(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			if err := dao.AddMember(args[1], args[2]); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove <daoID> <addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Remove a member",
+		Run: func(cmd *cobra.Command, args []string) {
+			dao, err := daoMgr.Info(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			dao.RemoveMember(args[1])
+		},
+	}
+
+	roleCmd := &cobra.Command{
+		Use:   "role <daoID> <addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Get member role",
+		Run: func(cmd *cobra.Command, args []string) {
+			dao, err := daoMgr.Info(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			role, ok := dao.MemberRole(args[1])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Println(role)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list <daoID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "List members",
+		Run: func(cmd *cobra.Command, args []string) {
+			dao, err := daoMgr.Info(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			for addr, role := range dao.MembersList() {
+				fmt.Printf("%s: %s\n", addr, role)
+			}
+		},
+	}
+
+	memberCmd.AddCommand(addCmd, removeCmd, roleCmd, listCmd)
+	rootCmd.AddCommand(memberCmd)
+}

--- a/cli/dao_proposal.go
+++ b/cli/dao_proposal.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var proposalMgr = core.NewProposalManager()
+
+func init() {
+	propCmd := &cobra.Command{
+		Use:   "dao-proposal",
+		Short: "Manage DAO proposals",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create <daoID> <creator> <description>",
+		Args:  cobra.MinimumNArgs(3),
+		Short: "Create a proposal",
+		Run: func(cmd *cobra.Command, args []string) {
+			dao, err := daoMgr.Info(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			desc := strings.Join(args[2:], " ")
+			p := proposalMgr.CreateProposal(dao, args[1], desc)
+			fmt.Println(p.ID)
+		},
+	}
+
+	voteCmd := &cobra.Command{
+		Use:   "vote <id> <voter> <weight> <yes|no>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Cast a vote",
+		Run: func(cmd *cobra.Command, args []string) {
+			w, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid weight")
+				return
+			}
+			support := strings.ToLower(args[3]) == "yes"
+			if err := proposalMgr.Vote(args[0], args[1], w, support); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	resultsCmd := &cobra.Command{
+		Use:   "results <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show voting results",
+		Run: func(cmd *cobra.Command, args []string) {
+			yes, no, err := proposalMgr.Results(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Printf("yes:%d no:%d\n", yes, no)
+		},
+	}
+
+	executeCmd := &cobra.Command{
+		Use:   "execute <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Mark proposal executed",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := proposalMgr.Execute(args[0]); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get proposal info",
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := proposalMgr.Get(args[0])
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Printf("%s DAO:%s Desc:%s Executed:%v\n", p.ID, p.DAOID, p.Desc, p.Executed)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List proposals",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, p := range proposalMgr.List() {
+				fmt.Printf("%s DAO:%s Desc:%s Executed:%v\n", p.ID, p.DAOID, p.Desc, p.Executed)
+			}
+		},
+	}
+
+	propCmd.AddCommand(createCmd, voteCmd, resultsCmd, executeCmd, getCmd, listCmd)
+	rootCmd.AddCommand(propCmd)
+}

--- a/cli/dao_quadratic_voting.go
+++ b/cli/dao_quadratic_voting.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	qvCmd := &cobra.Command{
+		Use:   "dao-qv",
+		Short: "Quadratic voting operations",
+	}
+
+	weightCmd := &cobra.Command{
+		Use:   "weight <tokens>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Calculate quadratic weight",
+		Run: func(cmd *cobra.Command, args []string) {
+			tokens, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid tokens")
+				return
+			}
+			fmt.Println(core.QuadraticWeight(tokens))
+		},
+	}
+
+	voteCmd := &cobra.Command{
+		Use:   "vote <id> <voter> <tokens> <yes|no>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Cast a quadratic vote",
+		Run: func(cmd *cobra.Command, args []string) {
+			tokens, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid tokens")
+				return
+			}
+			support := strings.ToLower(args[3]) == "yes"
+			if err := proposalMgr.CastQuadraticVote(args[0], args[1], tokens, support); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	qvCmd.AddCommand(weightCmd, voteCmd)
+	rootCmd.AddCommand(qvCmd)
+}

--- a/cli/dao_staking.go
+++ b/cli/dao_staking.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var daoStaking = core.NewDAOStaking()
+
+func init() {
+	stakingCmd := &cobra.Command{
+		Use:   "dao-stake",
+		Short: "DAO staking operations",
+	}
+
+	stakeCmd := &cobra.Command{
+		Use:   "stake <addr> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Stake tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			daoStaking.Stake(args[0], amt)
+		},
+	}
+
+	unstakeCmd := &cobra.Command{
+		Use:   "unstake <addr> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Unstake tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			if err := daoStaking.Unstake(args[0], amt); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	balanceCmd := &cobra.Command{
+		Use:   "balance <addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show staked balance",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(daoStaking.Balance(args[0]))
+		},
+	}
+
+	stakingCmd.AddCommand(stakeCmd, unstakeCmd, balanceCmd)
+	rootCmd.AddCommand(stakingCmd)
+}

--- a/cli/dao_token.go
+++ b/cli/dao_token.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var daoTokenLedger = core.NewDAOTokenLedger()
+
+func init() {
+	tokenCmd := &cobra.Command{
+		Use:   "dao-token",
+		Short: "DAO token ledger operations",
+	}
+
+	mintCmd := &cobra.Command{
+		Use:   "mint <addr> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Mint tokens to an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			daoTokenLedger.Mint(args[0], amt)
+		},
+	}
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <from> <to> <amount>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Transfer tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			if err := daoTokenLedger.Transfer(args[0], args[1], amt); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	balanceCmd := &cobra.Command{
+		Use:   "balance <addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get token balance",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(daoTokenLedger.Balance(args[0]))
+		},
+	}
+
+	tokenCmd.AddCommand(mintCmd, transferCmd, balanceCmd)
+	rootCmd.AddCommand(tokenCmd)
+}

--- a/go.sum
+++ b/go.sum
@@ -43,24 +43,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ========
-
-
-github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
-github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
-github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=


### PR DESCRIPTION
## Summary
- add cross-consensus network CLI with register/list/get commands
- add custodial node CLI for custody and release management
- add DAO management, membership, proposal, quadratic voting, staking, and token ledger CLI modules

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915bcf9a0c83209cbecbb2d39b1342