### PR TITLE
Add CLI commands for stage 3 modules

### DIFF
--- a/cli/centralbank.go
+++ b/cli/centralbank.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var centralBank = core.NewCentralBankingNode("central", "cbnode", ledger, "neutral")
+
+func init() {
+	cbCmd := &cobra.Command{Use: "centralbank", Short: "Central bank node operations"}
+
+	infoCmd := &cobra.Command{Use: "info", Short: "Show node info", Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("id: %s address: %s policy: %s\n", centralBank.ID, centralBank.Addr, centralBank.MonetaryPolicy)
+	}}
+
+	policyCmd := &cobra.Command{Use: "policy [description]", Args: cobra.ExactArgs(1), Short: "Update monetary policy", Run: func(cmd *cobra.Command, args []string) {
+		centralBank.UpdatePolicy(args[0])
+	}}
+
+	mintCmd := &cobra.Command{Use: "mint [to] [amount]", Args: cobra.ExactArgs(2), Short: "Mint currency tokens", Run: func(cmd *cobra.Command, args []string) {
+		amt, _ := strconv.ParseUint(args[1], 10, 64)
+		centralBank.Mint(args[0], amt)
+	}}
+
+	cbCmd.AddCommand(infoCmd, policyCmd, mintCmd)
+	rootCmd.AddCommand(cbCmd)
+}

