### PR TITLE
feat(cli): add stage 15 command interfaces

### DIFF
--- a/cli/syn3800.go
+++ b/cli/syn3800.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var grantRegistry = core.NewGrantRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3800",
+		Short: "Manage SYN3800 grant records",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create <beneficiary> <name> <amount>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Create a new grant",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			id := grantRegistry.CreateGrant(args[0], args[1], amt)
+			fmt.Println("grant created", id)
+		},
+	}
+
+	releaseCmd := &cobra.Command{
+		Use:   "release <id> <amount> [note]",
+		Args:  cobra.RangeArgs(2, 3),
+		Short: "Release funds for a grant",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			amt, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			note := ""
+			if len(args) == 3 {
+				note = args[2]
+			}
+			if err := grantRegistry.Disburse(id, amt, note); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show grant details",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			if g, ok := grantRegistry.GetGrant(id); ok {
+				b, _ := json.MarshalIndent(g, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List grants",
+		Run: func(cmd *cobra.Command, args []string) {
+			gs := grantRegistry.ListGrants()
+			b, _ := json.MarshalIndent(gs, "", "  ")
+			fmt.Println(string(b))
+		},
+	}
+
+	cmd.AddCommand(createCmd, releaseCmd, getCmd, listCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn3900.go
+++ b/cli/syn3900.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var benefitRegistry = core.NewBenefitRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3900",
+		Short: "Manage SYN3900 government benefits",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <recipient> <program> <amount>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Register a new benefit",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			id := benefitRegistry.RegisterBenefit(args[0], args[1], amt)
+			fmt.Println("benefit registered", id)
+		},
+	}
+
+	claimCmd := &cobra.Command{
+		Use:   "claim <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Claim a benefit",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			if err := benefitRegistry.Claim(id); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show benefit details",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			if b, ok := benefitRegistry.GetBenefit(id); ok {
+				data, _ := json.MarshalIndent(b, "", "  ")
+				fmt.Println(string(data))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	cmd.AddCommand(registerCmd, claimCmd, getCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn4200_token.go
+++ b/cli/syn4200_token.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn4200 = core.NewSYN4200Token()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn4200_token",
+		Short: "Charity token operations",
+	}
+
+	donateCmd := &cobra.Command{
+		Use:   "donate <symbol>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Donate to a charity campaign",
+		Run: func(cmd *cobra.Command, args []string) {
+			from, _ := cmd.Flags().GetString("from")
+			amt, _ := cmd.Flags().GetUint64("amt")
+			purpose, _ := cmd.Flags().GetString("purpose")
+			syn4200.Donate(args[0], from, amt, purpose)
+			fmt.Println("donation recorded")
+		},
+	}
+	donateCmd.Flags().String("from", "", "donor address")
+	donateCmd.Flags().Uint64("amt", 0, "donation amount")
+	donateCmd.Flags().String("purpose", "", "campaign purpose")
+	donateCmd.MarkFlagRequired("from")
+	donateCmd.MarkFlagRequired("amt")
+
+	progressCmd := &cobra.Command{
+		Use:   "progress <symbol>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show campaign progress",
+		Run: func(cmd *cobra.Command, args []string) {
+			if amt, ok := syn4200.CampaignProgress(args[0]); ok {
+				fmt.Println(amt)
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	cmd.AddCommand(donateCmd, progressCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn4700.go
+++ b/cli/syn4700.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var legalRegistry = core.NewLegalTokenRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn4700",
+		Short: "Manage SYN4700 legal tokens",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a legal token",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			doctype, _ := cmd.Flags().GetString("doctype")
+			hash, _ := cmd.Flags().GetString("hash")
+			owner, _ := cmd.Flags().GetString("owner")
+			expiry, _ := cmd.Flags().GetInt64("expiry")
+			supply, _ := cmd.Flags().GetUint64("supply")
+			parties, _ := cmd.Flags().GetStringArray("party")
+			t := core.NewLegalToken(id, name, symbol, doctype, hash, owner, time.Unix(expiry, 0), supply, parties)
+			legalRegistry.Add(t)
+			fmt.Println("token created")
+		},
+	}
+	createCmd.Flags().String("id", "", "token id")
+	createCmd.Flags().String("name", "", "name")
+	createCmd.Flags().String("symbol", "", "symbol")
+	createCmd.Flags().String("doctype", "", "document type")
+	createCmd.Flags().String("hash", "", "document hash")
+	createCmd.Flags().String("owner", "", "owner address")
+	createCmd.Flags().Int64("expiry", 0, "expiry unix timestamp")
+	createCmd.Flags().Uint64("supply", 0, "token supply")
+	createCmd.Flags().StringArray("party", []string{}, "parties")
+	createCmd.MarkFlagRequired("id")
+	createCmd.MarkFlagRequired("name")
+	createCmd.MarkFlagRequired("symbol")
+	createCmd.MarkFlagRequired("doctype")
+	createCmd.MarkFlagRequired("hash")
+	createCmd.MarkFlagRequired("owner")
+	createCmd.MarkFlagRequired("expiry")
+
+	signCmd := &cobra.Command{
+		Use:   "sign <id> <party> <sig>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Add a party signature",
+		Run: func(cmd *cobra.Command, args []string) {
+			if t, ok := legalRegistry.Get(args[0]); ok {
+				if err := t.Sign(args[1], args[2]); err != nil {
+					fmt.Println("error:", err)
+				}
+			}
+		},
+	}
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke <id> <party>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Revoke a signature",
+		Run: func(cmd *cobra.Command, args []string) {
+			if t, ok := legalRegistry.Get(args[0]); ok {
+				t.RevokeSignature(args[1])
+			}
+		},
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status <id> <status>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Update token status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if t, ok := legalRegistry.Get(args[0]); ok {
+				t.UpdateStatus(core.LegalTokenStatus(args[1]))
+			}
+		},
+	}
+
+	disputeCmd := &cobra.Command{
+		Use:   "dispute <id> <action> [result]",
+		Args:  cobra.RangeArgs(2, 3),
+		Short: "Record a dispute",
+		Run: func(cmd *cobra.Command, args []string) {
+			if t, ok := legalRegistry.Get(args[0]); ok {
+				res := ""
+				if len(args) == 3 {
+					res = args[2]
+				}
+				t.Dispute(args[1], res)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show token info",
+		Run: func(cmd *cobra.Command, args []string) {
+			if t, ok := legalRegistry.Get(args[0]); ok {
+				b, _ := json.MarshalIndent(t, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	cmd.AddCommand(createCmd, signCmd, revokeCmd, statusCmd, disputeCmd, infoCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn500.go
+++ b/cli/syn500.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn500Token *core.SYN500Token
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn500",
+		Short: "SYN500 utility token",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a SYN500 token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			owner, _ := cmd.Flags().GetString("owner")
+			dec, _ := cmd.Flags().GetUint("dec")
+			supply, _ := cmd.Flags().GetUint64("supply")
+			syn500Token = core.NewSYN500Token(name, symbol, owner, uint8(dec), supply)
+			fmt.Println("token created")
+		},
+	}
+	createCmd.Flags().String("name", "", "token name")
+	createCmd.Flags().String("symbol", "", "token symbol")
+	createCmd.Flags().String("owner", "", "owner address")
+	createCmd.Flags().Uint("dec", 0, "decimals")
+	createCmd.Flags().Uint64("supply", 0, "initial supply")
+	createCmd.MarkFlagRequired("name")
+	createCmd.MarkFlagRequired("symbol")
+	createCmd.MarkFlagRequired("owner")
+
+	grantCmd := &cobra.Command{
+		Use:   "grant <addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Grant a usage tier",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn500Token == nil {
+				fmt.Println("token not created")
+				return
+			}
+			tier, _ := cmd.Flags().GetInt("tier")
+			max, _ := cmd.Flags().GetUint64("max")
+			syn500Token.Grant(args[0], tier, max)
+			fmt.Println("granted")
+		},
+	}
+	grantCmd.Flags().Int("tier", 0, "service tier")
+	grantCmd.Flags().Uint64("max", 0, "max usage")
+	grantCmd.MarkFlagRequired("tier")
+	grantCmd.MarkFlagRequired("max")
+
+	useCmd := &cobra.Command{
+		Use:   "use <addr>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Record usage",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn500Token == nil {
+				fmt.Println("token not created")
+				return
+			}
+			if err := syn500Token.Use(args[0]); err != nil {
+				fmt.Println("error:", err)
+			} else {
+				fmt.Println("usage recorded")
+			}
+		},
+	}
+
+	cmd.AddCommand(createCmd, grantCmd, useCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn5000.go
+++ b/cli/syn5000.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn5000Tokens = map[string]*core.SYN5000Token{}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn5000",
+		Short: "SYN5000 gambling token",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a gambling token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			dec, _ := cmd.Flags().GetUint("dec")
+			t := core.NewSYN5000Token(name, symbol, uint8(dec))
+			syn5000Tokens[symbol] = t
+			fmt.Println("token created", symbol)
+		},
+	}
+	createCmd.Flags().String("name", "", "token name")
+	createCmd.Flags().String("symbol", "", "token symbol")
+	createCmd.Flags().Uint("dec", 0, "decimals")
+	createCmd.MarkFlagRequired("name")
+	createCmd.MarkFlagRequired("symbol")
+
+	betCmd := &cobra.Command{
+		Use:   "bet <bettor>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Place a bet",
+		Run: func(cmd *cobra.Command, args []string) {
+			tokenID, _ := cmd.Flags().GetString("id")
+			amt, _ := cmd.Flags().GetUint64("amt")
+			odds, _ := cmd.Flags().GetFloat64("odds")
+			game, _ := cmd.Flags().GetString("game")
+			t, ok := syn5000Tokens[tokenID]
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			id := t.PlaceBet(args[0], amt, odds, game)
+			fmt.Println("bet placed", id)
+		},
+	}
+	betCmd.Flags().String("id", "", "token symbol")
+	betCmd.Flags().Uint64("amt", 0, "bet amount")
+	betCmd.Flags().Float64("odds", 1, "betting odds")
+	betCmd.Flags().String("game", "", "game type")
+	betCmd.MarkFlagRequired("id")
+	betCmd.MarkFlagRequired("amt")
+	betCmd.MarkFlagRequired("odds")
+	betCmd.MarkFlagRequired("game")
+
+	resolveCmd := &cobra.Command{
+		Use:   "resolve",
+		Short: "Resolve a bet",
+		Run: func(cmd *cobra.Command, args []string) {
+			tokenID, _ := cmd.Flags().GetString("id")
+			betID, _ := cmd.Flags().GetUint64("bet")
+			win, _ := cmd.Flags().GetBool("win")
+			t, ok := syn5000Tokens[tokenID]
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			payout, err := t.ResolveBet(betID, win)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println("payout", payout)
+		},
+	}
+	resolveCmd.Flags().String("id", "", "token symbol")
+	resolveCmd.Flags().Uint64("bet", 0, "bet id")
+	resolveCmd.Flags().Bool("win", false, "mark bet as won")
+	resolveCmd.MarkFlagRequired("id")
+	resolveCmd.MarkFlagRequired("bet")
+
+	cmd.AddCommand(createCmd, betCmd, resolveCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn5000_index.go
+++ b/cli/syn5000_index.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var gamblingIndex = map[string]core.GamblingToken{}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn5000_index",
+		Short: "Gambling token index",
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add <symbol>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Add a new SYN5000 token to index",
+		Run: func(cmd *cobra.Command, args []string) {
+			gamblingIndex[args[0]] = core.NewSYN5000Token(args[0], args[0], 0)
+			fmt.Println("token added")
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tokens in index",
+		Run: func(cmd *cobra.Command, args []string) {
+			for sym := range gamblingIndex {
+				fmt.Println(sym)
+			}
+		},
+	}
+
+	cmd.AddCommand(addCmd, listCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn700.go
+++ b/cli/syn700.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var ipRegistry = core.NewIPRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn700",
+		Short: "Manage SYN700 IP tokens",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <id> <title> <desc> <creator> <owner>",
+		Args:  cobra.ExactArgs(5),
+		Short: "Register an IP asset",
+		Run: func(cmd *cobra.Command, args []string) {
+			if _, err := ipRegistry.Register(args[0], args[1], args[2], args[3], args[4]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	licenseCmd := &cobra.Command{
+		Use:   "license <tokenID> <licID> <type> <licensee> <royalty>",
+		Args:  cobra.ExactArgs(5),
+		Short: "Create a license",
+		Run: func(cmd *cobra.Command, args []string) {
+			royalty, _ := strconv.ParseUint(args[4], 10, 64)
+			if err := ipRegistry.CreateLicense(args[0], args[1], args[2], args[3], royalty); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	royaltyCmd := &cobra.Command{
+		Use:   "royalty <tokenID> <licID> <licensee> <amount>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Record a royalty payment",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[3], 10, 64)
+			if err := ipRegistry.RecordRoyalty(args[0], args[1], args[2], amt); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <tokenID>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show token info",
+		Run: func(cmd *cobra.Command, args []string) {
+			if t, ok := ipRegistry.Get(args[0]); ok {
+				b, _ := json.MarshalIndent(t, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	cmd.AddCommand(registerCmd, licenseCmd, royaltyCmd, infoCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn800_token.go
+++ b/cli/syn800_token.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var assetRegistry = core.NewAssetRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn800_token",
+		Short: "Manage SYN800 asset tokens",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <id> <desc> <valuation> <loc> <type> <cert>",
+		Args:  cobra.ExactArgs(6),
+		Short: "Register an asset",
+		Run: func(cmd *cobra.Command, args []string) {
+			val, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid valuation")
+				return
+			}
+			if _, err := assetRegistry.Register(args[0], args[1], val, args[3], args[4], args[5]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	updateCmd := &cobra.Command{
+		Use:   "update <id> <valuation>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Update asset valuation",
+		Run: func(cmd *cobra.Command, args []string) {
+			val, _ := strconv.ParseUint(args[1], 10, 64)
+			if err := assetRegistry.UpdateValuation(args[0], val); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Display asset information",
+		Run: func(cmd *cobra.Command, args []string) {
+			if a, ok := assetRegistry.Get(args[0]); ok {
+				b, _ := json.MarshalIndent(a, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	cmd.AddCommand(registerCmd, updateCmd, infoCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/system_health_logging.go
+++ b/cli/system_health_logging.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var sysLogger = core.NewSystemHealthLogger()
+var sysLogs []string
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "system_health",
+		Short: "System health utilities",
+	}
+
+	snapshotCmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "Display current system metrics",
+		Run: func(cmd *cobra.Command, args []string) {
+			m := sysLogger.Collect(0, 0)
+			b, _ := json.MarshalIndent(m, "", "  ")
+			fmt.Println(string(b))
+		},
+	}
+
+	logCmd := &cobra.Command{
+		Use:   "log <level> <msg>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Append a log message",
+		Run: func(cmd *cobra.Command, args []string) {
+			sysLogs = append(sysLogs, fmt.Sprintf("%s: %s", args[0], args[1]))
+		},
+	}
+
+	cmd.AddCommand(snapshotCmd, logCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/token_syn130.go
+++ b/cli/token_syn130.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var syn130Registry = core.NewTangibleAssetRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "token_syn130",
+		Short: "Manage SYN130 tangible assets",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <id> <owner> <meta> <value>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Register a tangible asset",
+		Run: func(cmd *cobra.Command, args []string) {
+			val, _ := strconv.ParseUint(args[3], 10, 64)
+			if _, err := syn130Registry.Register(args[0], args[1], args[2], val); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	valueCmd := &cobra.Command{
+		Use:   "value <id> <val>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Update valuation",
+		Run: func(cmd *cobra.Command, args []string) {
+			val, _ := strconv.ParseUint(args[1], 10, 64)
+			if err := syn130Registry.UpdateValuation(args[0], val); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	saleCmd := &cobra.Command{
+		Use:   "sale <id> <buyer> <price>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Record a sale",
+		Run: func(cmd *cobra.Command, args []string) {
+			price, _ := strconv.ParseUint(args[2], 10, 64)
+			if err := syn130Registry.RecordSale(args[0], args[1], price); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	leaseCmd := &cobra.Command{
+		Use:   "lease <id> <lessee> <pay> <start> <end>",
+		Args:  cobra.ExactArgs(5),
+		Short: "Start a lease",
+		Run: func(cmd *cobra.Command, args []string) {
+			pay, _ := strconv.ParseUint(args[2], 10, 64)
+			start, _ := strconv.ParseInt(args[3], 10, 64)
+			end, _ := strconv.ParseInt(args[4], 10, 64)
+			if err := syn130Registry.StartLease(args[0], args[1], pay, time.Unix(start, 0), time.Unix(end, 0)); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	endLeaseCmd := &cobra.Command{
+		Use:   "endlease <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "End a lease",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := syn130Registry.EndLease(args[0]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Get asset info",
+		Run: func(cmd *cobra.Command, args []string) {
+			if a, ok := syn130Registry.Get(args[0]); ok {
+				b, _ := json.MarshalIndent(a, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	cmd.AddCommand(registerCmd, valueCmd, saleCmd, leaseCmd, endLeaseCmd, infoCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/token_syn4900.go
+++ b/cli/token_syn4900.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var agriRegistry = core.NewAgriculturalRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "token_syn4900",
+		Short: "Manage SYN4900 agricultural assets",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register <id> <type> <owner> <origin> <qty> <harvest> <expiry> <cert>",
+		Args:  cobra.ExactArgs(8),
+		Short: "Register an agricultural asset",
+		Run: func(cmd *cobra.Command, args []string) {
+			qty, _ := strconv.ParseUint(args[4], 10, 64)
+			harvest, _ := strconv.ParseInt(args[5], 10, 64)
+			expiry, _ := strconv.ParseInt(args[6], 10, 64)
+			if _, err := agriRegistry.Register(args[0], args[1], args[2], args[3], qty, time.Unix(harvest, 0), time.Unix(expiry, 0), args[7]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <id> <owner>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Transfer ownership",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := agriRegistry.Transfer(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status <id> <status>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Update asset status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := agriRegistry.UpdateStatus(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show asset info",
+		Run: func(cmd *cobra.Command, args []string) {
+			if a, ok := agriRegistry.Get(args[0]); ok {
+				b, _ := json.MarshalIndent(a, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	cmd.AddCommand(registerCmd, transferCmd, statusCmd, infoCmd)
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add SYN3800 grant management CLI
- implement SYN3900 benefit registry CLI
- support system health snapshots and logging via CLI
- expose SYN5000 gambling and interface index commands
- add CLIs for tokens SYN4200, SYN4700, SYN500, SYN700, SYN800, SYN130, and SYN4900

## Testing
- `go test ./...` *(fails: contractVM redeclared in cli/contracts.go)*

------
https://chatgpt.com/codex/tasks/task_e_68915f61fc788320ae0eb2c3fee75b6c