### PR TITLE
Add CLI support for validator, VM, sandbox, warfare, and watchtower nodes

### DIFF
--- a/cli/validator_node.go
+++ b/cli/validator_node.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var validatorNode *core.ValidatorNode
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "validatornode",
+		Short: "Operations for validator nodes",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a validator node",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			addr, _ := cmd.Flags().GetString("addr")
+			minStake, _ := cmd.Flags().GetUint64("minstake")
+			quorum, _ := cmd.Flags().GetInt("quorum")
+			validatorNode = core.NewValidatorNode(id, addr, core.NewLedger(), minStake, quorum)
+			fmt.Println("validator node created")
+		},
+	}
+	createCmd.Flags().String("id", "", "node id")
+	createCmd.Flags().String("addr", "", "node address")
+	createCmd.Flags().Uint64("minstake", 0, "minimum stake")
+	createCmd.Flags().Int("quorum", 1, "quorum requirement")
+	cmd.AddCommand(createCmd)
+
+	addCmd := &cobra.Command{
+		Use:   "add <addr> <stake>",
+		Short: "Add a validator",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if validatorNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			stake, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid stake")
+				return
+			}
+			if err := validatorNode.AddValidator(args[0], stake); err != nil {
+				fmt.Println("add validator error:", err)
+				return
+			}
+			fmt.Println("validator added")
+		},
+	}
+	cmd.AddCommand(addCmd)
+
+	removeCmd := &cobra.Command{
+		Use:   "remove <addr>",
+		Short: "Remove a validator",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if validatorNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			validatorNode.RemoveValidator(args[0])
+			fmt.Println("validator removed")
+		},
+	}
+	cmd.AddCommand(removeCmd)
+
+	slashCmd := &cobra.Command{
+		Use:   "slash <addr>",
+		Short: "Slash a validator",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if validatorNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			validatorNode.SlashValidator(args[0])
+			fmt.Println("validator slashed")
+		},
+	}
+	cmd.AddCommand(slashCmd)
+
+	quorumCmd := &cobra.Command{
+		Use:   "quorum",
+		Short: "Check if quorum is reached",
+		Run: func(cmd *cobra.Command, args []string) {
+			if validatorNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			fmt.Println(validatorNode.HasQuorum())
+		},
+	}
+	cmd.AddCommand(quorumCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/virtual_machine.go
+++ b/cli/virtual_machine.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var simpleVM *core.SimpleVM
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "simplevm",
+		Short: "Manage the simple virtual machine",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create [mode]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Create a new VM instance",
+		Run: func(cmd *cobra.Command, args []string) {
+			mode := core.VMLight
+			if len(args) == 1 {
+				switch args[0] {
+				case "heavy":
+					mode = core.VMHeavy
+				case "superlight":
+					mode = core.VMSuperLight
+				}
+			}
+			simpleVM = core.NewSimpleVM(mode)
+			fmt.Println("vm created")
+		},
+	}
+	cmd.AddCommand(createCmd)
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the VM",
+		Run: func(cmd *cobra.Command, args []string) {
+			if simpleVM == nil {
+				fmt.Println("vm not created")
+				return
+			}
+			if err := simpleVM.Start(); err != nil {
+				fmt.Println("start error:", err)
+				return
+			}
+			fmt.Println("vm started")
+		},
+	}
+	cmd.AddCommand(startCmd)
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the VM",
+		Run: func(cmd *cobra.Command, args []string) {
+			if simpleVM == nil {
+				fmt.Println("vm not created")
+				return
+			}
+			if err := simpleVM.Stop(); err != nil {
+				fmt.Println("stop error:", err)
+				return
+			}
+			fmt.Println("vm stopped")
+		},
+	}
+	cmd.AddCommand(stopCmd)
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show running status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if simpleVM == nil {
+				fmt.Println("vm not created")
+				return
+			}
+			fmt.Println(simpleVM.Status())
+		},
+	}
+	cmd.AddCommand(statusCmd)
+
+	execCmd := &cobra.Command{
+		Use:   "exec <wasmHex> [argsHex] [gas]",
+		Args:  cobra.RangeArgs(1, 3),
+		Short: "Execute bytecode on the VM",
+		Run: func(cmd *cobra.Command, args []string) {
+			if simpleVM == nil {
+				fmt.Println("vm not created")
+				return
+			}
+			if !simpleVM.Status() {
+				fmt.Println("vm not running")
+				return
+			}
+			wasm, err := hex.DecodeString(args[0])
+			if err != nil {
+				fmt.Println("invalid wasm")
+				return
+			}
+			var in []byte
+			if len(args) > 1 {
+				in, err = hex.DecodeString(args[1])
+				if err != nil {
+					fmt.Println("invalid args")
+					return
+				}
+			}
+			gas := uint64(100)
+			if len(args) > 2 {
+				gas, err = strconv.ParseUint(args[2], 10, 64)
+				if err != nil {
+					fmt.Println("invalid gas")
+					return
+				}
+			}
+			out, used, err := simpleVM.Execute(wasm, "", in, gas)
+			if err != nil {
+				fmt.Println("exec error:", err)
+				return
+			}
+			fmt.Printf("out: %x gasUsed: %d\n", out, used)
+		},
+	}
+	cmd.AddCommand(execCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/vm_sandbox_management.go
+++ b/cli/vm_sandbox_management.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var sandboxMgr = core.NewSandboxManager()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "sandbox",
+		Short: "Manage VM sandboxes",
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start <id> <contract> <gas> <memory>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Start a sandbox",
+		Run: func(cmd *cobra.Command, args []string) {
+			gas, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid gas")
+				return
+			}
+			mem, err := strconv.ParseUint(args[3], 10, 64)
+			if err != nil {
+				fmt.Println("invalid memory limit")
+				return
+			}
+			if _, err := sandboxMgr.StartSandbox(args[0], args[1], gas, mem); err != nil {
+				fmt.Println("start error:", err)
+				return
+			}
+			fmt.Println("sandbox started")
+		},
+	}
+	cmd.AddCommand(startCmd)
+
+	stopCmd := &cobra.Command{
+		Use:   "stop <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Stop a sandbox",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sandboxMgr.StopSandbox(args[0]); err != nil {
+				fmt.Println("stop error:", err)
+				return
+			}
+			fmt.Println("sandbox stopped")
+		},
+	}
+	cmd.AddCommand(stopCmd)
+
+	resetCmd := &cobra.Command{
+		Use:   "reset <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Reset sandbox timer",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sandboxMgr.ResetSandbox(args[0]); err != nil {
+				fmt.Println("reset error:", err)
+				return
+			}
+			fmt.Println("sandbox reset")
+		},
+	}
+	cmd.AddCommand(resetCmd)
+
+	statusCmd := &cobra.Command{
+		Use:   "status <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show sandbox status",
+		Run: func(cmd *cobra.Command, args []string) {
+			sb, ok := sandboxMgr.SandboxStatus(args[0])
+			if !ok {
+				fmt.Println("sandbox not found")
+				return
+			}
+			fmt.Printf("%+v\n", sb)
+		},
+	}
+	cmd.AddCommand(statusCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List sandboxes",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, sb := range sandboxMgr.ListSandboxes() {
+				fmt.Printf("%+v\n", sb)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/warfare_node.go
+++ b/cli/warfare_node.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+	militarynodes "synnergy/internal/nodes/military_nodes"
+)
+
+var warfareNode *core.WarfareNode
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "warfare",
+		Short: "Interact with a warfare node",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create warfare node",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			addr, _ := cmd.Flags().GetString("addr")
+			base := core.NewNode(id, addr, core.NewLedger())
+			warfareNode = core.NewWarfareNode(base)
+			fmt.Println("warfare node created")
+		},
+	}
+	createCmd.Flags().String("id", "", "node id")
+	createCmd.Flags().String("addr", "", "node address")
+	cmd.AddCommand(createCmd)
+
+	cmdCmd := &cobra.Command{
+		Use:   "command <cmd>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Execute secure command",
+		Run: func(cmd *cobra.Command, args []string) {
+			if warfareNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			if err := warfareNode.SecureCommand(args[0]); err != nil {
+				fmt.Println("command error:", err)
+				return
+			}
+			fmt.Println("command executed")
+		},
+	}
+	cmd.AddCommand(cmdCmd)
+
+	trackCmd := &cobra.Command{
+		Use:   "track <assetID> <location> <status>",
+		Args:  cobra.ExactArgs(3),
+		Short: "Record logistics information",
+		Run: func(cmd *cobra.Command, args []string) {
+			if warfareNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			warfareNode.TrackLogistics(args[0], args[1], args[2])
+			fmt.Println("logistics recorded")
+		},
+	}
+	cmd.AddCommand(trackCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "logistics [assetID]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List logistics records",
+		Run: func(cmd *cobra.Command, args []string) {
+			if warfareNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			var recs []militarynodes.LogisticsRecord
+			if len(args) == 1 {
+				recs = warfareNode.LogisticsByAsset(args[0])
+			} else {
+				recs = warfareNode.Logistics()
+			}
+			for i, r := range recs {
+				fmt.Printf("%d: %+v\n", i, r)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	shareCmd := &cobra.Command{
+		Use:   "share <info>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Share tactical information",
+		Run: func(cmd *cobra.Command, args []string) {
+			if warfareNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			warfareNode.ShareTactical(args[0])
+			fmt.Println("info shared")
+		},
+	}
+	cmd.AddCommand(shareCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/watchtower_node.go
+++ b/cli/watchtower_node.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var watchNode *core.Watchtower
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "watchtower",
+		Short: "Manage watchtower node",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create watchtower node",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			watchNode = core.NewWatchtowerNode(id, log.New(os.Stdout, "", 0))
+			fmt.Println("watchtower node created")
+		},
+	}
+	createCmd.Flags().String("id", "", "node id")
+	cmd.AddCommand(createCmd)
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start monitoring",
+		Run: func(cmd *cobra.Command, args []string) {
+			if watchNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			if err := watchNode.Start(context.Background()); err != nil {
+				fmt.Println("start error:", err)
+				return
+			}
+			fmt.Println("watchtower started")
+		},
+	}
+	cmd.AddCommand(startCmd)
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop monitoring",
+		Run: func(cmd *cobra.Command, args []string) {
+			if watchNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			if err := watchNode.Stop(); err != nil {
+				fmt.Println("stop error:", err)
+				return
+			}
+			fmt.Println("watchtower stopped")
+		},
+	}
+	cmd.AddCommand(stopCmd)
+
+	forkCmd := &cobra.Command{
+		Use:   "fork <height> <hash>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Report fork event",
+		Run: func(cmd *cobra.Command, args []string) {
+			if watchNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			h, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid height")
+				return
+			}
+			watchNode.ReportFork(h, args[1])
+			fmt.Println("fork reported")
+		},
+	}
+	cmd.AddCommand(forkCmd)
+
+	metricsCmd := &cobra.Command{
+		Use:   "metrics",
+		Short: "Show latest system metrics",
+		Run: func(cmd *cobra.Command, args []string) {
+			if watchNode == nil {
+				fmt.Println("node not initialised")
+				return
+			}
+			fmt.Printf("%+v\n", watchNode.Metrics())
+		},
+	}
+	cmd.AddCommand(metricsCmd)
+
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add validator node CLI to create nodes, manage validators, and check quorum
- add simple VM CLI with lifecycle and execution commands
- add VM sandbox management CLI for sandbox lifecycle and status
- add warfare node CLI for secure commands and logistics tracking
- add watchtower node CLI to monitor, report forks, and view metrics

## Testing
- `go test ./...` *(fails: contractVM redeclared in cli/contracts.go and cli/contract_management.go)*

------
https://chatgpt.com/codex/tasks/task_e_68915f6e4b0483208b197f82ba36c5a9