--- a/cli/charity.go
+++ b/cli/charity.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+type dummyElectorate struct{}
+
+func (dummyElectorate) IsIDTokenHolder(addr core.Address) bool { return true }
+
+type memState struct {
+	balances map[core.Address]uint64
+	store    map[string][]byte
+}
+
+func newMemState() *memState {
+	return &memState{balances: map[core.Address]uint64{}, store: map[string][]byte{}}
+}
+
+func (m *memState) Transfer(from, to core.Address, amount uint64) error {
+	m.balances[from] -= amount
+	m.balances[to] += amount
+	return nil
+}
+
+func (m *memState) SetState(key, value []byte)          { m.store[string(key)] = value }
+func (m *memState) GetState(key []byte) ([]byte, error) { return m.store[string(key)], nil }
+func (m *memState) HasState(key []byte) (bool, error)   { _, ok := m.store[string(key)]; return ok, nil }
+func (m *memState) BalanceOf(addr core.Address) uint64  { return m.balances[addr] }
+
+type memIter struct {
+	keys  []string
+	idx   int
+	store map[string][]byte
+}
+
+func (m *memState) PrefixIterator(prefix []byte) core.StateIterator {
+	p := string(prefix)
+	keys := []string{}
+	for k := range m.store {
+		if strings.HasPrefix(k, p) {
+			keys = append(keys, k)
+		}
+	}
+	return &memIter{keys: keys, idx: -1, store: m.store}
+}
+
+func (it *memIter) Next() bool {
+	it.idx++
+	return it.idx < len(it.keys)
+}
+
+func (it *memIter) Value() []byte { return it.store[it.keys[it.idx]] }
+
+var charityState = newMemState()
+var charityPool = core.NewCharityPool(logrus.New(), charityState, dummyElectorate{}, time.Now())
+
+func init() {
+	poolCmd := &cobra.Command{Use: "charity_pool", Short: "Charity pool operations"}
+
+	registerCmd := &cobra.Command{
+		Use:   "register [addr] [category] [name]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Register a charity with the pool.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			addr := core.Address(args[0])
+			catVal, _ := strconv.Atoi(args[1])
+			return charityPool.Register(addr, args[2], core.CharityCategory(catVal))
+		},
+	}
+
+	voteCmd := &cobra.Command{
+		Use:   "vote [voterAddr] [charityAddr]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Vote for a charity during the cycle.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			voter := core.Address(args[0])
+			charity := core.Address(args[1])
+			return charityPool.Vote(voter, charity)
+		},
+	}
+
+	tickCmd := &cobra.Command{
+		Use:   "tick [timestamp]",
+		Args:  cobra.RangeArgs(0, 1),
+		Short: "Manually trigger pool cron tasks.",
+		Run: func(cmd *cobra.Command, args []string) {
+			ts := time.Now()
+			if len(args) == 1 {
+				if v, err := strconv.ParseInt(args[0], 10, 64); err == nil {
+					ts = time.Unix(v, 0)
+				}
+			}
+			charityPool.Tick(ts)
+		},
+	}
+
+	registrationCmd := &cobra.Command{
+		Use:   "registration [addr] [cycle]",
+		Args:  cobra.RangeArgs(1, 2),
+		Short: "Show registration info for a charity.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			addr := core.Address(args[0])
+			var cycle uint64
+			if len(args) == 2 {
+				c, _ := strconv.ParseUint(args[1], 10, 64)
+				cycle = c
+			}
+			reg, ok, err := charityPool.GetRegistration(cycle, addr)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("not found")
+			}
+			b, _ := json.Marshal(reg)
+			fmt.Println(string(b))
+			return nil
+		},
+	}
+
+	winnersCmd := &cobra.Command{
+		Use:   "winners [cycle]",
+		Args:  cobra.RangeArgs(0, 1),
+		Short: "List winning charities for a cycle.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var cycle uint64
+			if len(args) == 1 {
+				c, _ := strconv.ParseUint(args[0], 10, 64)
+				cycle = c
+			}
+			ws, err := charityPool.Winners(cycle)
+			if err != nil {
+				return err
+			}
+			for _, a := range ws {
+				fmt.Println(a)
+			}
+			return nil
+		},
+	}
+
+	poolCmd.AddCommand(registerCmd, voteCmd, tickCmd, registrationCmd, winnersCmd)
+
+	mgmtCmd := &cobra.Command{Use: "charity_mgmt", Short: "Charity pool management"}
+
+	donateCmd := &cobra.Command{
+		Use:   "donate [from] [amt]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Donate tokens to the charity pool.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			from := core.Address(args[0])
+			amt, _ := strconv.ParseUint(args[1], 10, 64)
+			charityState.balances[from] += amt
+			return charityPool.Deposit(from, amt)
+		},
+	}
+
+	withdrawCmd := &cobra.Command{
+		Use:   "withdraw [to] [amt]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Withdraw internal charity funds.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			to := core.Address(args[0])
+			amt, _ := strconv.ParseUint(args[1], 10, 64)
+			return charityState.Transfer(core.InternalCharityAccount, to, amt)
+		},
+	}
+
+	balancesCmd := &cobra.Command{
+		Use:   "balances",
+		Short: "Show pool and internal balances.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("pool: %d internal: %d\n", charityState.BalanceOf(core.CharityPoolAccount), charityState.BalanceOf(core.InternalCharityAccount))
+		},
+	}
+
+	mgmtCmd.AddCommand(donateCmd, withdrawCmd, balancesCmd)
+
+	rootCmd.AddCommand(poolCmd, mgmtCmd)
+}

