### PR TITLE
Add CLI commands for stage 8 modules

### DIFF
--- a/cli/gateway.go
+++ b/cli/gateway.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+	nodes "synnergy/internal/nodes"
+)
+
+var gateway = core.NewGatewayNode(nodes.Address("gw1"), core.GatewayConfig{})
+
+func init() {
+	gwCmd := &cobra.Command{
+		Use:   "gateway",
+		Short: "Gateway node endpoint management",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register [name]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Register an endpoint",
+		Run: func(cmd *cobra.Command, args []string) {
+			name := args[0]
+			gateway.RegisterEndpoint(name, func(b []byte) error {
+				fmt.Printf("%s received: %s\n", name, string(b))
+				return nil
+			})
+		},
+	}
+
+	callCmd := &cobra.Command{
+		Use:   "call [name] [data]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Invoke an endpoint",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := gateway.Handle(args[0], []byte(args[1])); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove [name]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove an endpoint",
+		Run: func(cmd *cobra.Command, args []string) {
+			gateway.RemoveEndpoint(args[0])
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered endpoints",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, e := range gateway.Endpoints() {
+				fmt.Println(e)
+			}
+		},
+	}
+
+	gwCmd.AddCommand(registerCmd, callCmd, removeCmd, listCmd)
+	rootCmd.AddCommand(gwCmd)
+}

--- a/cli/genesis.go
+++ b/cli/genesis.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var genesisWallets = core.DefaultGenesisWallets()
+
+func init() {
+	genesisCmd := &cobra.Command{
+		Use:   "genesis",
+		Short: "Genesis wallet utilities",
+	}
+
+	showCmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show default genesis wallet addresses",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Genesis: %s\n", genesisWallets.Genesis)
+			fmt.Printf("InternalDevelopment: %s\n", genesisWallets.InternalDevelopment)
+			fmt.Printf("InternalCharity: %s\n", genesisWallets.InternalCharity)
+			fmt.Printf("ExternalCharity: %s\n", genesisWallets.ExternalCharity)
+			fmt.Printf("LoanPool: %s\n", genesisWallets.LoanPool)
+			fmt.Printf("PassiveIncome: %s\n", genesisWallets.PassiveIncome)
+			fmt.Printf("ValidatorsMiners: %s\n", genesisWallets.ValidatorsMiners)
+			fmt.Printf("NodeHosts: %s\n", genesisWallets.NodeHosts)
+			fmt.Printf("CreatorWallet: %s\n", genesisWallets.CreatorWallet)
+		},
+	}
+
+	allocateCmd := &cobra.Command{
+		Use:   "allocate [total]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Allocate fees to genesis wallets",
+		Run: func(cmd *cobra.Command, args []string) {
+			total, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid total:", err)
+				return
+			}
+			dist := core.AllocateToGenesisWallets(total, genesisWallets)
+			for addr, amt := range dist {
+				fmt.Printf("%s: %d\n", addr, amt)
+			}
+		},
+	}
+
+	genesisCmd.AddCommand(showCmd, allocateCmd)
+	rootCmd.AddCommand(genesisCmd)
+}

--- a/cli/government.go
+++ b/cli/government.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func init() {
+	govCmd := &cobra.Command{
+		Use:   "government",
+		Short: "Government authority node operations",
+	}
+
+	newCmd := &cobra.Command{
+		Use:   "new [address] [role] [department]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Create a government authority node",
+		Run: func(cmd *cobra.Command, args []string) {
+			n := core.NewGovernmentAuthorityNode(args[0], args[1], args[2])
+			fmt.Printf("node address=%s role=%s department=%s\n", n.Address, n.Role, n.Department)
+		},
+	}
+
+	govCmd.AddCommand(newCmd)
+	rootCmd.AddCommand(govCmd)
+}

--- a/cli/high_availability.go
+++ b/cli/high_availability.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var failover *core.FailoverManager
+
+func init() {
+	haCmd := &cobra.Command{
+		Use:   "highavailability",
+		Short: "High availability failover management",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init [primary] [timeoutSec]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Initialise failover manager",
+		Run: func(cmd *cobra.Command, args []string) {
+			t, err := strconv.ParseInt(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid timeout:", err)
+				return
+			}
+			failover = core.NewFailoverManager(args[0], time.Duration(t)*time.Second)
+		},
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Register a backup node",
+		Run: func(cmd *cobra.Command, args []string) {
+			if failover == nil {
+				fmt.Println("manager not initialised")
+				return
+			}
+			failover.RegisterBackup(args[0])
+		},
+	}
+
+	heartbeatCmd := &cobra.Command{
+		Use:   "heartbeat [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Record a heartbeat",
+		Run: func(cmd *cobra.Command, args []string) {
+			if failover == nil {
+				fmt.Println("manager not initialised")
+				return
+			}
+			failover.Heartbeat(args[0])
+		},
+	}
+
+	activeCmd := &cobra.Command{
+		Use:   "active",
+		Short: "Show active node",
+		Run: func(cmd *cobra.Command, args []string) {
+			if failover == nil {
+				fmt.Println("manager not initialised")
+				return
+			}
+			fmt.Println(failover.Active())
+		},
+	}
+
+	haCmd.AddCommand(initCmd, addCmd, heartbeatCmd, activeCmd)
+	rootCmd.AddCommand(haCmd)
+}

