### PR TITLE
Add CLI support for zero trust channels and new nodes

### DIFF
--- a/cli/experimental_node.go
+++ b/cli/experimental_node.go
@@ -1,0 +1,82 @@
+//go:build experimental
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	nodes "synnergy/internal/nodes"
+)
+
+var expNode *nodes.ExperimentalNode
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "experimental",
+		Short: "Manage experimental node (requires -tags=experimental)",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Create a new experimental node",
+		Run: func(cmd *cobra.Command, args []string) {
+			expNode = nodes.NewExperimentalNode(nodes.Address(args[0]))
+			fmt.Println("created")
+		},
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the node",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if expNode == nil {
+				return fmt.Errorf("node not created")
+			}
+			return expNode.Start()
+		},
+	}
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the node",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if expNode == nil {
+				return fmt.Errorf("node not created")
+			}
+			return expNode.Stop()
+		},
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show node status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if expNode == nil {
+				fmt.Println("no node")
+				return
+			}
+			if expNode.IsRunning() {
+				fmt.Println("running")
+			} else {
+				fmt.Println("stopped")
+			}
+		},
+	}
+
+	dialCmd := &cobra.Command{
+		Use:   "dial [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Dial a seed peer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if expNode == nil {
+				return fmt.Errorf("node not created")
+			}
+			return expNode.DialSeed(nodes.Address(args[0]))
+		},
+	}
+
+	cmd.AddCommand(createCmd, startCmd, stopCmd, statusCmd, dialCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/geospatial_node.go
+++ b/cli/geospatial_node.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	syn "synnergy"
+)
+
+var geoNode = syn.NewGeospatialNode()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "geospatial",
+		Short: "Record and query geospatial data",
+	}
+
+	recordCmd := &cobra.Command{
+		Use:   "record [subject] [lat] [lon]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Record a geospatial data point",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			lat, err := strconv.ParseFloat(args[1], 64)
+			if err != nil {
+				return err
+			}
+			lon, err := strconv.ParseFloat(args[2], 64)
+			if err != nil {
+				return err
+			}
+			geoNode.Record(args[0], lat, lon)
+			fmt.Println("recorded")
+			return nil
+		},
+	}
+
+	historyCmd := &cobra.Command{
+		Use:   "history [subject]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show recorded locations for a subject",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, r := range geoNode.History(args[0]) {
+				fmt.Printf("%s %.6f %.6f %s\n", r.Subject, r.Latitude, r.Longitude, r.Timestamp.Format(time.RFC3339))
+			}
+		},
+	}
+
+	cmd.AddCommand(recordCmd, historyCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/zero_trust_data_channels.go
+++ b/cli/zero_trust_data_channels.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var ztEngine = core.NewZeroTrustEngine()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "zero-trust",
+		Short: "Manage zero trust data channels",
+	}
+
+	openCmd := &cobra.Command{
+		Use:   "open [id] [hexkey]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Open a secure channel",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := hex.DecodeString(args[1])
+			if err != nil {
+				return err
+			}
+			if err := ztEngine.OpenChannel(args[0], key); err != nil {
+				return err
+			}
+			fmt.Println("channel opened")
+			return nil
+		},
+	}
+
+	sendCmd := &cobra.Command{
+		Use:   "send [id] [msg]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Send an encrypted message",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cipher, err := ztEngine.Send(args[0], []byte(args[1]))
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%x\n", cipher)
+			return nil
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "messages [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "List encrypted messages",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, m := range ztEngine.Messages(args[0]) {
+				fmt.Printf("%x\n", m)
+			}
+		},
+	}
+
+	closeCmd := &cobra.Command{
+		Use:   "close [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Close a channel",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ztEngine.CloseChannel(args[0]); err != nil {
+				return err
+			}
+			fmt.Println("channel closed")
+			return nil
+		},
+	}
+
+	cmd.AddCommand(openCmd, sendCmd, listCmd, closeCmd)
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add zero-trust data channel command group for opening, sending and closing encrypted channels
- expose geospatial node CLI to record and query coordinate history
- provide experimental node CLI (enabled with `-tags experimental`) for create/start/stop/dial operations

## Testing
- `go test ./...` *(fails: contractVM redeclared in cli/contracts.go)*

------
https://chatgpt.com/codex/tasks/task_e_68915f7a1e5c832099340f19c9e8124e