### PR TITLE
Add CLI support for identity and regulatory components

### DIFF
--- a/cli/identity.go
+++ b/cli/identity.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	synnergy "synnergy"
+)
+
+var identitySvc = synnergy.NewIdentityService()
+
+func init() {
+	identityCmd := &cobra.Command{
+		Use:   "identity",
+		Short: "Identity verification operations",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register [addr] [name] [dob] [nationality]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Register identity information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return identitySvc.Register(args[0], args[1], args[2], args[3])
+		},
+	}
+
+	verifyCmd := &cobra.Command{
+		Use:   "verify [addr] [method]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Record a verification method",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return identitySvc.Verify(args[0], args[1])
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve identity information",
+		Run: func(cmd *cobra.Command, args []string) {
+			info, ok := identitySvc.Info(args[0])
+			if !ok {
+				fmt.Println("identity not found")
+				return
+			}
+			fmt.Printf("Name: %s\nDOB: %s\nNationality: %s\n", info.Name, info.DateOfBirth, info.Nationality)
+		},
+	}
+
+	logsCmd := &cobra.Command{
+		Use:   "logs [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show verification logs",
+		Run: func(cmd *cobra.Command, args []string) {
+			logs := identitySvc.Logs(args[0])
+			for _, l := range logs {
+				fmt.Printf("%s - %s\n", l.Timestamp.Format(time.RFC3339), l.Method)
+			}
+		},
+	}
+
+	identityCmd.AddCommand(registerCmd, verifyCmd, infoCmd, logsCmd)
+	rootCmd.AddCommand(identityCmd)
+}

--- a/cli/idwallet.go
+++ b/cli/idwallet.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	synnergy "synnergy"
+)
+
+var idRegistry = synnergy.NewIDRegistry()
+
+func init() {
+	idwCmd := &cobra.Command{
+		Use:   "idwallet",
+		Short: "ID wallet registry operations",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register [addr] [info]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Register a wallet",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return idRegistry.Register(args[0], args[1])
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show registration info",
+		Run: func(cmd *cobra.Command, args []string) {
+			info, ok := idRegistry.Info(args[0])
+			if !ok {
+				fmt.Println("not registered")
+				return
+			}
+			fmt.Println(info)
+		},
+	}
+
+	checkCmd := &cobra.Command{
+		Use:   "check [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Check if a wallet is registered",
+		Run: func(cmd *cobra.Command, args []string) {
+			if idRegistry.IsRegistered(args[0]) {
+				fmt.Println("registered")
+			} else {
+				fmt.Println("not registered")
+			}
+		},
+	}
+
+	idwCmd.AddCommand(registerCmd, infoCmd, checkCmd)
+	rootCmd.AddCommand(idwCmd)
+}

--- a/cli/private_tx.go
+++ b/cli/private_tx.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	synnergy "synnergy"
+)
+
+var privTxMgr = synnergy.NewPrivateTxManager()
+
+func init() {
+	privCmd := &cobra.Command{Use: "privtx", Short: "Private transaction utilities"}
+
+	sendCmd := &cobra.Command{
+		Use:   "send [hexkey] [plaintext]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Encrypt and store a private transaction",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := hex.DecodeString(args[0])
+			if err != nil {
+				return err
+			}
+			encrypted, err := synnergy.Encrypt(key, []byte(args[1]))
+			if err != nil {
+				return err
+			}
+			block, err := aes.NewCipher(key)
+			if err != nil {
+				return err
+			}
+			gcm, err := cipher.NewGCM(block)
+			if err != nil {
+				return err
+			}
+			nonceSize := gcm.NonceSize()
+			tx := synnergy.PrivateTransaction{Nonce: encrypted[:nonceSize], Payload: encrypted[nonceSize:]}
+			privTxMgr.Send(tx)
+			fmt.Println("transaction stored")
+			return nil
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List stored private transactions",
+		Run: func(cmd *cobra.Command, args []string) {
+			txs := privTxMgr.List()
+			for i, tx := range txs {
+				fmt.Printf("%d: nonce=%x payload=%x\n", i, tx.Nonce, tx.Payload)
+			}
+		},
+	}
+
+	decryptCmd := &cobra.Command{
+		Use:   "decrypt [hexkey] [index]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Decrypt a stored transaction by index",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := hex.DecodeString(args[0])
+			if err != nil {
+				return err
+			}
+			idx, err := strconv.Atoi(args[1])
+			if err != nil {
+				return err
+			}
+			txs := privTxMgr.List()
+			if idx < 0 || idx >= len(txs) {
+				return fmt.Errorf("index out of range")
+			}
+			data := append(txs[idx].Nonce, txs[idx].Payload...)
+			plain, err := synnergy.Decrypt(key, data)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(plain))
+			return nil
+		},
+	}
+
+	privCmd.AddCommand(sendCmd, listCmd, decryptCmd)
+	rootCmd.AddCommand(privCmd)
+}

