### PR TITLE
Add CLI commands for stage 7 modules

### DIFF
--- a/cli/elected_authority_node.go
+++ b/cli/elected_authority_node.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var electedNode *core.ElectedAuthorityNode
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "elected-node",
+		Short: "Manage elected authority nodes",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an elected authority node",
+		Run: func(cmd *cobra.Command, args []string) {
+			addr, _ := cmd.Flags().GetString("addr")
+			role, _ := cmd.Flags().GetString("role")
+			termDur, _ := cmd.Flags().GetDuration("term")
+			electedNode = core.NewElectedAuthorityNode(addr, role, termDur)
+			fmt.Println("elected authority node created")
+		},
+	}
+	createCmd.Flags().String("addr", "", "node address")
+	createCmd.Flags().String("role", "validator", "node role")
+	createCmd.Flags().Duration("term", time.Hour, "term duration")
+	cmd.AddCommand(createCmd)
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show node status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if electedNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			fmt.Printf("address: %s role: %s term_end: %s active: %v\n",
+				electedNode.Address,
+				electedNode.Role,
+				electedNode.TermEnd.Format(time.RFC3339),
+				electedNode.IsActive(time.Now()))
+		},
+	}
+	cmd.AddCommand(statusCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/faucet.go
+++ b/cli/faucet.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var faucet *core.Faucet
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "faucet",
+		Short: "Interact with the test token faucet",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise faucet balance and parameters",
+		Run: func(cmd *cobra.Command, args []string) {
+			bal, _ := cmd.Flags().GetUint64("balance")
+			amt, _ := cmd.Flags().GetUint64("amount")
+			cd, _ := cmd.Flags().GetDuration("cooldown")
+			faucet = core.NewFaucet(bal, amt, cd)
+			fmt.Println("faucet initialised")
+		},
+	}
+	initCmd.Flags().Uint64("balance", 1000, "initial balance")
+	initCmd.Flags().Uint64("amount", 1, "dispense amount")
+	initCmd.Flags().Duration("cooldown", time.Minute, "cooldown between requests")
+	cmd.AddCommand(initCmd)
+
+	requestCmd := &cobra.Command{
+		Use:   "request <addr>",
+		Short: "Request funds from the faucet",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if faucet == nil {
+				fmt.Println("faucet not initialised")
+				return
+			}
+			amt, err := faucet.Request(args[0])
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Printf("dispensed %d tokens\n", amt)
+		},
+	}
+	cmd.AddCommand(requestCmd)
+
+	balCmd := &cobra.Command{
+		Use:   "balance",
+		Short: "Show remaining faucet balance",
+		Run: func(cmd *cobra.Command, args []string) {
+			if faucet == nil {
+				fmt.Println("faucet not initialised")
+				return
+			}
+			fmt.Printf("balance: %d\n", faucet.Balance())
+		},
+	}
+	cmd.AddCommand(balCmd)
+
+	cfgCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Update faucet configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			if faucet == nil {
+				fmt.Println("faucet not initialised")
+				return
+			}
+			amt, _ := cmd.Flags().GetUint64("amount")
+			cd, _ := cmd.Flags().GetDuration("cooldown")
+			faucet.UpdateConfig(amt, cd)
+			fmt.Println("configuration updated")
+		},
+	}
+	cfgCmd.Flags().Uint64("amount", 1, "dispense amount")
+	cfgCmd.Flags().Duration("cooldown", time.Minute, "cooldown between requests")
+	cmd.AddCommand(cfgCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/firewall.go
+++ b/cli/firewall.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var firewall = core.NewFirewall()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "firewall",
+		Short: "Manage firewall rules",
+	}
+
+	allowCmd := &cobra.Command{
+		Use:   "allow <ip>",
+		Short: "Allow connections from an IP",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			firewall.Allow(args[0])
+			fmt.Println("ip allowed")
+		},
+	}
+	cmd.AddCommand(allowCmd)
+
+	blockCmd := &cobra.Command{
+		Use:   "block <ip>",
+		Short: "Block connections from an IP",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			firewall.Block(args[0])
+			fmt.Println("ip blocked")
+		},
+	}
+	cmd.AddCommand(blockCmd)
+
+	checkCmd := &cobra.Command{
+		Use:   "check <ip>",
+		Short: "Check if an IP is allowed",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(firewall.IsAllowed(args[0]))
+		},
+	}
+	cmd.AddCommand(checkCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List firewall rules",
+		Run: func(cmd *cobra.Command, args []string) {
+			allowed, blocked := firewall.Rules()
+			fmt.Printf("allowed: %v\nblocked: %v\n", allowed, blocked)
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/forensic_node.go
+++ b/cli/forensic_node.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+	nodes "synnergy/internal/nodes"
+)
+
+var forensic = core.NewForensicNode()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "forensic",
+		Short: "Record transactions and network traces",
+	}
+
+	txCmd := &cobra.Command{
+		Use:   "record-tx",
+		Short: "Record a minimal transaction",
+		Run: func(cmd *cobra.Command, args []string) {
+			hash, _ := cmd.Flags().GetString("hash")
+			from, _ := cmd.Flags().GetString("from")
+			to, _ := cmd.Flags().GetString("to")
+			value, _ := cmd.Flags().GetUint64("value")
+			tx := nodes.TransactionLite{Hash: hash, From: from, To: to, Value: value, Timestamp: time.Now()}
+			if err := forensic.RecordTransaction(tx); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("transaction recorded")
+			}
+		},
+	}
+	txCmd.Flags().String("hash", "", "transaction hash")
+	txCmd.Flags().String("from", "", "from address")
+	txCmd.Flags().String("to", "", "to address")
+	txCmd.Flags().Uint64("value", 0, "value")
+	cmd.AddCommand(txCmd)
+
+	traceCmd := &cobra.Command{
+		Use:   "record-trace",
+		Short: "Record a network trace",
+		Run: func(cmd *cobra.Command, args []string) {
+			peer, _ := cmd.Flags().GetString("peer")
+			event, _ := cmd.Flags().GetString("event")
+			trace := nodes.NetworkTrace{PeerID: peer, Event: event, Timestamp: time.Now()}
+			if err := forensic.RecordNetworkTrace(trace); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("trace recorded")
+			}
+		},
+	}
+	traceCmd.Flags().String("peer", "", "peer id")
+	traceCmd.Flags().String("event", "", "event description")
+	cmd.AddCommand(traceCmd)
+
+	listTx := &cobra.Command{
+		Use:   "txs",
+		Short: "List recorded transactions",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, tx := range forensic.Transactions() {
+				fmt.Printf("%s %s->%s %d\n", tx.Hash, tx.From, tx.To, tx.Value)
+			}
+		},
+	}
+	cmd.AddCommand(listTx)
+
+	listTrace := &cobra.Command{
+		Use:   "traces",
+		Short: "List recorded network traces",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, tr := range forensic.NetworkTraces() {
+				fmt.Printf("%s %s %s\n", tr.PeerID, tr.Event, tr.Timestamp.Format(time.RFC3339))
+			}
+		},
+	}
+	cmd.AddCommand(listTrace)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/full_node.go
+++ b/cli/full_node.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+	nodes "synnergy/internal/nodes"
+)
+
+var fullNode *core.FullNode
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "fullnode",
+		Short: "Manage full node configuration",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a full node",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			modeStr, _ := cmd.Flags().GetString("mode")
+			var mode core.FullNodeMode
+			if modeStr == "archive" {
+				mode = core.FullNodeModeArchive
+			} else {
+				mode = core.FullNodeModePruned
+			}
+			fullNode = core.NewFullNode(nodes.Address(id), mode)
+			fmt.Println("full node created")
+		},
+	}
+	createCmd.Flags().String("id", "", "node id")
+	createCmd.Flags().String("mode", "archive", "mode: archive or pruned")
+	cmd.AddCommand(createCmd)
+
+	modeCmd := &cobra.Command{
+		Use:   "mode",
+		Short: "Show current node mode",
+		Run: func(cmd *cobra.Command, args []string) {
+			if fullNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			fmt.Println(fullNode.CurrentMode())
+		},
+	}
+	cmd.AddCommand(modeCmd)
+
+	setCmd := &cobra.Command{
+		Use:   "set-mode <mode>",
+		Short: "Update node mode",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if fullNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			if args[0] == "archive" {
+				fullNode.SetMode(core.FullNodeModeArchive)
+			} else {
+				fullNode.SetMode(core.FullNodeModePruned)
+			}
+			fmt.Println("mode updated")
+		},
+	}
+	cmd.AddCommand(setCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/gas.go
+++ b/cli/gas.go
@@ -7,13 +7,15 @@ import (
 	"synnergy/core"
 )
 
-var gasTable = core.DefaultGasTable()
-
-func init() {
-	gasCmd := &cobra.Command{
+var (
+	gasTable = core.DefaultGasTable()
+	gasCmd   = &cobra.Command{
 		Use:   "gas",
 		Short: "Interact with gas table",
 	}
+)
+
+func init() {
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List gas costs",

--- a/cli/gas_table.go
+++ b/cli/gas_table.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	setCmd := &cobra.Command{
+		Use:   "set <opcode> <cost>",
+		Short: "Set gas cost for an opcode",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			op, err := strconv.ParseUint(args[0], 10, 32)
+			if err != nil {
+				fmt.Printf("invalid opcode: %v\n", err)
+				return
+			}
+			cost, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Printf("invalid cost: %v\n", err)
+				return
+			}
+			core.SetGasCost(core.Opcode(op), cost)
+			fmt.Println("gas cost updated")
+		},
+	}
+
+	snapCmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Print current gas table snapshot",
+		Run: func(cmd *cobra.Command, args []string) {
+			snapshot := core.GasTableSnapshot()
+			for op, cost := range snapshot {
+				fmt.Printf("%v: %d\n", op, cost)
+			}
+		},
+	}
+
+	gasCmd.AddCommand(setCmd)
+	gasCmd.AddCommand(snapCmd)
+}

