### PR TITLE
Add Stage 12 CLI command groups

### DIFF
--- a/cli/replication.go
+++ b/cli/replication.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	repCmd := &cobra.Command{
+		Use:   "replication",
+		Short: "Control block replication",
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the replicator",
+		Run: func(cmd *cobra.Command, args []string) {
+			replicator.Start()
+		},
+	}
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the replicator",
+		Run: func(cmd *cobra.Command, args []string) {
+			replicator.Stop()
+		},
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show replicator status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if replicator.Status() {
+				fmt.Println("running")
+			} else {
+				fmt.Println("stopped")
+			}
+		},
+	}
+
+	replicateCmd := &cobra.Command{
+		Use:   "replicate [hash]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Mark a block as replicated",
+		Run: func(cmd *cobra.Command, args []string) {
+			if replicator.ReplicateBlock(args[0]) {
+				fmt.Println("replicated")
+			} else {
+				fmt.Println("replication inactive")
+			}
+		},
+	}
+
+	repCmd.AddCommand(startCmd, stopCmd, statusCmd, replicateCmd)
+	rootCmd.AddCommand(repCmd)
+}

--- a/cli/rollup_management.go
+++ b/cli/rollup_management.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rmCmd := &cobra.Command{
+		Use:   "rollup_management",
+		Short: "Control rollup aggregator",
+	}
+
+	pauseCmd := &cobra.Command{
+		Use:   "pause",
+		Short: "Pause the rollup aggregator",
+		Run: func(cmd *cobra.Command, args []string) {
+			rollupMgr.Pause()
+		},
+	}
+
+	resumeCmd := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume the rollup aggregator",
+		Run: func(cmd *cobra.Command, args []string) {
+			rollupMgr.Resume()
+		},
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show aggregator status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if rollupMgr.Status() {
+				fmt.Println("paused")
+			} else {
+				fmt.Println("running")
+			}
+		},
+	}
+
+	rmCmd.AddCommand(pauseCmd, resumeCmd, statusCmd)
+	rootCmd.AddCommand(rmCmd)
+}

--- a/cli/rollups.go
+++ b/cli/rollups.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	rollupAgg = core.NewRollupAggregator()
+	rollupMgr = core.NewRollupManager(rollupAgg)
+)
+
+func init() {
+	rollupsCmd := &cobra.Command{
+		Use:   "rollups",
+		Short: "Manage rollup batches",
+	}
+
+	submitCmd := &cobra.Command{
+		Use:   "submit [tx1 tx2 ...]",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Submit a new rollup batch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := rollupAgg.SubmitBatch(args)
+			if err != nil {
+				return err
+			}
+			fmt.Println(id)
+			return nil
+		},
+	}
+
+	challengeCmd := &cobra.Command{
+		Use:   "challenge <batchID> <txIdx> <proof>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Submit a fraud proof for a batch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			idx, err := strconv.Atoi(args[1])
+			if err != nil {
+				return err
+			}
+			return rollupAgg.ChallengeBatch(args[0], idx, []byte(args[2]))
+		},
+	}
+
+	finalizeCmd := &cobra.Command{
+		Use:   "finalize <batchID> <valid>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Finalize or revert a batch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			valid, err := strconv.ParseBool(args[1])
+			if err != nil {
+				return err
+			}
+			return rollupAgg.FinalizeBatch(args[0], valid)
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <batchID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Display batch header and state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			b, ok := rollupAgg.BatchInfo(args[0])
+			if !ok {
+				return fmt.Errorf("batch not found")
+			}
+			fmt.Printf("%s %s %d\n", b.ID, b.Status, len(b.Transactions))
+			return nil
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List recent batches",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, b := range rollupAgg.ListBatches() {
+				fmt.Printf("%s %s %d\n", b.ID, b.Status, len(b.Transactions))
+			}
+		},
+	}
+
+	txsCmd := &cobra.Command{
+		Use:   "txs <batchID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "List transactions in a batch",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			txs, err := rollupAgg.BatchTransactions(args[0])
+			if err != nil {
+				return err
+			}
+			for _, tx := range txs {
+				fmt.Println(tx)
+			}
+			return nil
+		},
+	}
+
+	rollupsCmd.AddCommand(submitCmd, challengeCmd, finalizeCmd, infoCmd, listCmd, txsCmd)
+	rootCmd.AddCommand(rollupsCmd)
+}

