### PR TITLE
Add CLI for contracts and cross-chain modules

### DIFF
--- a/cli/contracts.go
+++ b/cli/contracts.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	contractVM       = core.NewSimpleVM()
+	contractRegistry = core.NewContractRegistry(contractVM)
+)
+
+func init() {
+	// start VM to allow contract execution
+	_ = contractVM.Start()
+
+	contractsCmd := &cobra.Command{
+		Use:   "contracts",
+		Short: "Compile, deploy and invoke smart contracts",
+	}
+
+	compileCmd := &cobra.Command{
+		Use:   "compile [src.wat|src.wasm]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Compile WAT or WASM to deterministic bytecode",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			src, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			_, hash, err := core.CompileWASM(src)
+			if err != nil {
+				return err
+			}
+			fmt.Println(hash)
+			return nil
+		},
+	}
+
+	var wasmPath, manifestPath, owner string
+	var gasLimit uint64
+
+	deployCmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploy compiled WASM",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wasmPath == "" {
+				return fmt.Errorf("--wasm required")
+			}
+			wasm, err := os.ReadFile(wasmPath)
+			if err != nil {
+				return err
+			}
+			var manifest string
+			if manifestPath != "" {
+				m, err := os.ReadFile(manifestPath)
+				if err != nil {
+					return err
+				}
+				manifest = string(m)
+			}
+			addr, err := contractRegistry.Deploy(wasm, manifest, gasLimit, owner)
+			if err != nil {
+				return err
+			}
+			fmt.Println(addr)
+			return nil
+		},
+	}
+	deployCmd.Flags().StringVar(&wasmPath, "wasm", "", "Path to compiled WASM")
+	deployCmd.Flags().StringVar(&manifestPath, "ric", "", "Path to Ricardian manifest")
+	deployCmd.Flags().Uint64Var(&gasLimit, "gas", 100000, "Gas limit")
+	deployCmd.Flags().StringVar(&owner, "owner", "", "Owner address")
+
+	var invokeMethod, invokeArgs string
+	var invokeGas uint64
+	invokeCmd := &cobra.Command{
+		Use:   "invoke <address>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Invoke a contract method",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			addr := args[0]
+			out, gas, err := contractRegistry.Invoke(addr, invokeMethod, []byte(invokeArgs), invokeGas)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("output: %s\ngas: %d\n", string(out), gas)
+			return nil
+		},
+	}
+	invokeCmd.Flags().StringVar(&invokeMethod, "method", "", "Contract method to call")
+	invokeCmd.Flags().StringVar(&invokeArgs, "args", "", "Arguments as raw bytes")
+	invokeCmd.Flags().Uint64Var(&invokeGas, "gas", 0, "Gas limit (0 for default)")
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List deployed contracts",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, c := range contractRegistry.List() {
+				fmt.Printf("%s owner=%s gas=%d paused=%v\n", c.Address, c.Owner, c.GasLimit, c.Paused)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <address>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show contract manifest",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, ok := contractRegistry.Get(args[0])
+			if !ok {
+				return fmt.Errorf("contract not found")
+			}
+			fmt.Println(c.Manifest)
+			return nil
+		},
+	}
+
+	contractsCmd.AddCommand(compileCmd, deployCmd, invokeCmd, listCmd, infoCmd)
+	rootCmd.AddCommand(contractsCmd)
+}

--- a/cli/contracts_opcodes.go
+++ b/cli/contracts_opcodes.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "contractopcodes",
+		Short: "List contract-related opcodes",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("%d: OpInitContracts\n", core.OpInitContracts)
+			fmt.Printf("%d: OpPauseContract\n", core.OpPauseContract)
+			fmt.Printf("%d: OpResumeContract\n", core.OpResumeContract)
+			fmt.Printf("%d: OpUpgradeContract\n", core.OpUpgradeContract)
+			fmt.Printf("%d: OpContractInfo\n", core.OpContractInfo)
+			fmt.Printf("%d: OpDeployAIContract\n", core.OpDeployAIContract)
+			fmt.Printf("%d: OpInvokeAIContract\n", core.OpInvokeAIContract)
+		},
+	}
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/cross_chain.go
+++ b/cli/cross_chain.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var bridgeRegistry = core.NewBridgeRegistry()
+
+func init() {
+	ccCmd := &cobra.Command{
+		Use:   "cross_chain",
+		Short: "Manage cross-chain bridges",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <source_chain> <target_chain> <relayer_addr>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Register a bridge",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			b, err := bridgeRegistry.RegisterBridge(args[0], args[1], args[2])
+			if err != nil {
+				return err
+			}
+			fmt.Println(b.ID)
+			return nil
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered bridges",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, b := range bridgeRegistry.ListBridges() {
+				fmt.Printf("%s: %s -> %s\n", b.ID, b.SourceChain, b.TargetChain)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <bridge_id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve a bridge configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			b, ok := bridgeRegistry.GetBridge(args[0])
+			if !ok {
+				return fmt.Errorf("bridge not found")
+			}
+			fmt.Printf("%s: %s -> %s relayers=%d\n", b.ID, b.SourceChain, b.TargetChain, len(b.Relayers))
+			return nil
+		},
+	}
+
+	authorizeCmd := &cobra.Command{
+		Use:   "authorize <bridge_id> <relayer_addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Whitelist a relayer address",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return bridgeRegistry.AuthorizeRelayer(args[0], args[1])
+		},
+	}
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke <bridge_id> <relayer_addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Remove a relayer from the whitelist",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return bridgeRegistry.RevokeRelayer(args[0], args[1])
+		},
+	}
+
+	ccCmd.AddCommand(registerCmd, listCmd, getCmd, authorizeCmd, revokeCmd)
+	rootCmd.AddCommand(ccCmd)
+}

