### PR TITLE
Add CLI support for stage 18 nodes

### DIFF
--- a/cli/contract_management.go
+++ b/cli/contract_management.go
@@ -10,9 +10,7 @@ import (
 )
 
 var (
-	contractVM       = core.NewSimpleVM()
-	contractRegistry = core.NewContractRegistry(contractVM)
-	contractMgr      = core.NewContractManager(contractRegistry)
+	contractMgr = core.NewContractManager(contractRegistry)
 )
 
 func init() {

--- a/cli/geospatial.go
+++ b/cli/geospatial.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy"
+)
+
+var geoNode = synnergy.NewGeospatialNode()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "geospatial",
+		Short: "Geospatial node operations",
+	}
+
+	recordCmd := &cobra.Command{
+		Use:   "record [subject] [lat] [lon]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Record a geospatial point",
+		Run: func(cmd *cobra.Command, args []string) {
+			lat, err := strconv.ParseFloat(args[1], 64)
+			if err != nil {
+				fmt.Println("invalid latitude:", err)
+				return
+			}
+			lon, err := strconv.ParseFloat(args[2], 64)
+			if err != nil {
+				fmt.Println("invalid longitude:", err)
+				return
+			}
+			geoNode.Record(args[0], lat, lon)
+		},
+	}
+
+	historyCmd := &cobra.Command{
+		Use:   "history [subject]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show recorded locations",
+		Run: func(cmd *cobra.Command, args []string) {
+			recs := geoNode.History(args[0])
+			for _, r := range recs {
+				fmt.Printf("%s %f %f %s\n", r.Subject, r.Latitude, r.Longitude, r.Timestamp.Format(time.RFC3339))
+			}
+		},
+	}
+
+	cmd.AddCommand(recordCmd, historyCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/holographic_node.go
+++ b/cli/holographic_node.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy"
+	nodes "synnergy/internal/nodes"
+)
+
+var holoNode = nodes.NewHolographicNode(nodes.Address("holo-1"))
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "holographic",
+		Short: "Holographic node operations",
+	}
+
+	storeCmd := &cobra.Command{
+		Use:   "store [id] [data] [shards]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Store data as holographic frame",
+		Run: func(cmd *cobra.Command, args []string) {
+			n, err := strconv.Atoi(args[2])
+			if err != nil {
+				fmt.Println("invalid shard count:", err)
+				return
+			}
+			frame := synnergy.SplitHolographic(args[0], []byte(args[1]), n)
+			holoNode.Store(frame)
+			fmt.Println("stored")
+		},
+	}
+
+	retrieveCmd := &cobra.Command{
+		Use:   "retrieve [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve stored data",
+		Run: func(cmd *cobra.Command, args []string) {
+			frame, ok := holoNode.Retrieve(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			data := synnergy.ReconstructHolographic(frame)
+			fmt.Println(string(data))
+		},
+	}
+
+	peersCmd := &cobra.Command{
+		Use:   "peers",
+		Short: "List known peers",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, p := range holoNode.Peers() {
+				fmt.Println(p)
+			}
+		},
+	}
+
+	dialCmd := &cobra.Command{
+		Use:   "dial [addr]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Dial a seed peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := holoNode.DialSeed(nodes.Address(args[0])); err != nil {
+				fmt.Println("dial error:", err)
+			}
+		},
+	}
+
+	cmd.AddCommand(storeCmd, retrieveCmd, peersCmd, dialCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/light_node.go
+++ b/cli/light_node.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+	nodes "synnergy/internal/nodes"
+)
+
+var lightNode = core.NewLightNode(nodes.Address("light-1"))
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "light",
+		Short: "Light node operations",
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add-header [hash] [height] [parent]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Add a block header",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				fmt.Println("invalid height:", err)
+				return
+			}
+			header := nodes.BlockHeader{Hash: args[0], Height: h, ParentHash: args[2]}
+			lightNode.AddHeader(header)
+		},
+	}
+
+	latestCmd := &cobra.Command{
+		Use:   "latest",
+		Short: "Show latest header",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, ok := lightNode.LatestHeader()
+			if !ok {
+				fmt.Println("no headers")
+				return
+			}
+			fmt.Printf("%d %s %s\n", h.Height, h.Hash, h.ParentHash)
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "headers",
+		Short: "List all headers",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, h := range lightNode.Headers() {
+				fmt.Printf("%d %s %s\n", h.Height, h.Hash, h.ParentHash)
+			}
+		},
+	}
+
+	cmd.AddCommand(addCmd, latestCmd, listCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/optimization_node.go
+++ b/cli/optimization_node.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	optnodes "synnergy/internal/nodes/extra/optimization_nodes"
+)
+
+var optimizer = &optnodes.SimpleOptimizer{}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "optimization",
+		Short: "Optimization node utilities",
+	}
+
+	suggestCmd := &cobra.Command{
+		Use:   "suggest [cpu] [mem] [latency] [throughput]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Get scaling suggestion",
+		Run: func(cmd *cobra.Command, args []string) {
+			cpu, err := strconv.ParseFloat(args[0], 64)
+			if err != nil {
+				fmt.Println("invalid cpu usage:", err)
+				return
+			}
+			mem, err := strconv.ParseFloat(args[1], 64)
+			if err != nil {
+				fmt.Println("invalid memory usage:", err)
+				return
+			}
+			lat, err := strconv.ParseFloat(args[2], 64)
+			if err != nil {
+				fmt.Println("invalid latency:", err)
+				return
+			}
+			th, err := strconv.ParseFloat(args[3], 64)
+			if err != nil {
+				fmt.Println("invalid throughput:", err)
+				return
+			}
+			s := optimizer.Optimize(optnodes.Metrics{CPUUsage: cpu, MemoryUsage: mem, LatencyMS: lat, Throughput: th})
+			fmt.Printf("scale=%v notes=%s\n", s.ScaleResources, s.Notes)
+		},
+	}
+
+	cmd.AddCommand(suggestCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/watchtower.go
+++ b/cli/watchtower.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy"
+)
+
+var (
+	wtCtx    = context.Background()
+	wtLogger = log.New(os.Stdout, "", log.LstdFlags)
+	wtNode   = synnergy.NewWatchtowerNode("wt-1", wtLogger)
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "watchtower",
+		Short: "Watchtower node operations",
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start monitoring",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := wtNode.Start(wtCtx); err != nil {
+				fmt.Println("start error:", err)
+			}
+		},
+	}
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop monitoring",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := wtNode.Stop(); err != nil {
+				fmt.Println("stop error:", err)
+			}
+		},
+	}
+
+	forkCmd := &cobra.Command{
+		Use:   "fork [height] [hash]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Report a fork",
+		Run: func(cmd *cobra.Command, args []string) {
+			h, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				fmt.Println("invalid height:", err)
+				return
+			}
+			wtNode.ReportFork(h, args[1])
+		},
+	}
+
+	metricsCmd := &cobra.Command{
+		Use:   "metrics",
+		Short: "Show latest metrics",
+		Run: func(cmd *cobra.Command, args []string) {
+			m := wtNode.Metrics()
+			fmt.Printf("cpu=%.2f mem=%d peers=%d height=%d time=%s\n", m.CPUUsage, m.MemoryUsage, m.PeerCount, m.LastBlockHeight, m.Timestamp.Format(time.RFC3339))
+		},
+	}
+
+	cmd.AddCommand(startCmd, stopCmd, forkCmd, metricsCmd)
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add geospatial CLI for recording coordinates and viewing history
- add holographic node CLI for storing/retrieving holographic frames and managing peers
- add light node CLI for managing block headers
- add optimization CLI to suggest resource scaling from runtime metrics
- add watchtower CLI for monitoring, fork reporting, and metrics
- deduplicate contract management globals

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68915f834f688320a54a2d1999a5e759