### PR TITLE
Add voting power update command for syn2500 CLI

### DIFF
--- a/cli/syn2500_token.go
+++ b/cli/syn2500_token.go
@@ -75,6 +75,24 @@ func init() {
 	}
 	cmd.AddCommand(delCmd)
 
+	updateCmd := &cobra.Command{
+		Use:   "update <id> <power>",
+		Short: "Update voting power for a member",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			m, ok := syn2500.GetMember(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			var power uint64
+			fmt.Sscanf(args[1], "%d", &power)
+			m.UpdateVotingPower(power)
+			fmt.Println("voting power updated")
+		},
+	}
+	cmd.AddCommand(updateCmd)
+
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List members",


### PR DESCRIPTION
## Summary
- expose DAO voting power update via `syn2500` CLI command

## Testing
- `go test ./core -run 'TradeFinanceToken|VestingSchedule|TokenInsurancePolicy|FuturesContract|EventTickets'`
- `go test ./cli/...` *(fails: contractVM redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_e_68915f5902ac8320988f9db98cb50b33