--- a/cli/historical.go
+++ b/cli/historical.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+	nodes "synnergy/internal/nodes"
+)
+
+var historicalNode = core.NewHistoricalNode()
+
+func init() {
+	histCmd := &cobra.Command{
+		Use:   "historical",
+		Short: "Historical node operations",
+	}
+
+	archiveCmd := &cobra.Command{
+		Use:   "archive [height] [hash]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Archive a block summary",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid height:", err)
+				return
+			}
+			summary := nodes.BlockSummary{Height: h, Hash: args[1], Timestamp: time.Now()}
+			if err := historicalNode.ArchiveBlock(summary); err != nil {
+				fmt.Println("archive error:", err)
+			}
+		},
+	}
+
+	heightCmd := &cobra.Command{
+		Use:   "height [n]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Fetch block by height",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid height:", err)
+				return
+			}
+			b, ok := historicalNode.GetBlockByHeight(h)
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%d %s %s\n", b.Height, b.Hash, b.Timestamp.Format(time.RFC3339))
+		},
+	}
+
+	hashCmd := &cobra.Command{
+		Use:   "hash [hash]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Fetch block by hash",
+		Run: func(cmd *cobra.Command, args []string) {
+			b, ok := historicalNode.GetBlockByHash(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%d %s %s\n", b.Height, b.Hash, b.Timestamp.Format(time.RFC3339))
+		},
+	}
+
+	totalCmd := &cobra.Command{
+		Use:   "total",
+		Short: "Show total archived blocks",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(historicalNode.TotalBlocks())
+		},
+	}
+
+	histCmd.AddCommand(archiveCmd, heightCmd, hashCmd, totalCmd)
+	rootCmd.AddCommand(histCmd)
+}

--- a/cli/identity.go
+++ b/cli/identity.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var identitySvc = core.NewIdentityService()
+
+func init() {
+	idCmd := &cobra.Command{
+		Use:   "identity",
+		Short: "Identity verification service",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register [addr] [name] [dob] [nationality]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Register identity information",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := identitySvc.Register(args[0], args[1], args[2], args[3]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	verifyCmd := &cobra.Command{
+		Use:   "verify [addr] [method]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Record a verification method",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := identitySvc.Verify(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show identity information",
+		Run: func(cmd *cobra.Command, args []string) {
+			info, ok := identitySvc.Info(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("Name: %s DOB: %s Nationality: %s\n", info.Name, info.DateOfBirth, info.Nationality)
+		},
+	}
+
+	logsCmd := &cobra.Command{
+		Use:   "logs [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show verification logs",
+		Run: func(cmd *cobra.Command, args []string) {
+			logs := identitySvc.Logs(args[0])
+			for _, l := range logs {
+				fmt.Printf("%s %s\n", l.Method, l.Timestamp.Format("2006-01-02T15:04:05"))
+			}
+		},
+	}
+
+	idCmd.AddCommand(registerCmd, verifyCmd, infoCmd, logsCmd)
+	rootCmd.AddCommand(idCmd)
+}

--- a/cli/idwallet.go
+++ b/cli/idwallet.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var idRegistry = core.NewIDRegistry()
+
+func init() {
+	idwCmd := &cobra.Command{
+		Use:   "idwallet",
+		Short: "ID wallet registration",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register [address] [info]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Register an ID wallet",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := idRegistry.Register(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	checkCmd := &cobra.Command{
+		Use:   "check [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Check registration info",
+		Run: func(cmd *cobra.Command, args []string) {
+			info, ok := idRegistry.Info(args[0])
+			if !ok {
+				fmt.Println("not registered")
+				return
+			}
+			fmt.Println(info)
+		},
+	}
+
+	idwCmd.AddCommand(registerCmd, checkCmd)
+	rootCmd.AddCommand(idwCmd)
+}

--- a/cli/immutability.go
+++ b/cli/immutability.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var enforcer *core.ImmutabilityEnforcer
+
+func init() {
+	immCmd := &cobra.Command{
+		Use:   "immutability",
+		Short: "Immutability enforcement utilities",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise enforcer with ledger genesis",
+		Run: func(cmd *cobra.Command, args []string) {
+			gen := core.NewBlock(nil, "")
+			gen.Hash = gen.HeaderHash(0)
+			ledger.AddBlock(gen)
+			enforcer = core.NewImmutabilityEnforcer(gen)
+			fmt.Println("genesis hash", gen.Hash)
+		},
+	}
+
+	checkCmd := &cobra.Command{
+		Use:   "check",
+		Short: "Verify ledger against genesis hash",
+		Run: func(cmd *cobra.Command, args []string) {
+			if enforcer == nil {
+				fmt.Println("enforcer not initialised")
+				return
+			}
+			if err := enforcer.CheckLedger(ledger); err != nil {
+				fmt.Println("check failed:", err)
+				return
+			}
+			fmt.Println("ledger matches genesis hash")
+		},
+	}
+
+	immCmd.AddCommand(initCmd, checkCmd)
+	rootCmd.AddCommand(immCmd)
+}

--- a/cli/initrep.go
+++ b/cli/initrep.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	replicator = core.NewReplicator(ledger)
+	initSvc    = core.NewInitService(replicator)
+)
+
+func init() {
+	initrepCmd := &cobra.Command{
+		Use:   "initrep",
+		Short: "Initialization replication control",
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Bootstrap ledger and start replication",
+		Run: func(cmd *cobra.Command, args []string) {
+			initSvc.Start()
+		},
+	}
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop initialization service",
+		Run: func(cmd *cobra.Command, args []string) {
+			initSvc.Stop()
+		},
+	}
+
+	initrepCmd.AddCommand(startCmd, stopCmd)
+	rootCmd.AddCommand(initrepCmd)
+}


### PR DESCRIPTION
## Summary
- add gateway CLI for registering, invoking, removing and listing endpoints
- implement genesis wallet CLI to display addresses and allocate fee totals
- add government, high availability, historical, identity, idwallet, immutability and initrep CLI utilities

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915be44b488320b0136393454cf7ce