--- a/cli/regnode.go
+++ b/cli/regnode.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	synnergy "synnergy"
+)
+
+var regNode = synnergy.NewRegulatoryNode("regnode1", regManager)
+
+func init() {
+	nodeCmd := &cobra.Command{Use: "regnode", Short: "Regulatory node operations"}
+
+	approveCmd := &cobra.Command{
+		Use:   "approve [from] [to] [amount]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Approve a transaction against regulations",
+		Run: func(cmd *cobra.Command, args []string) {
+			amount, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			tx := synnergy.Transaction{From: args[0], To: args[1], Amount: amount}
+			if regNode.ApproveTransaction(tx) {
+				fmt.Println("approved")
+			} else {
+				fmt.Println("rejected")
+			}
+		},
+	}
+
+	flagCmd := &cobra.Command{
+		Use:   "flag [addr] [reason]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Flag an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			regNode.FlagEntity(args[0], args[1])
+		},
+	}
+
+	logsCmd := &cobra.Command{
+		Use:   "logs [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show regulatory flags",
+		Run: func(cmd *cobra.Command, args []string) {
+			logs := regNode.Logs(args[0])
+			for _, l := range logs {
+				fmt.Println(l)
+			}
+		},
+	}
+
+	nodeCmd.AddCommand(approveCmd, flagCmd, logsCmd)
+	rootCmd.AddCommand(nodeCmd)
+}

--- a/cli/regulation.go
+++ b/cli/regulation.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	synnergy "synnergy"
+)
+
+var regManager = synnergy.NewRegulatoryManager()
+
+func init() {
+	regCmd := &cobra.Command{
+		Use:   "regulation",
+		Short: "Manage regulatory rules",
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add [id] [maxAmount] [jurisdiction] [description]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Add a regulation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			maxAmt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				return err
+			}
+			reg := synnergy.Regulation{ID: args[0], MaxAmount: maxAmt, Jurisdiction: args[2], Description: args[3]}
+			return regManager.AddRegulation(reg)
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a regulation",
+		Run: func(cmd *cobra.Command, args []string) {
+			regManager.RemoveRegulation(args[0])
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get a regulation",
+		Run: func(cmd *cobra.Command, args []string) {
+			reg, ok := regManager.GetRegulation(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%s: max=%d jurisdiction=%s description=%s\n", reg.ID, reg.MaxAmount, reg.Jurisdiction, reg.Description)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List regulations",
+		Run: func(cmd *cobra.Command, args []string) {
+			regs := regManager.ListRegulations()
+			for _, r := range regs {
+				fmt.Printf("%s: max=%d jurisdiction=%s description=%s\n", r.ID, r.MaxAmount, r.Jurisdiction, r.Description)
+			}
+		},
+	}
+
+	evalCmd := &cobra.Command{
+		Use:   "eval [from] [to] [amount]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Evaluate a transaction",
+		Run: func(cmd *cobra.Command, args []string) {
+			amount, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			tx := synnergy.Transaction{From: args[0], To: args[1], Amount: amount}
+			v := regManager.EvaluateTransaction(tx)
+			if len(v) == 0 {
+				fmt.Println("no violations")
+			} else {
+				fmt.Println("violations:", v)
+			}
+		},
+	}
+
+	regCmd.AddCommand(addCmd, removeCmd, getCmd, listCmd, evalCmd)
+	rootCmd.AddCommand(regCmd)
+}

--- a/go.sum
+++ b/go.sum
@@ -43,24 +43,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ========
-
-
-github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
-github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
-github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=


### PR DESCRIPTION
## Summary
- add identity CLI for registering, verifying, and inspecting identity records
- implement ID wallet registry CLI with registration and lookup commands
- support private transactions, regulations, and regulatory node operations via CLI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915bed4ce0832087246b612c44e3e2