--- a/cli/compliance.go
+++ b/cli/compliance.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var compliance = core.NewComplianceService()
+
+func init() {
+	compCmd := &cobra.Command{Use: "compliance", Short: "Compliance operations"}
+
+	validateCmd := &cobra.Command{
+		Use:   "validate [kyc.json]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Validate and store a KYC document commitment.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var input struct {
+				Address string `json:"address"`
+				Data    string `json:"data"`
+			}
+			b, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			if err := json.Unmarshal(b, &input); err != nil {
+				return err
+			}
+			commit, err := compliance.ValidateKYC(input.Address, []byte(input.Data))
+			if err != nil {
+				return err
+			}
+			fmt.Println("commitment:", commit)
+			return nil
+		},
+	}
+
+	eraseCmd := &cobra.Command{
+		Use:   "erase [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a user's KYC data.",
+		Run: func(cmd *cobra.Command, args []string) {
+			compliance.EraseKYC(args[0])
+		},
+	}
+
+	fraudCmd := &cobra.Command{
+		Use:   "fraud [address] [severity]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Record a fraud signal.",
+		Run: func(cmd *cobra.Command, args []string) {
+			sev, _ := strconv.Atoi(args[1])
+			compliance.RecordFraud(args[0], sev)
+		},
+	}
+
+	riskCmd := &cobra.Command{
+		Use:   "risk [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve accumulated fraud risk score.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(compliance.RiskScore(args[0]))
+		},
+	}
+
+	auditCmd := &cobra.Command{
+		Use:   "audit [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Display the audit trail for an address.",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, e := range compliance.AuditTrail(args[0]) {
+				b, _ := json.Marshal(e)
+				fmt.Println(string(b))
+			}
+		},
+	}
+
+	monitorCmd := &cobra.Command{
+		Use:   "monitor [tx.json] [threshold]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Run anomaly detection on a transaction.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var tx core.ComplianceTransaction
+			b, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			if err := json.Unmarshal(b, &tx); err != nil {
+				return err
+			}
+			thr, _ := strconv.ParseFloat(args[1], 64)
+			if compliance.MonitorTransaction(tx, thr) {
+				fmt.Println("anomaly detected")
+			} else {
+				fmt.Println("ok")
+			}
+			return nil
+		},
+	}
+
+	zkpCmd := &cobra.Command{
+		Use:   "verifyzkp [blob.bin] [commitmentHex] [proofHex]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Verify a zero-knowledge proof.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			b, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			ok := compliance.VerifyZKP(b, args[1], args[2])
+			fmt.Println(ok)
+			return nil
+		},
+	}
+
+	compCmd.AddCommand(validateCmd, eraseCmd, fraudCmd, riskCmd, auditCmd, monitorCmd, zkpCmd)
+	rootCmd.AddCommand(compCmd)
+}

--- a/cli/compliance_mgmt.go
+++ b/cli/compliance_mgmt.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+	"synnergy/core"
+)
+
+var complianceMgr = core.NewComplianceManager()
+
+func init() {
+	mgmtCmd := &cobra.Command{Use: "compliance_management", Short: "Manage address compliance"}
+
+	suspendCmd := &cobra.Command{Use: "suspend [addr]", Args: cobra.ExactArgs(1), Short: "Suspend an address", Run: func(cmd *cobra.Command, args []string) {
+		complianceMgr.Suspend(args[0])
+	}}
+
+	resumeCmd := &cobra.Command{Use: "resume [addr]", Args: cobra.ExactArgs(1), Short: "Lift a suspension", Run: func(cmd *cobra.Command, args []string) {
+		complianceMgr.Resume(args[0])
+	}}
+
+	whitelistCmd := &cobra.Command{Use: "whitelist [addr]", Args: cobra.ExactArgs(1), Short: "Add an address to the whitelist", Run: func(cmd *cobra.Command, args []string) {
+		complianceMgr.Whitelist(args[0])
+	}}
+
+	unwhitelistCmd := &cobra.Command{Use: "unwhitelist [addr]", Args: cobra.ExactArgs(1), Short: "Remove an address from the whitelist", Run: func(cmd *cobra.Command, args []string) {
+		complianceMgr.Unwhitelist(args[0])
+	}}
+
+	statusCmd := &cobra.Command{Use: "status [addr]", Args: cobra.ExactArgs(1), Short: "Show suspension and whitelist status", Run: func(cmd *cobra.Command, args []string) {
+		s, w := complianceMgr.Status(args[0])
+		fmt.Printf("suspended: %v whitelisted: %v\n", s, w)
+	}}
+
+	reviewCmd := &cobra.Command{Use: "review [tx.json]", Args: cobra.ExactArgs(1), Short: "Check a transaction before broadcast", RunE: func(cmd *cobra.Command, args []string) error {
+		var tx core.Transaction
+		b, err := os.ReadFile(args[0])
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(b, &tx); err != nil {
+			return err
+		}
+		if err := complianceMgr.ReviewTransaction(tx); err != nil {
+			return err
+		}
+		fmt.Println("ok")
+		return nil
+	}}
+
+	mgmtCmd.AddCommand(suspendCmd, resumeCmd, whitelistCmd, unwhitelistCmd, statusCmd, reviewCmd)
+	rootCmd.AddCommand(mgmtCmd)
+}

