### PR TITLE
Add Stage 11 CLI commands

### DIFF
--- a/cli/peer_management.go
+++ b/cli/peer_management.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var peerMgr = core.NewPeerManager()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "peer",
+		Short: "Peer discovery and connections",
+	}
+
+	discoverCmd := &cobra.Command{
+		Use:   "discover [topic]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List known peers or those advertising a topic",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 1 {
+				for _, id := range peerMgr.Discover(args[0]) {
+					fmt.Println(id)
+				}
+				return
+			}
+			for _, id := range peerMgr.ListPeers() {
+				fmt.Println(id)
+			}
+		},
+	}
+
+	connectCmd := &cobra.Command{
+		Use:   "connect [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Connect to a peer by address",
+		Run: func(cmd *cobra.Command, args []string) {
+			id := peerMgr.Connect(args[0])
+			fmt.Println("connected", id)
+		},
+	}
+
+	advertiseCmd := &cobra.Command{
+		Use:   "advertise [topic]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Advertise current node on a topic",
+		Run: func(cmd *cobra.Command, args []string) {
+			peerMgr.Advertise(currentNode.ID, args[0])
+		},
+	}
+
+	cmd.AddCommand(discoverCmd, connectCmd, advertiseCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/plasma.go
+++ b/cli/plasma.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var plasmaBridge = core.NewPlasmaBridge()
+
+var plasmaCmd = &cobra.Command{
+	Use:   "plasma",
+	Short: "Interact with the Plasma bridge",
+}
+
+func init() {
+	rootCmd.AddCommand(plasmaCmd)
+}

--- a/cli/plasma_management.go
+++ b/cli/plasma_management.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	mgmtCmd := &cobra.Command{
+		Use:   "plasma-mgmt",
+		Short: "Manage Plasma bridge operations",
+	}
+
+	pauseCmd := &cobra.Command{
+		Use:   "pause",
+		Short: "Pause Plasma bridge operations",
+		Run:   func(cmd *cobra.Command, args []string) { plasmaBridge.Pause() },
+	}
+
+	resumeCmd := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume Plasma bridge operations",
+		Run:   func(cmd *cobra.Command, args []string) { plasmaBridge.Resume() },
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show whether Plasma bridge is paused",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(plasmaBridge.Status())
+		},
+	}
+
+	mgmtCmd.AddCommand(pauseCmd, resumeCmd, statusCmd)
+	plasmaCmd.AddCommand(mgmtCmd)
+}

