### PR TITLE
Add CLI commands for Stage 13 modules

### DIFF
--- a/cli/stake_penalty.go
+++ b/cli/stake_penalty.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var stakePenaltyMgr = core.NewStakePenaltyManager()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "stake_penalty",
+		Short: "Apply staking penalties or rewards",
+	}
+
+	slashCmd := &cobra.Command{
+		Use:   "slash <addr> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Slash staked tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			stakePenaltyMgr.Slash(stakingNode, args[0], amt)
+			fmt.Println("slashed")
+		},
+	}
+
+	rewardCmd := &cobra.Command{
+		Use:   "reward <addr> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Reward staked tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			stakePenaltyMgr.Reward(stakingNode, args[0], amt)
+			fmt.Println("rewarded")
+		},
+	}
+
+	cmd.AddCommand(slashCmd, rewardCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/staking_node.go
+++ b/cli/staking_node.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var stakingNode = core.NewStakingNode()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "staking_node",
+		Short: "Manage staking balances",
+	}
+
+	stakeCmd := &cobra.Command{
+		Use:   "stake <addr> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Stake tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			stakingNode.Stake(args[0], amt)
+			fmt.Println("staked")
+		},
+	}
+
+	unstakeCmd := &cobra.Command{
+		Use:   "unstake <addr> <amount>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Unstake tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			stakingNode.Unstake(args[0], amt)
+			fmt.Println("unstaked")
+		},
+	}
+
+	balanceCmd := &cobra.Command{
+		Use:   "balance <addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show staked balance",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(stakingNode.Balance(args[0]))
+		},
+	}
+
+	totalCmd := &cobra.Command{
+		Use:   "total",
+		Short: "Show total staked tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(stakingNode.TotalStaked())
+		},
+	}
+
+	cmd.AddCommand(stakeCmd, unstakeCmd, balanceCmd, totalCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/state_rw.go
+++ b/cli/state_rw.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+type stateStore struct {
+	balances map[core.Address]uint64
+	kv       map[string][]byte
+}
+
+type stateIter struct {
+	keys []string
+	idx  int
+	kv   map[string][]byte
+}
+
+func (m *stateIter) Next() bool {
+	if m.idx >= len(m.keys) {
+		return false
+	}
+	m.idx++
+	return true
+}
+
+func (m *stateIter) Value() []byte {
+	return m.kv[m.keys[m.idx-1]]
+}
+
+func newStateStore() *stateStore {
+	return &stateStore{balances: make(map[core.Address]uint64), kv: make(map[string][]byte)}
+}
+
+func (m *stateStore) Transfer(from, to core.Address, amount uint64) error {
+	if m.balances[from] < amount {
+		return errors.New("insufficient balance")
+	}
+	m.balances[from] -= amount
+	m.balances[to] += amount
+	return nil
+}
+
+func (m *stateStore) SetState(key, value []byte) {
+	m.kv[string(key)] = value
+}
+
+func (m *stateStore) GetState(key []byte) ([]byte, error) {
+	v, ok := m.kv[string(key)]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return v, nil
+}
+
+func (m *stateStore) HasState(key []byte) (bool, error) {
+	_, ok := m.kv[string(key)]
+	return ok, nil
+}
+
+func (m *stateStore) PrefixIterator(prefix []byte) core.StateIterator {
+	keys := make([]string, 0)
+	for k := range m.kv {
+		if strings.HasPrefix(k, string(prefix)) {
+			keys = append(keys, k)
+		}
+	}
+	return &stateIter{keys: keys, kv: m.kv}
+}
+
+func (m *stateStore) BalanceOf(addr core.Address) uint64 {
+	return m.balances[addr]
+}
+
+var state = newStateStore()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "state",
+		Short: "In-memory StateRW utilities",
+	}
+
+	setCmd := &cobra.Command{
+		Use:   "set <key> <value>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Set a key/value pair",
+		Run: func(cmd *cobra.Command, args []string) {
+			state.SetState([]byte(args[0]), []byte(args[1]))
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <key>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get value for a key",
+		Run: func(cmd *cobra.Command, args []string) {
+			v, err := state.GetState([]byte(args[0]))
+			if err != nil {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Println(string(v))
+		},
+	}
+
+	hasCmd := &cobra.Command{
+		Use:   "has <key>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Check if key exists",
+		Run: func(cmd *cobra.Command, args []string) {
+			ok, _ := state.HasState([]byte(args[0]))
+			fmt.Println(ok)
+		},
+	}
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <from> <to> <amount>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Transfer balance",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			if err := state.Transfer(core.Address(args[0]), core.Address(args[1]), amt); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	balanceCmd := &cobra.Command{
+		Use:   "balance <addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show balance",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(state.BalanceOf(core.Address(args[0])))
+		},
+	}
+
+	iterCmd := &cobra.Command{
+		Use:   "iterate <prefix>",
+		Args:  cobra.ExactArgs(1),
+		Short: "List key/values with prefix",
+		Run: func(cmd *cobra.Command, args []string) {
+			it := state.PrefixIterator([]byte(args[0]))
+			for it.Next() {
+				fmt.Println(string(it.Value()))
+			}
+		},
+	}
+
+	cmd.AddCommand(setCmd, getCmd, hasCmd, transferCmd, balanceCmd, iterCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var swarm = core.NewSwarm()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "swarm",
+		Short: "Manage swarms of nodes",
+	}
+
+	joinCmd := &cobra.Command{
+		Use:   "join <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Join a node to the swarm",
+		Run: func(cmd *cobra.Command, args []string) {
+			n := core.NewNode(args[0], args[0], core.NewLedger())
+			swarm.Join(n)
+			fmt.Println("node joined")
+		},
+	}
+
+	leaveCmd := &cobra.Command{
+		Use:   "leave <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a node from the swarm",
+		Run: func(cmd *cobra.Command, args []string) {
+			swarm.Leave(args[0])
+		},
+	}
+
+	peersCmd := &cobra.Command{
+		Use:   "peers",
+		Short: "List peer IDs",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, id := range swarm.Peers() {
+				fmt.Println(id)
+			}
+		},
+	}
+
+	broadcastCmd := &cobra.Command{
+		Use:   "broadcast <from> <to> <amount>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Broadcast a transaction to all members",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			tx := core.NewTransaction(args[0], args[1], amt, 0, 0)
+			swarm.Broadcast(tx)
+		},
+	}
+
+	consensusCmd := &cobra.Command{
+		Use:   "consensus",
+		Short: "Start consensus on the swarm",
+		Run: func(cmd *cobra.Command, args []string) {
+			blocks := swarm.StartConsensus()
+			fmt.Printf("mined %d blocks\n", len(blocks))
+		},
+	}
+
+	cmd.AddCommand(joinCmd, leaveCmd, peersCmd, broadcastCmd, consensusCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn1300.go
+++ b/cli/syn1300.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn1300 = core.NewSupplyChainRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn1300",
+		Short: "Supply chain asset registry",
+	}
+
+	regCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a new asset",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			desc, _ := cmd.Flags().GetString("desc")
+			owner, _ := cmd.Flags().GetString("owner")
+			loc, _ := cmd.Flags().GetString("loc")
+			if _, err := syn1300.Register(id, desc, owner, loc); err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Println("asset registered")
+		},
+	}
+	regCmd.Flags().String("id", "", "asset id")
+	regCmd.Flags().String("desc", "", "description")
+	regCmd.Flags().String("owner", "", "owner")
+	regCmd.Flags().String("loc", "", "initial location")
+	cmd.AddCommand(regCmd)
+
+	updCmd := &cobra.Command{
+		Use:   "update <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Update asset status",
+		Run: func(cmd *cobra.Command, args []string) {
+			loc, _ := cmd.Flags().GetString("loc")
+			status, _ := cmd.Flags().GetString("status")
+			note, _ := cmd.Flags().GetString("note")
+			if err := syn1300.Update(args[0], loc, status, note); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+	updCmd.Flags().String("loc", "", "location")
+	updCmd.Flags().String("status", "", "status")
+	updCmd.Flags().String("note", "", "note")
+	cmd.AddCommand(updCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get asset info",
+		Run: func(cmd *cobra.Command, args []string) {
+			asset, ok := syn1300.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%s owned by %s at %s status %s events %d\n", asset.ID, asset.Owner, asset.Location, asset.Status, len(asset.History))
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn131_token.go
+++ b/cli/syn131_token.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn131 = core.NewSYN131Registry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn131",
+		Short: "SYN131 intangible asset tokens",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new token",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			owner, _ := cmd.Flags().GetString("owner")
+			val, _ := cmd.Flags().GetUint64("valuation")
+			if _, err := syn131.Create(id, name, symbol, owner, val); err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Println("token created")
+		},
+	}
+	createCmd.Flags().String("id", "", "token id")
+	createCmd.Flags().String("name", "", "name")
+	createCmd.Flags().String("symbol", "", "symbol")
+	createCmd.Flags().String("owner", "", "owner")
+	createCmd.Flags().Uint64("valuation", 0, "valuation")
+	cmd.AddCommand(createCmd)
+
+	valCmd := &cobra.Command{
+		Use:   "value <id> <valuation>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Update valuation",
+		Run: func(cmd *cobra.Command, args []string) {
+			val, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid valuation")
+				return
+			}
+			if err := syn131.UpdateValuation(args[0], val); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+	cmd.AddCommand(valCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get token info",
+		Run: func(cmd *cobra.Command, args []string) {
+			tok, ok := syn131.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%s %s %s owner:%s val:%d\n", tok.ID, tok.Name, tok.Symbol, tok.Owner, tok.Valuation)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn1401.go
+++ b/cli/syn1401.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var investments = core.NewInvestmentRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn1401",
+		Short: "SYN1401 investment tokens",
+	}
+
+	issueCmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Issue a new investment",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			owner, _ := cmd.Flags().GetString("owner")
+			principal, _ := cmd.Flags().GetUint64("principal")
+			rate, _ := cmd.Flags().GetFloat64("rate")
+			maturityUnix, _ := cmd.Flags().GetInt64("maturity")
+			maturity := time.Unix(maturityUnix, 0)
+			if _, err := investments.Issue(id, owner, principal, rate, maturity); err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Println("investment issued")
+		},
+	}
+	issueCmd.Flags().String("id", "", "investment id")
+	issueCmd.Flags().String("owner", "", "owner")
+	issueCmd.Flags().Uint64("principal", 0, "principal")
+	issueCmd.Flags().Float64("rate", 0, "annual rate")
+	issueCmd.Flags().Int64("maturity", time.Now().Unix(), "maturity unix time")
+	cmd.AddCommand(issueCmd)
+
+	accrueCmd := &cobra.Command{
+		Use:   "accrue <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Accrue interest to now",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := investments.Accrue(args[0], time.Now())
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Println(amt)
+		},
+	}
+	cmd.AddCommand(accrueCmd)
+
+	redeemCmd := &cobra.Command{
+		Use:   "redeem <id> <owner>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Redeem an investment",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := investments.Redeem(args[0], args[1], time.Now())
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Println(amt)
+		},
+	}
+	cmd.AddCommand(redeemCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get investment info",
+		Run: func(cmd *cobra.Command, args []string) {
+			rec, ok := investments.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			fmt.Printf("%s owner:%s principal:%d accrued:%d\n", rec.ID, rec.Owner, rec.Principal, rec.Accrued)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn1600.go
+++ b/cli/syn1600.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var musicToken *core.MusicToken
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn1600",
+		Short: "Music token utilities",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise a music token",
+		Run: func(cmd *cobra.Command, args []string) {
+			title, _ := cmd.Flags().GetString("title")
+			artist, _ := cmd.Flags().GetString("artist")
+			album, _ := cmd.Flags().GetString("album")
+			musicToken = core.NewMusicToken(title, artist, album)
+			fmt.Println("token initialised")
+		},
+	}
+	initCmd.Flags().String("title", "", "song title")
+	initCmd.Flags().String("artist", "", "artist")
+	initCmd.Flags().String("album", "", "album")
+	cmd.AddCommand(initCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show token info",
+		Run: func(cmd *cobra.Command, args []string) {
+			if musicToken == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			t, a, al := musicToken.Info()
+			fmt.Printf("%s by %s on %s\n", t, a, al)
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update token metadata",
+		Run: func(cmd *cobra.Command, args []string) {
+			if musicToken == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			title, _ := cmd.Flags().GetString("title")
+			artist, _ := cmd.Flags().GetString("artist")
+			album, _ := cmd.Flags().GetString("album")
+			musicToken.Update(title, artist, album)
+		},
+	}
+	updateCmd.Flags().String("title", "", "song title")
+	updateCmd.Flags().String("artist", "", "artist")
+	updateCmd.Flags().String("album", "", "album")
+	cmd.AddCommand(updateCmd)
+
+	shareCmd := &cobra.Command{
+		Use:   "share <addr> <share>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Set royalty share",
+		Run: func(cmd *cobra.Command, args []string) {
+			if musicToken == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			s, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid share")
+				return
+			}
+			musicToken.SetRoyaltyShare(args[0], s)
+		},
+	}
+	cmd.AddCommand(shareCmd)
+
+	payoutCmd := &cobra.Command{
+		Use:   "payout <amount>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Distribute payout",
+		Run: func(cmd *cobra.Command, args []string) {
+			if musicToken == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			amt, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			payouts, err := musicToken.Distribute(amt)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			for addr, p := range payouts {
+				fmt.Printf("%s:%d\n", addr, p)
+			}
+		},
+	}
+	cmd.AddCommand(payoutCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn1700_token.go
+++ b/cli/syn1700_token.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var event *core.EventMetadata
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn1700",
+		Short: "Event ticket token",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise event metadata",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			desc, _ := cmd.Flags().GetString("desc")
+			location, _ := cmd.Flags().GetString("location")
+			start, _ := cmd.Flags().GetInt64("start")
+			end, _ := cmd.Flags().GetInt64("end")
+			supply, _ := cmd.Flags().GetUint64("supply")
+			event = core.NewEvent(name, desc, location, start, end, supply)
+			fmt.Println("event initialised")
+		},
+	}
+	initCmd.Flags().String("name", "", "event name")
+	initCmd.Flags().String("desc", "", "description")
+	initCmd.Flags().String("location", "", "location")
+	initCmd.Flags().Int64("start", 0, "start unix time")
+	initCmd.Flags().Int64("end", 0, "end unix time")
+	initCmd.Flags().Uint64("supply", 0, "ticket supply")
+	cmd.AddCommand(initCmd)
+
+	issueCmd := &cobra.Command{
+		Use:   "issue <owner> <class> <type> <price>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Issue a ticket",
+		Run: func(cmd *cobra.Command, args []string) {
+			if event == nil {
+				fmt.Println("event not initialised")
+				return
+			}
+			price, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				fmt.Println("invalid price")
+				return
+			}
+			id, err := event.IssueTicket(args[0], args[1], args[2], price)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			fmt.Println(id)
+		},
+	}
+	cmd.AddCommand(issueCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <id> <from> <to>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Transfer a ticket",
+		Run: func(cmd *cobra.Command, args []string) {
+			if event == nil {
+				fmt.Println("event not initialised")
+				return
+			}
+			id, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid id")
+				return
+			}
+			if err := event.TransferTicket(id, args[1], args[2]); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	verifyCmd := &cobra.Command{
+		Use:   "verify <id> <holder>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Verify ticket ownership",
+		Run: func(cmd *cobra.Command, args []string) {
+			if event == nil {
+				fmt.Println("event not initialised")
+				return
+			}
+			id, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid id")
+				return
+			}
+			fmt.Println(event.VerifyTicket(id, args[1]))
+		},
+	}
+	cmd.AddCommand(verifyCmd)
+
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- implement staking_node CLI for staking operations
- add stake_penalty CLI to slash and reward validators
- provide state, swarm, and token CLIs for supply-chain, intangible assets, investments, music, and event tickets

## Testing
- `go test ./cli/...` *(fails: contractVM redeclared in cli/contracts.go)*

------
https://chatgpt.com/codex/tasks/task_e_68915f49b9848320844090072fdb31b6