--- a/cli/syn2100.go
+++ b/cli/syn2100.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn2100 = core.NewTradeFinanceToken()
+
+func parseTime(t string) time.Time {
+	if t == "" {
+		return time.Now()
+	}
+	tt, err := time.Parse(time.RFC3339, t)
+	if err != nil {
+		return time.Now()
+	}
+	return tt
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2100",
+		Short: "Trade finance token operations",
+	}
+
+	regCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a financial document",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			issuer, _ := cmd.Flags().GetString("issuer")
+			recipient, _ := cmd.Flags().GetString("recipient")
+			amount, _ := cmd.Flags().GetUint64("amount")
+			issueStr, _ := cmd.Flags().GetString("issue")
+			dueStr, _ := cmd.Flags().GetString("due")
+			desc, _ := cmd.Flags().GetString("desc")
+			syn2100.RegisterDocument(id, issuer, recipient, amount, parseTime(issueStr), parseTime(dueStr), desc)
+			fmt.Println("document registered")
+		},
+	}
+	regCmd.Flags().String("id", "", "document id")
+	regCmd.Flags().String("issuer", "", "issuer")
+	regCmd.Flags().String("recipient", "", "recipient")
+	regCmd.Flags().Uint64("amount", 0, "amount")
+	regCmd.Flags().String("issue", "", "issue time RFC3339")
+	regCmd.Flags().String("due", "", "due time RFC3339")
+	regCmd.Flags().String("desc", "", "description")
+	cmd.AddCommand(regCmd)
+
+	finCmd := &cobra.Command{
+		Use:   "finance <docID> <financier>",
+		Short: "Finance a document",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := syn2100.FinanceDocument(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("document financed")
+			}
+		},
+	}
+	cmd.AddCommand(finCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <docID>",
+		Short: "Get document info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			d, ok := syn2100.GetDocument(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%+v\n", *d)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List documents",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, d := range syn2100.ListDocuments() {
+				fmt.Printf("%s %s->%s %d financed:%v\n", d.DocID, d.Issuer, d.Recipient, d.Amount, d.Financed)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	addLiq := &cobra.Command{
+		Use:   "add-liquidity <addr> <amt>",
+		Short: "Add liquidity",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			amt := uint64(0)
+			fmt.Sscanf(args[1], "%d", &amt)
+			syn2100.AddLiquidity(args[0], amt)
+			fmt.Println("liquidity added")
+		},
+	}
+	cmd.AddCommand(addLiq)
+
+	remLiq := &cobra.Command{
+		Use:   "remove-liquidity <addr> <amt>",
+		Short: "Remove liquidity",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			amt := uint64(0)
+			fmt.Sscanf(args[1], "%d", &amt)
+			if err := syn2100.RemoveLiquidity(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("liquidity removed")
+			}
+		},
+	}
+	cmd.AddCommand(remLiq)
+
+	liqCmd := &cobra.Command{
+		Use:   "liquidity",
+		Short: "List liquidity pools",
+		Run: func(cmd *cobra.Command, args []string) {
+			var sb strings.Builder
+			for addr, amt := range syn2100.Liquidity {
+				sb.WriteString(fmt.Sprintf("%s:%d ", addr, amt))
+			}
+			fmt.Println(sb.String())
+		},
+	}
+	cmd.AddCommand(liqCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn223_token.go
+++ b/cli/syn223_token.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn223 *core.SYN223Token
+
+func parseMap(input string) map[string]uint64 {
+	m := make(map[string]uint64)
+	if input == "" {
+		return m
+	}
+	parts := strings.Split(input, ",")
+	for _, p := range parts {
+		kv := strings.SplitN(p, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		var amt uint64
+		fmt.Sscanf(kv[1], "%d", &amt)
+		m[kv[0]] = amt
+	}
+	return m
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn223",
+		Short: "SYN223 token utilities",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise the SYN223 token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			owner, _ := cmd.Flags().GetString("owner")
+			supply, _ := cmd.Flags().GetUint64("supply")
+			syn223 = core.NewSYN223Token(name, symbol, owner, supply)
+			fmt.Println("token initialised")
+		},
+	}
+	initCmd.Flags().String("name", "", "token name")
+	initCmd.Flags().String("symbol", "", "token symbol")
+	initCmd.Flags().String("owner", "", "owner address")
+	initCmd.Flags().Uint64("supply", 0, "initial supply")
+	cmd.AddCommand(initCmd)
+
+	wlCmd := &cobra.Command{
+		Use:   "whitelist <addr>",
+		Short: "Add address to whitelist",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn223 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			syn223.AddToWhitelist(args[0])
+			fmt.Println("whitelisted")
+		},
+	}
+	cmd.AddCommand(wlCmd)
+
+	uwlCmd := &cobra.Command{
+		Use:   "unwhitelist <addr>",
+		Short: "Remove address from whitelist",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn223 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			syn223.RemoveFromWhitelist(args[0])
+			fmt.Println("removed from whitelist")
+		},
+	}
+	cmd.AddCommand(uwlCmd)
+
+	blCmd := &cobra.Command{
+		Use:   "blacklist <addr>",
+		Short: "Add address to blacklist",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn223 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			syn223.AddToBlacklist(args[0])
+			fmt.Println("blacklisted")
+		},
+	}
+	cmd.AddCommand(blCmd)
+
+	ublCmd := &cobra.Command{
+		Use:   "unblacklist <addr>",
+		Short: "Remove address from blacklist",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn223 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			syn223.RemoveFromBlacklist(args[0])
+			fmt.Println("removed from blacklist")
+		},
+	}
+	cmd.AddCommand(ublCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <from> <to> <amt>",
+		Short: "Transfer tokens",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn223 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := syn223.Transfer(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("transfer complete")
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	balCmd := &cobra.Command{
+		Use:   "balance <addr>",
+		Short: "Show balance",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn223 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			fmt.Println(syn223.BalanceOf(args[0]))
+		},
+	}
+	cmd.AddCommand(balCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2500_token.go
+++ b/cli/syn2500_token.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn2500 = core.NewSyn2500Registry()
+
+func parseMeta(meta string) map[string]string {
+	m := make(map[string]string)
+	if meta == "" {
+		return m
+	}
+	for _, kv := range strings.Split(meta, ",") {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2500",
+		Short: "DAO membership registry",
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a member",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			addr, _ := cmd.Flags().GetString("addr")
+			power, _ := cmd.Flags().GetUint64("power")
+			meta, _ := cmd.Flags().GetString("meta")
+			m := core.NewSyn2500Member(id, addr, power, parseMeta(meta))
+			syn2500.AddMember(m)
+			fmt.Println("member added")
+		},
+	}
+	addCmd.Flags().String("id", "", "member id")
+	addCmd.Flags().String("addr", "", "address")
+	addCmd.Flags().Uint64("power", 0, "voting power")
+	addCmd.Flags().String("meta", "", "metadata key=value,comma-separated")
+	cmd.AddCommand(addCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get member info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			m, ok := syn2500.GetMember(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%+v\n", *m)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	delCmd := &cobra.Command{
+		Use:   "remove <id>",
+		Short: "Remove member",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			syn2500.RemoveMember(args[0])
+			fmt.Println("member removed")
+		},
+	}
+	cmd.AddCommand(delCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List members",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, m := range syn2500.ListMembers() {
+				fmt.Printf("%s %s %d\n", m.ID, m.Address, m.VotingPower)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2700.go
+++ b/cli/syn2700.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var schedule *core.VestingSchedule
+
+func parseEntries(s string) []core.VestingEntry {
+	if s == "" {
+		return nil
+	}
+	var entries []core.VestingEntry
+	parts := strings.Split(s, ",")
+	for _, p := range parts {
+		kv := strings.SplitN(p, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, kv[0])
+		if err != nil {
+			continue
+		}
+		var amt uint64
+		fmt.Sscanf(kv[1], "%d", &amt)
+		entries = append(entries, core.VestingEntry{ReleaseTime: t, Amount: amt})
+	}
+	return entries
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2700",
+		Short: "Vesting schedule management",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a vesting schedule",
+		Run: func(cmd *cobra.Command, args []string) {
+			data, _ := cmd.Flags().GetString("entries")
+			schedule = core.NewVestingSchedule(parseEntries(data))
+			fmt.Println("schedule created")
+		},
+	}
+	createCmd.Flags().String("entries", "", "entry as time:amount,comma-separated")
+	cmd.AddCommand(createCmd)
+
+	claimCmd := &cobra.Command{
+		Use:   "claim",
+		Short: "Claim vested amounts",
+		Run: func(cmd *cobra.Command, args []string) {
+			if schedule == nil {
+				fmt.Println("schedule not created")
+				return
+			}
+			amt := schedule.Claim(time.Now())
+			fmt.Printf("claimed %d\n", amt)
+		},
+	}
+	cmd.AddCommand(claimCmd)
+
+	pendingCmd := &cobra.Command{
+		Use:   "pending",
+		Short: "Show pending amount",
+		Run: func(cmd *cobra.Command, args []string) {
+			if schedule == nil {
+				fmt.Println("schedule not created")
+				return
+			}
+			fmt.Printf("pending %d\n", schedule.Pending(time.Now()))
+		},
+	}
+	cmd.AddCommand(pendingCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2900.go
+++ b/cli/syn2900.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var policy *core.TokenInsurancePolicy
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2900",
+		Short: "Token insurance policies",
+	}
+
+	issueCmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Issue a new policy",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			holder, _ := cmd.Flags().GetString("holder")
+			coverage, _ := cmd.Flags().GetString("coverage")
+			premium, _ := cmd.Flags().GetUint64("premium")
+			payout, _ := cmd.Flags().GetUint64("payout")
+			deductible, _ := cmd.Flags().GetUint64("deductible")
+			limit, _ := cmd.Flags().GetUint64("limit")
+			startStr, _ := cmd.Flags().GetString("start")
+			endStr, _ := cmd.Flags().GetString("end")
+			start, _ := time.Parse(time.RFC3339, startStr)
+			end, _ := time.Parse(time.RFC3339, endStr)
+			policy = core.NewTokenInsurancePolicy(id, holder, coverage, premium, payout, deductible, limit, start, end)
+			fmt.Println("policy issued")
+		},
+	}
+	issueCmd.Flags().String("id", "", "policy id")
+	issueCmd.Flags().String("holder", "", "policy holder")
+	issueCmd.Flags().String("coverage", "", "coverage type")
+	issueCmd.Flags().Uint64("premium", 0, "premium amount")
+	issueCmd.Flags().Uint64("payout", 0, "payout amount")
+	issueCmd.Flags().Uint64("deductible", 0, "deductible")
+	issueCmd.Flags().Uint64("limit", 0, "limit")
+	issueCmd.Flags().String("start", time.Now().Format(time.RFC3339), "start time")
+	issueCmd.Flags().String("end", time.Now().Add(24*time.Hour).Format(time.RFC3339), "end time")
+	cmd.AddCommand(issueCmd)
+
+	activeCmd := &cobra.Command{
+		Use:   "active",
+		Short: "Check if policy is active",
+		Run: func(cmd *cobra.Command, args []string) {
+			if policy == nil {
+				fmt.Println("no policy")
+				return
+			}
+			fmt.Println(policy.IsActive(time.Now()))
+		},
+	}
+	cmd.AddCommand(activeCmd)
+
+	claimCmd := &cobra.Command{
+		Use:   "claim",
+		Short: "Claim the policy",
+		Run: func(cmd *cobra.Command, args []string) {
+			if policy == nil {
+				fmt.Println("no policy")
+				return
+			}
+			amt, err := policy.Claim(time.Now())
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Printf("payout %d\n", amt)
+		},
+	}
+	cmd.AddCommand(claimCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn300_token.go
+++ b/cli/syn300_token.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn300 *core.SYN300Token
+
+func parseBalances(s string) map[string]uint64 {
+	m := make(map[string]uint64)
+	if s == "" {
+		return m
+	}
+	for _, kv := range strings.Split(s, ",") {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		var amt uint64
+		fmt.Sscanf(parts[1], "%d", &amt)
+		m[parts[0]] = amt
+	}
+	return m
+}
+
+func init() {
+	cmd := &cobra.Command{Use: "syn300", Short: "SYN300 governance token"}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise token with balances",
+		Run: func(cmd *cobra.Command, args []string) {
+			balStr, _ := cmd.Flags().GetString("balances")
+			syn300 = core.NewSYN300Token(parseBalances(balStr))
+			fmt.Println("token initialised")
+		},
+	}
+	initCmd.Flags().String("balances", "", "initial balances addr=amt,comma-separated")
+	cmd.AddCommand(initCmd)
+
+	delCmd := &cobra.Command{
+		Use:   "delegate <owner> <delegate>",
+		Short: "Delegate voting power",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			syn300.Delegate(args[0], args[1])
+			fmt.Println("delegated")
+		},
+	}
+	cmd.AddCommand(delCmd)
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke <owner>",
+		Short: "Revoke delegation",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			syn300.RevokeDelegation(args[0])
+			fmt.Println("revoked")
+		},
+	}
+	cmd.AddCommand(revokeCmd)
+
+	powerCmd := &cobra.Command{
+		Use:   "power <addr>",
+		Short: "Show voting power",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			fmt.Println(syn300.VotingPower(args[0]))
+		},
+	}
+	cmd.AddCommand(powerCmd)
+
+	propCmd := &cobra.Command{
+		Use:   "propose <creator> <desc>",
+		Short: "Create proposal",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			id := syn300.CreateProposal(args[0], args[1])
+			fmt.Printf("proposal %d created\n", id)
+		},
+	}
+	cmd.AddCommand(propCmd)
+
+	voteCmd := &cobra.Command{
+		Use:   "vote <id> <voter> <approve>",
+		Short: "Cast vote",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			var id uint64
+			fmt.Sscanf(args[0], "%d", &id)
+			approve := args[2] == "true"
+			if err := syn300.Vote(id, args[1], approve); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("vote recorded")
+			}
+		},
+	}
+	cmd.AddCommand(voteCmd)
+
+	execCmd := &cobra.Command{
+		Use:   "execute <id> <quorum>",
+		Short: "Execute proposal if quorum met",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			var id, quorum uint64
+			fmt.Sscanf(args[0], "%d", &id)
+			fmt.Sscanf(args[1], "%d", &quorum)
+			if err := syn300.Execute(id, quorum); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("proposal executed")
+			}
+		},
+	}
+	cmd.AddCommand(execCmd)
+
+	statusCmd := &cobra.Command{
+		Use:   "status <id>",
+		Short: "Show proposal status",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			var id uint64
+			fmt.Sscanf(args[0], "%d", &id)
+			p, err := syn300.ProposalStatus(id)
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Printf("%+v\n", *p)
+		},
+	}
+	cmd.AddCommand(statusCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List proposals",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn300 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			for _, p := range syn300.ListProposals() {
+				fmt.Printf("%d %s executed:%v\n", p.ID, p.Description, p.Executed)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn3200.go
+++ b/cli/syn3200.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var bills = core.NewBillRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3200",
+		Short: "Bill registry operations",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a bill",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			issuer, _ := cmd.Flags().GetString("issuer")
+			payer, _ := cmd.Flags().GetString("payer")
+			amt, _ := cmd.Flags().GetUint64("amount")
+			dueStr, _ := cmd.Flags().GetString("due")
+			meta, _ := cmd.Flags().GetString("meta")
+			due, _ := time.Parse(time.RFC3339, dueStr)
+			if _, err := bills.Create(id, issuer, payer, amt, due, meta); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("bill created")
+			}
+		},
+	}
+	createCmd.Flags().String("id", "", "bill id")
+	createCmd.Flags().String("issuer", "", "issuer")
+	createCmd.Flags().String("payer", "", "payer")
+	createCmd.Flags().Uint64("amount", 0, "amount")
+	createCmd.Flags().String("due", time.Now().Add(24*time.Hour).Format(time.RFC3339), "due time")
+	createCmd.Flags().String("meta", "", "metadata")
+	cmd.AddCommand(createCmd)
+
+	payCmd := &cobra.Command{
+		Use:   "pay <id> <payer> <amt>",
+		Short: "Record a payment",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := bills.Pay(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("payment recorded")
+			}
+		},
+	}
+	cmd.AddCommand(payCmd)
+
+	adjustCmd := &cobra.Command{
+		Use:   "adjust <id> <amt>",
+		Short: "Adjust bill amount",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			if err := bills.Adjust(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("bill adjusted")
+			}
+		},
+	}
+	cmd.AddCommand(adjustCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get bill info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			b, ok := bills.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%+v\n", *b)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn3500_token.go
+++ b/cli/syn3500_token.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn3500 *core.SYN3500Token
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3500",
+		Short: "SYN3500 currency token",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise the token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			issuer, _ := cmd.Flags().GetString("issuer")
+			rate, _ := cmd.Flags().GetFloat64("rate")
+			syn3500 = core.NewSYN3500Token(name, symbol, issuer, rate)
+			fmt.Println("token initialised")
+		},
+	}
+	initCmd.Flags().String("name", "", "name")
+	initCmd.Flags().String("symbol", "", "symbol")
+	initCmd.Flags().String("issuer", "", "issuer")
+	initCmd.Flags().Float64("rate", 1.0, "exchange rate")
+	cmd.AddCommand(initCmd)
+
+	rateCmd := &cobra.Command{
+		Use:   "setrate <rate>",
+		Short: "Update exchange rate",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3500 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			r, _ := strconv.ParseFloat(args[0], 64)
+			syn3500.SetRate(r)
+			fmt.Println("rate updated")
+		},
+	}
+	cmd.AddCommand(rateCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show token info",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3500 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			sym, issuer, rate := syn3500.Info()
+			fmt.Printf("%s %s %.2f\n", sym, issuer, rate)
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	mintCmd := &cobra.Command{
+		Use:   "mint <addr> <amt>",
+		Short: "Mint tokens",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3500 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			syn3500.Mint(args[0], amt)
+			fmt.Println("minted")
+		},
+	}
+	cmd.AddCommand(mintCmd)
+
+	redeemCmd := &cobra.Command{
+		Use:   "redeem <addr> <amt>",
+		Short: "Redeem tokens",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3500 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			if err := syn3500.Redeem(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("redeemed")
+			}
+		},
+	}
+	cmd.AddCommand(redeemCmd)
+
+	balCmd := &cobra.Command{
+		Use:   "balance <addr>",
+		Short: "Show balance",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3500 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			fmt.Println(syn3500.BalanceOf(args[0]))
+		},
+	}
+	cmd.AddCommand(balCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn3600.go
+++ b/cli/syn3600.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var contract *core.FuturesContract
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3600",
+		Short: "Futures contract utilities",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a futures contract",
+		Run: func(cmd *cobra.Command, args []string) {
+			underlying, _ := cmd.Flags().GetString("underlying")
+			qty, _ := cmd.Flags().GetUint64("qty")
+			price, _ := cmd.Flags().GetUint64("price")
+			expStr, _ := cmd.Flags().GetString("expiration")
+			exp, _ := time.Parse(time.RFC3339, expStr)
+			contract = core.NewFuturesContract(underlying, qty, price, exp)
+			fmt.Println("contract created")
+		},
+	}
+	createCmd.Flags().String("underlying", "", "underlying asset")
+	createCmd.Flags().Uint64("qty", 0, "quantity")
+	createCmd.Flags().Uint64("price", 0, "price per unit")
+	createCmd.Flags().String("expiration", time.Now().Add(24*time.Hour).Format(time.RFC3339), "expiration time")
+	cmd.AddCommand(createCmd)
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Check if contract expired",
+		Run: func(cmd *cobra.Command, args []string) {
+			if contract == nil {
+				fmt.Println("no contract")
+				return
+			}
+			fmt.Println(contract.IsExpired(time.Now()))
+		},
+	}
+	cmd.AddCommand(statusCmd)
+
+	settleCmd := &cobra.Command{
+		Use:   "settle <marketPrice>",
+		Short: "Settle contract and show PnL",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if contract == nil {
+				fmt.Println("no contract")
+				return
+			}
+			var price uint64
+			fmt.Sscanf(args[0], "%d", &price)
+			pnl := contract.Settle(price)
+			fmt.Printf("pnl %d\n", pnl)
+		},
+	}
+	cmd.AddCommand(settleCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn3700_token.go
+++ b/cli/syn3700_token.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn3700 *core.SYN3700Token
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3700",
+		Short: "Index token management",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise index token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			syn3700 = core.NewSYN3700Token(name, symbol)
+			fmt.Println("token initialised")
+		},
+	}
+	initCmd.Flags().String("name", "", "name")
+	initCmd.Flags().String("symbol", "", "symbol")
+	cmd.AddCommand(initCmd)
+
+	addCmd := &cobra.Command{
+		Use:   "add <token> <weight>",
+		Short: "Add component",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3700 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			w, _ := strconv.ParseFloat(args[1], 64)
+			syn3700.AddComponent(args[0], w)
+			fmt.Println("component added")
+		},
+	}
+	cmd.AddCommand(addCmd)
+
+	removeCmd := &cobra.Command{
+		Use:   "remove <token>",
+		Short: "Remove component",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3700 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn3700.RemoveComponent(args[0]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("component removed")
+			}
+		},
+	}
+	cmd.AddCommand(removeCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List components",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3700 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			for _, c := range syn3700.ListComponents() {
+				fmt.Printf("%s %.2f\n", c.Token, c.Weight)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	valueCmd := &cobra.Command{
+		Use:   "value",
+		Short: "Compute index value from price list",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn3700 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			priceStr, _ := cmd.Flags().GetString("prices")
+			m := make(map[string]float64)
+			for _, kv := range strings.Split(priceStr, ",") {
+				parts := strings.SplitN(kv, "=", 2)
+				if len(parts) != 2 {
+					continue
+				}
+				v, _ := strconv.ParseFloat(parts[1], 64)
+				m[parts[0]] = v
+			}
+			fmt.Println(syn3700.Value(m))
+		},
+	}
+	valueCmd.Flags().String("prices", "", "token=price comma-separated")
+	cmd.AddCommand(valueCmd)
+
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add CLI management for elected authority nodes, faucet, firewall, forensic node and full node
- expand gas commands with update and snapshot capabilities
- provide command-line access to SYN2100–SYN3700 token features

## Testing
- `go test ./...` *(fails: checksum mismatch for github.com/sirupsen/logrus)*

------
https://chatgpt.com/codex/tasks/task_e_68915bd978ec8320ad1c9409d28c8bab