--- a/cli/rpc_webrtc.go
+++ b/cli/rpc_webrtc.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	webrtcRPC   = core.NewWebRTCRPC()
+	webrtcPeers = make(map[string]<-chan []byte)
+)
+
+func init() {
+	rpcCmd := &cobra.Command{
+		Use:   "rpc_webrtc",
+		Short: "Simulate WebRTC-style RPC",
+	}
+
+	connectCmd := &cobra.Command{
+		Use:   "connect <peerID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Connect a peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			ch := webrtcRPC.Connect(args[0])
+			webrtcPeers[args[0]] = ch
+			fmt.Println("connected")
+		},
+	}
+
+	sendCmd := &cobra.Command{
+		Use:   "send <peerID> <msg>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Send a message to a peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			if !webrtcRPC.Send(args[0], []byte(args[1])) {
+				fmt.Println("peer not found")
+			}
+		},
+	}
+
+	recvCmd := &cobra.Command{
+		Use:   "recv <peerID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Receive a message from a peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			ch, ok := webrtcPeers[args[0]]
+			if !ok {
+				fmt.Println("peer not found")
+				return
+			}
+			select {
+			case msg := <-ch:
+				fmt.Println(string(msg))
+			default:
+				fmt.Println("no message")
+			}
+		},
+	}
+
+	disconnectCmd := &cobra.Command{
+		Use:   "disconnect <peerID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Disconnect a peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			webrtcRPC.Disconnect(args[0])
+			delete(webrtcPeers, args[0])
+		},
+	}
+
+	rpcCmd.AddCommand(connectCmd, sendCmd, recvCmd, disconnectCmd)
+	rootCmd.AddCommand(rpcCmd)
+}

--- a/cli/sharding.go
+++ b/cli/sharding.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var shardMgr = core.NewShardManager(2)
+
+func init() {
+	shardCmd := &cobra.Command{
+		Use:   "sharding",
+		Short: "Manage sharded network state",
+	}
+
+	leaderCmd := &cobra.Command{Use: "leader"}
+
+	leaderGetCmd := &cobra.Command{
+		Use:   "get <shardID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show leader for a shard",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.Atoi(args[0])
+			addr, ok := shardMgr.GetLeader(id)
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Println(addr)
+		},
+	}
+
+	leaderSetCmd := &cobra.Command{
+		Use:   "set <shardID> <addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Set leader for a shard",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.Atoi(args[0])
+			shardMgr.SetLeader(id, args[1])
+		},
+	}
+
+	leaderCmd.AddCommand(leaderGetCmd, leaderSetCmd)
+
+	mapCmd := &cobra.Command{
+		Use:   "map",
+		Short: "List shard leaders",
+		Run: func(cmd *cobra.Command, args []string) {
+			for id, addr := range shardMgr.LeaderMap() {
+				fmt.Printf("%d %s\n", id, addr)
+			}
+		},
+	}
+
+	submitCmd := &cobra.Command{
+		Use:   "submit <fromShard> <toShard> <txHash>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Submit cross-shard tx header",
+		Run: func(cmd *cobra.Command, args []string) {
+			from, _ := strconv.Atoi(args[0])
+			to, _ := strconv.Atoi(args[1])
+			shardMgr.SubmitCrossShardTx(from, to, args[2])
+		},
+	}
+
+	pullCmd := &cobra.Command{
+		Use:   "pull <shardID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Pull receipts for shard",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.Atoi(args[0])
+			for _, tx := range shardMgr.PullReceipts(id) {
+				fmt.Println(tx)
+			}
+		},
+	}
+
+	reshardCmd := &cobra.Command{
+		Use:   "reshard <bits>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Set shard bit-size",
+		Run: func(cmd *cobra.Command, args []string) {
+			bits, _ := strconv.Atoi(args[0])
+			shardMgr.Reshard(uint8(bits))
+		},
+	}
+
+	rebalanceCmd := &cobra.Command{
+		Use:   "rebalance <threshold>",
+		Args:  cobra.ExactArgs(1),
+		Short: "List shards exceeding load",
+		Run: func(cmd *cobra.Command, args []string) {
+			th, _ := strconv.Atoi(args[0])
+			for _, id := range shardMgr.Rebalance(th) {
+				fmt.Println(id)
+			}
+		},
+	}
+
+	shardCmd.AddCommand(leaderCmd, mapCmd, submitCmd, pullCmd, reshardCmd, rebalanceCmd)
+	rootCmd.AddCommand(shardCmd)
+}