--- a/cli/plasma_operations.go
+++ b/cli/plasma_operations.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	opsCmd := &cobra.Command{
+		Use:   "plasma-ops",
+		Short: "Plasma bridge deposits and exits",
+	}
+
+	depositCmd := &cobra.Command{
+		Use:   "deposit [owner] [token] [amount]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Deposit tokens into the Plasma bridge",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[2], 10, 64)
+			if err := plasmaBridge.Deposit(args[0], args[1], amt); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	exitCmd := &cobra.Command{
+		Use:   "exit [owner] [token] [amount]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Start an exit from the bridge",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[2], 10, 64)
+			nonce, err := plasmaBridge.StartExit(args[0], args[1], amt)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(nonce)
+		},
+	}
+
+	finalizeCmd := &cobra.Command{
+		Use:   "finalize [nonce]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Finalize a pending exit",
+		Run: func(cmd *cobra.Command, args []string) {
+			n, _ := strconv.ParseUint(args[0], 10, 64)
+			if err := plasmaBridge.FinalizeExit(n); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get [nonce]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get details of an exit",
+		Run: func(cmd *cobra.Command, args []string) {
+			n, _ := strconv.ParseUint(args[0], 10, 64)
+			ex, err := plasmaBridge.GetExit(n)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Printf("%+v\n", ex)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list [owner]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List exits, optionally by owner",
+		Run: func(cmd *cobra.Command, args []string) {
+			owner := ""
+			if len(args) == 1 {
+				owner = args[0]
+			}
+			for _, ex := range plasmaBridge.ListExits(owner) {
+				fmt.Printf("%+v\n", ex)
+			}
+		},
+	}
+
+	opsCmd.AddCommand(depositCmd, exitCmd, finalizeCmd, getCmd, listCmd)
+	plasmaCmd.AddCommand(opsCmd)
+}

--- a/cli/private_transactions.go
+++ b/cli/private_transactions.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var privTxMgr = core.NewPrivateTxManager()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "private-tx",
+		Short: "Manage private transactions",
+	}
+
+	encryptCmd := &cobra.Command{
+		Use:   "encrypt [key] [data]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Encrypt transaction payload bytes",
+		Run: func(cmd *cobra.Command, args []string) {
+			ct, err := core.Encrypt([]byte(args[0]), []byte(args[1]))
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(hex.EncodeToString(ct))
+		},
+	}
+
+	decryptCmd := &cobra.Command{
+		Use:   "decrypt [key] [hexdata]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Decrypt previously encrypted payload",
+		Run: func(cmd *cobra.Command, args []string) {
+			data, err := hex.DecodeString(args[1])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			pt, err := core.Decrypt([]byte(args[0]), data)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(string(pt))
+		},
+	}
+
+	sendCmd := &cobra.Command{
+		Use:   "send [file]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Submit an encrypted transaction JSON file",
+		Run: func(cmd *cobra.Command, args []string) {
+			b, err := os.ReadFile(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			var j struct {
+				Payload string `json:"payload"`
+				Nonce   string `json:"nonce"`
+			}
+			if err := json.Unmarshal(b, &j); err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			payload, err := hex.DecodeString(j.Payload)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			nonce, err := hex.DecodeString(j.Nonce)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			privTxMgr.Send(core.PrivateTransaction{Payload: payload, Nonce: nonce})
+		},
+	}
+
+	cmd.AddCommand(encryptCmd, decryptCmd, sendCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/quorum_tracker.go
+++ b/cli/quorum_tracker.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	quorumTracker  *core.QuorumTracker
+	quorumRequired int
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "quorum",
+		Short: "Manage quorum tracker",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init [total] [threshold]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Initialise a quorum tracker",
+		Run: func(cmd *cobra.Command, args []string) {
+			t, _ := strconv.Atoi(args[1])
+			quorumRequired = t
+			quorumTracker = core.NewQuorumTracker(t)
+		},
+	}
+
+	voteCmd := &cobra.Command{
+		Use:   "vote [address]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Record a vote from an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			if quorumTracker != nil {
+				quorumTracker.Join(args[0])
+			}
+		},
+	}
+
+	checkCmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check if quorum is reached",
+		Run: func(cmd *cobra.Command, args []string) {
+			if quorumTracker == nil {
+				fmt.Println(false)
+				return
+			}
+			fmt.Println(quorumTracker.Reached())
+		},
+	}
+
+	resetCmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Clear all recorded votes",
+		Run: func(cmd *cobra.Command, args []string) {
+			if quorumTracker != nil {
+				quorumTracker = core.NewQuorumTracker(quorumRequired)
+			}
+		},
+	}
+
+	cmd.AddCommand(initCmd, voteCmd, checkCmd, resetCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/regulatory_management.go
+++ b/cli/regulatory_management.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var regManager = core.NewRegulatoryManager()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "regulator",
+		Short: "Manage regulations",
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add [id] [jurisdiction] [description] [maxAmount]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Add a new regulation",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[3], 10, 64)
+			reg := core.Regulation{ID: args[0], Jurisdiction: args[1], Description: args[2], MaxAmount: amt}
+			if err := regManager.AddRegulation(reg); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a regulation",
+		Run:   func(cmd *cobra.Command, args []string) { regManager.RemoveRegulation(args[0]) },
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all regulations",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, r := range regManager.ListRegulations() {
+				fmt.Printf("%s %s %d\n", r.ID, r.Jurisdiction, r.MaxAmount)
+			}
+		},
+	}
+
+	evalCmd := &cobra.Command{
+		Use:   "evaluate [amount]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Check amount against regulations",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[0], 10, 64)
+			tx := core.Transaction{Amount: amt}
+			v := regManager.EvaluateTransaction(tx)
+			if len(v) == 0 {
+				fmt.Println("ok")
+				return
+			}
+			fmt.Println(v)
+		},
+	}
+
+	cmd.AddCommand(addCmd, removeCmd, listCmd, evalCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/regulatory_node.go
+++ b/cli/regulatory_node.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var regNode = core.NewRegulatoryNode("regnode1", regManager)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "regnode",
+		Short: "Regulatory node operations",
+	}
+
+	approveCmd := &cobra.Command{
+		Use:   "approve [amount]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Approve or reject a transaction by amount",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[0], 10, 64)
+			tx := core.Transaction{Amount: amt}
+			fmt.Println(regNode.ApproveTransaction(tx))
+		},
+	}
+
+	flagCmd := &cobra.Command{
+		Use:   "flag [addr] [reason]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Flag an address for a reason",
+		Run:   func(cmd *cobra.Command, args []string) { regNode.FlagEntity(args[0], args[1]) },
+	}
+
+	logsCmd := &cobra.Command{
+		Use:   "logs [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show logs for an address",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, l := range regNode.Logs(args[0]) {
+				fmt.Println(l)
+			}
+		},
+	}
+
+	cmd.AddCommand(approveCmd, flagCmd, logsCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/replication.go
+++ b/cli/replication.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "replication",
+		Short: "Control block replication",
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Launch replication goroutines",
+		Run:   func(cmd *cobra.Command, args []string) { replicator.Start() },
+	}
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the replication subsystem",
+		Run:   func(cmd *cobra.Command, args []string) { replicator.Stop() },
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show replication status",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(replicator.Status())
+		},
+	}
+
+	replicateCmd := &cobra.Command{
+		Use:   "replicate [hash]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Gossip a known block",
+		Run: func(cmd *cobra.Command, args []string) {
+			if replicator.ReplicateBlock(args[0]) {
+				fmt.Println("replicated")
+			} else {
+				fmt.Println("replication not running")
+			}
+		},
+	}
+
+	cmd.AddCommand(startCmd, stopCmd, statusCmd, replicateCmd)
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add peer discovery and connection commands
- expose plasma bridge operations and management
- provide helpers for private tx, quorum tracking, regulatory controls, and replication

## Testing
- `go test ./...` *(fails: contractVM redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_e_68915f3472ec8320823ad26d7250bd29