--- a/cli/cross_chain_agnostic_protocols.go
+++ b/cli/cross_chain_agnostic_protocols.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var protocolRegistry = core.NewProtocolRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "cross_chain_agnostic_protocols",
+		Short: "Register cross-chain protocols",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <name>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Register a new protocol definition",
+		Run: func(cmd *cobra.Command, args []string) {
+			id := protocolRegistry.Register(args[0])
+			fmt.Println(id)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered protocols",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, p := range protocolRegistry.List() {
+				fmt.Printf("%d: %s\n", p.ID, p.Name)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve a protocol configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			p, ok := protocolRegistry.Get(id)
+			if !ok {
+				return fmt.Errorf("protocol not found")
+			}
+			fmt.Printf("%d: %s\n", p.ID, p.Name)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(registerCmd, listCmd, getCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/cross_chain_bridge.go
+++ b/cli/cross_chain_bridge.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var transferManager = core.NewBridgeTransferManager()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "cross_chain_bridge",
+		Short: "Manage cross-chain token transfers",
+	}
+
+	depositCmd := &cobra.Command{
+		Use:   "deposit <bridge_id> <from> <to> <amount> [tokenID]",
+		Args:  cobra.RangeArgs(4, 5),
+		Short: "Lock assets for bridging",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			amount, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				return err
+			}
+			tokenID := ""
+			if len(args) == 5 {
+				tokenID = args[4]
+			}
+			t, err := transferManager.Deposit(args[0], args[1], args[2], amount, tokenID)
+			if err != nil {
+				return err
+			}
+			fmt.Println(t.ID)
+			return nil
+		},
+	}
+
+	claimCmd := &cobra.Command{
+		Use:   "claim <transfer_id> <proof>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Release assets using a proof",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return transferManager.Claim(args[0], args[1])
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show a transfer record",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			t, ok := transferManager.GetTransfer(args[0])
+			if !ok {
+				return fmt.Errorf("transfer not found")
+			}
+			fmt.Printf("%s: bridge=%s from=%s to=%s amount=%d token=%s status=%s\n", t.ID, t.BridgeID, t.From, t.To, t.Amount, t.TokenID, t.Status)
+			return nil
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all transfers",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, t := range transferManager.ListTransfers() {
+				fmt.Printf("%s: bridge=%s from=%s to=%s amount=%d token=%s status=%s\n", t.ID, t.BridgeID, t.From, t.To, t.Amount, t.TokenID, t.Status)
+			}
+		},
+	}
+
+	cmd.AddCommand(depositCmd, claimCmd, getCmd, listCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/cross_chain_connection.go
+++ b/cli/cross_chain_connection.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var connectionManager = core.NewChainConnectionManager()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "cross_chain_connection",
+		Short: "Create and monitor chain connections",
+	}
+
+	openCmd := &cobra.Command{
+		Use:   "open <local_chain> <remote_chain>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Establish a new connection",
+		Run: func(cmd *cobra.Command, args []string) {
+			id := connectionManager.Open(args[0], args[1])
+			fmt.Println(id)
+		},
+	}
+
+	closeCmd := &cobra.Command{
+		Use:   "close <connection_id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Terminate a connection",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			return connectionManager.Close(id)
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <connection_id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve connection details",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			c, err := connectionManager.Get(id)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%d: %s <-> %s open=%v\n", c.ID, c.LocalChain, c.RemoteChain, c.Open)
+			return nil
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List active and historic connections",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, c := range connectionManager.List() {
+				fmt.Printf("%d: %s <-> %s open=%v\n", c.ID, c.LocalChain, c.RemoteChain, c.Open)
+			}
+		},
+	}
+
+	cmd.AddCommand(openCmd, closeCmd, getCmd, listCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/cross_chain_contracts.go
+++ b/cli/cross_chain_contracts.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var crossContractRegistry = core.NewCrossChainRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "xcontract",
+		Short: "Register cross-chain contract mappings",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <local_addr> <remote_chain> <remote_addr>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Register a contract mapping",
+		Run: func(cmd *cobra.Command, args []string) {
+			crossContractRegistry.RegisterMapping(args[0], args[1], args[2])
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered mappings",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, m := range crossContractRegistry.ListMappings() {
+				fmt.Printf("%s -> %s:%s\n", m.LocalAddress, m.RemoteChain, m.RemoteAddress)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <local_addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve mapping info",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			m, ok := crossContractRegistry.GetMapping(args[0])
+			if !ok {
+				return fmt.Errorf("mapping not found")
+			}
+			fmt.Printf("%s -> %s:%s\n", m.LocalAddress, m.RemoteChain, m.RemoteAddress)
+			return nil
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove <local_addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Delete a mapping",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return crossContractRegistry.RemoveMapping(args[0])
+		},
+	}
+
+	cmd.AddCommand(registerCmd, listCmd, getCmd, removeCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/cross_chain_transactions.go
+++ b/cli/cross_chain_transactions.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var crossTxManager = core.NewCrossChainTxManager(core.NewLedger())
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "cross_tx",
+		Short: "Execute cross-chain asset transfers",
+	}
+
+	lockMintCmd := &cobra.Command{
+		Use:   "lockmint <bridge_id> <asset_id> <amount> <proof> --from <addr> --to <addr>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Lock native assets and mint wrapped tokens",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			from, _ := cmd.Flags().GetString("from")
+			to, _ := cmd.Flags().GetString("to")
+			amount, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				return err
+			}
+			id, err := crossTxManager.LockMint(parseInt(args[0]), from, to, args[1], amount, args[3])
+			if err != nil {
+				return err
+			}
+			fmt.Println(id)
+			return nil
+		},
+	}
+	lockMintCmd.Flags().String("from", "", "Sender address")
+	lockMintCmd.Flags().String("to", "", "Recipient address")
+	lockMintCmd.MarkFlagRequired("from")
+	lockMintCmd.MarkFlagRequired("to")
+
+	burnReleaseCmd := &cobra.Command{
+		Use:   "burnrelease <bridge_id> <to> <asset_id> <amount> --from <addr>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Burn wrapped tokens and release native assets",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			from, _ := cmd.Flags().GetString("from")
+			amount, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				return err
+			}
+			id, err := crossTxManager.BurnRelease(parseInt(args[0]), from, args[1], args[2], amount)
+			if err != nil {
+				return err
+			}
+			fmt.Println(id)
+			return nil
+		},
+	}
+	burnReleaseCmd.Flags().String("from", "", "Sender address")
+	burnReleaseCmd.MarkFlagRequired("from")
+
+	getCmd := &cobra.Command{
+		Use:   "get <tx_id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve a cross-chain transfer by ID",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			t, err := crossTxManager.GetTransfer(id)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%d: bridge=%d from=%s to=%s asset=%s amount=%d type=%s completed=%v\n", t.ID, t.BridgeID, t.From, t.To, t.AssetID, t.Amount, t.Type, t.Completed)
+			return nil
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List cross-chain transfer records",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, t := range crossTxManager.ListTransfers() {
+				fmt.Printf("%d: bridge=%d from=%s to=%s asset=%s amount=%d type=%s completed=%v\n", t.ID, t.BridgeID, t.From, t.To, t.AssetID, t.Amount, t.Type, t.Completed)
+			}
+		},
+	}
+
+	cmd.AddCommand(lockMintCmd, burnReleaseCmd, listCmd, getCmd)
+	rootCmd.AddCommand(cmd)
+}
+
+func parseInt(s string) int {
+	i, _ := strconv.Atoi(s)
+	return i
+}

--- a/go.sum
+++ b/go.sum
@@ -44,7 +44,7 @@ github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsF
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ========
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 
 
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=


### PR DESCRIPTION
## Summary
- add comprehensive `contracts` CLI for compiling, deploying and invoking WASM smart contracts
- support listing contract-related opcodes via `contractopcodes`
- implement cross-chain command groups for bridge management, protocol registry, transfers, connections, contract mappings and transactions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915bc50c108320adb2684fae466936