--- a/cli/sidechain_ops.go
+++ b/cli/sidechain_ops.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	opsCmd := &cobra.Command{
+		Use:   "sidechain_ops",
+		Short: "Operate on side-chain escrows",
+	}
+
+	depositCmd := &cobra.Command{
+		Use:   "deposit <chainID> <addr> <amount>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Deposit tokens to a side-chain escrow",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				return err
+			}
+			return sidechainOps.Deposit(args[0], args[1], amt)
+		},
+	}
+
+	withdrawCmd := &cobra.Command{
+		Use:   "withdraw <chainID> <addr> <amount> <proof>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Withdraw from a side-chain escrow",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				return err
+			}
+			return sidechainOps.Withdraw(args[0], args[1], amt, args[3])
+		},
+	}
+
+	balanceCmd := &cobra.Command{
+		Use:   "balance <chainID> <addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Show escrow balance for address",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bal, err := sidechainOps.EscrowBalance(args[0], args[1])
+			if err != nil {
+				return err
+			}
+			fmt.Println(bal)
+			return nil
+		},
+	}
+
+	opsCmd.AddCommand(depositCmd, withdrawCmd, balanceCmd)
+	rootCmd.AddCommand(opsCmd)
+}

--- a/cli/sidechains.go
+++ b/cli/sidechains.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	sidechainRegistry = core.NewSidechainRegistry()
+	sidechainOps      = core.NewSidechainOps(sidechainRegistry)
+)
+
+func init() {
+	scCmd := &cobra.Command{
+		Use:   "sidechain",
+		Short: "Manage side-chains",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <id> <meta> [validators...]",
+		Args:  cobra.MinimumNArgs(2),
+		Short: "Register a new side-chain",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sc, err := sidechainRegistry.Register(args[0], args[1], args[2:])
+			if err != nil {
+				return err
+			}
+			fmt.Println(sc.ID)
+			return nil
+		},
+	}
+
+	headerCmd := &cobra.Command{
+		Use:   "header <id> <header>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Submit a side-chain header",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return sidechainRegistry.SubmitHeader(args[0], args[1])
+		},
+	}
+
+	getHeaderCmd := &cobra.Command{
+		Use:   "get-header <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get the latest header for a side-chain",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, ok := sidechainRegistry.GetHeader(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Println(h)
+		},
+	}
+
+	metaCmd := &cobra.Command{
+		Use:   "meta <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Display side-chain metadata",
+		Run: func(cmd *cobra.Command, args []string) {
+			sc, ok := sidechainRegistry.Meta(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%s %s %v paused=%v\n", sc.ID, sc.Metadata, sc.Validators, sc.Paused)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered side-chains",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, sc := range sidechainRegistry.List() {
+				fmt.Printf("%s %s paused=%v\n", sc.ID, sc.Header, sc.Paused)
+			}
+		},
+	}
+
+	pauseCmd := &cobra.Command{
+		Use:   "pause <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Pause a side-chain",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return sidechainRegistry.Pause(args[0])
+		},
+	}
+
+	resumeCmd := &cobra.Command{
+		Use:   "resume <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Resume a paused side-chain",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return sidechainRegistry.Resume(args[0])
+		},
+	}
+
+	updateValidatorsCmd := &cobra.Command{
+		Use:   "update-validators <id> <v1> [v2...]",
+		Args:  cobra.MinimumNArgs(2),
+		Short: "Update validator set for a side-chain",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return sidechainRegistry.UpdateValidators(args[0], args[1:])
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a side-chain",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return sidechainRegistry.Remove(args[0])
+		},
+	}
+
+	scCmd.AddCommand(registerCmd, headerCmd, getHeaderCmd, metaCmd, listCmd, pauseCmd, resumeCmd, updateValidatorsCmd, removeCmd)
+	rootCmd.AddCommand(scCmd)
+}


### PR DESCRIPTION
## Summary
- add replication CLI with start, stop, status and replicate subcommands
- add rollups CLI for batch submission, challenge, finalize, info, list and tx listing
- add rollup management CLI to pause/resume aggregator and query status
- add rpc_webrtc CLI for peer connect, send, receive and disconnect
- add sharding CLI with leader, map, submit, pull, reshard and rebalance commands
- add sidechain registry CLI to register and administer side-chains
- add sidechain_ops CLI for deposit, withdraw and balance operations

## Testing
- `go test ./cli/...` *(fails: contractVM redeclared in cli/contracts.go)*

------
https://chatgpt.com/codex/tasks/task_e_68915f3e530c8320820c6cde7eaea8db