--- a/cli/compression.go
+++ b/cli/compression.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	compCmd := &cobra.Command{Use: "compression", Short: "Compressed ledger snapshots"}
+
+	saveCmd := &cobra.Command{
+		Use:   "save [file]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Write a compressed ledger snapshot.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return core.SaveCompressedSnapshot(ledger, args[0])
+		},
+	}
+
+	loadCmd := &cobra.Command{
+		Use:   "load [file]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Load a compressed snapshot and display the height.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			l, err := core.LoadCompressedSnapshot(args[0])
+			if err != nil {
+				return err
+			}
+			ledger = l
+			h, _ := ledger.Head()
+			fmt.Println("height:", h)
+			return nil
+		},
+	}
+
+	compCmd.AddCommand(saveCmd, loadCmd)
+	rootCmd.AddCommand(compCmd)
+}

--- a/cli/connpool.go
+++ b/cli/connpool.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var pool = core.NewConnectionPool(8)
+
+func init() {
+	poolCmd := &cobra.Command{Use: "connpool", Short: "Manage connection pool"}
+
+	statsCmd := &cobra.Command{Use: "stats", Short: "Show pool statistics", Run: func(cmd *cobra.Command, args []string) {
+		s := pool.Stats()
+		fmt.Printf("active: %d capacity: %d\n", s.Active, s.Capacity)
+	}}
+
+	dialCmd := &cobra.Command{Use: "dial [addr]", Args: cobra.ExactArgs(1), Short: "Dial an address using the pool", RunE: func(cmd *cobra.Command, args []string) error {
+		_, err := pool.Dial(args[0])
+		return err
+	}}
+
+	closeCmd := &cobra.Command{Use: "close", Short: "Close the pool", Run: func(cmd *cobra.Command, args []string) {
+		pool.Close()
+	}}
+
+	poolCmd.AddCommand(statsCmd, dialCmd, closeCmd)
+	rootCmd.AddCommand(poolCmd)
+}

--- a/cli/synchronization.go
+++ b/cli/synchronization.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syncMgr = core.NewSyncManager(ledger)
+
+func init() {
+	syncCmd := &cobra.Command{Use: "synchronization", Short: "Blockchain synchronization"}
+
+	startCmd := &cobra.Command{Use: "start", Short: "Start the sync manager", Run: func(cmd *cobra.Command, args []string) { syncMgr.Start() }}
+
+	stopCmd := &cobra.Command{Use: "stop", Short: "Stop the sync manager", Run: func(cmd *cobra.Command, args []string) { syncMgr.Stop() }}
+
+	statusCmd := &cobra.Command{Use: "status", Short: "Show sync status", Run: func(cmd *cobra.Command, args []string) {
+		running, h := syncMgr.Status()
+		fmt.Printf("running: %v height: %d\n", running, h)
+	}}
+
+	onceCmd := &cobra.Command{Use: "once", Short: "Run one sync round", RunE: func(cmd *cobra.Command, args []string) error {
+		return syncMgr.Once()
+	}}
+
+	syncCmd.AddCommand(startCmd, stopCmd, statusCmd, onceCmd)
+	rootCmd.AddCommand(syncCmd)
+}

--- a/go.sum
+++ b/go.sum
@@ -43,24 +43,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ========
-
-
-github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
-github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
-github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=


### PR DESCRIPTION
## Summary
- Add ledger compression commands to save and load compressed snapshots
- Implement sync manager CLI for starting, stopping and checking sync status
- Introduce connection pool, compliance, compliance management, central bank and charity pool management CLI modules

## Testing
- `go mod tidy`
- `go test ./cli`


------
https://chatgpt.com/codex/tasks/task_e_68915baf65b8832092c342ae1277b7f9