### PR TITLE
Add CLI support for stage20 tokens

### DIFF
--- a/cli/syn200.go
+++ b/cli/syn200.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var carbonReg = tokens.NewCarbonRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn200",
+		Short: "Carbon credit registry",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a carbon project",
+		Run: func(cmd *cobra.Command, args []string) {
+			owner, _ := cmd.Flags().GetString("owner")
+			name, _ := cmd.Flags().GetString("name")
+			total, _ := cmd.Flags().GetUint64("total")
+			p := carbonReg.Register(owner, name, total)
+			fmt.Println(p.ID)
+		},
+	}
+	registerCmd.Flags().String("owner", "", "project owner")
+	registerCmd.Flags().String("name", "", "project name")
+	registerCmd.Flags().Uint64("total", 0, "total credits")
+	cmd.AddCommand(registerCmd)
+
+	issueCmd := &cobra.Command{
+		Use:   "issue <projectID> <holder> <amount>",
+		Short: "Issue credits to holder",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := carbonReg.Issue(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("issued")
+			}
+		},
+	}
+	cmd.AddCommand(issueCmd)
+
+	retireCmd := &cobra.Command{
+		Use:   "retire <projectID> <holder> <amount>",
+		Short: "Retire credits from holder",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := carbonReg.Retire(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("retired")
+			}
+		},
+	}
+	cmd.AddCommand(retireCmd)
+
+	verifyCmd := &cobra.Command{
+		Use:   "verify <projectID> <verifier> <recordID> <status>",
+		Short: "Add verification record",
+		Args:  cobra.ExactArgs(4),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := carbonReg.AddVerification(args[0], args[1], args[2], args[3]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("verification recorded")
+			}
+		},
+	}
+	cmd.AddCommand(verifyCmd)
+
+	verifsCmd := &cobra.Command{
+		Use:   "verifications <projectID>",
+		Short: "List verifications for project",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			v, ok := carbonReg.Verifications(args[0])
+			if !ok {
+				fmt.Println("project not found")
+				return
+			}
+			for _, rec := range v {
+				fmt.Printf("%+v\n", rec)
+			}
+		},
+	}
+	cmd.AddCommand(verifsCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info <projectID>",
+		Short: "Show project information",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := carbonReg.ProjectInfo(args[0])
+			if !ok {
+				fmt.Println("project not found")
+				return
+			}
+			fmt.Printf("%+v\n", *p)
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List projects",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, p := range carbonReg.ListProjects() {
+				fmt.Printf("%+v\n", *p)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2369.go
+++ b/cli/syn2369.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var itemReg = tokens.NewItemRegistry()
+
+func parseAttrMap(input string) map[string]string {
+	m := make(map[string]string)
+	if input == "" {
+		return m
+	}
+	for _, part := range strings.Split(input, ",") {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) == 2 {
+			m[kv[0]] = kv[1]
+		}
+	}
+	return m
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2369",
+		Short: "Virtual item registry",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create virtual item",
+		Run: func(cmd *cobra.Command, args []string) {
+			owner, _ := cmd.Flags().GetString("owner")
+			name, _ := cmd.Flags().GetString("name")
+			desc, _ := cmd.Flags().GetString("desc")
+			attrs, _ := cmd.Flags().GetString("attrs")
+			it := itemReg.CreateItem(owner, name, desc, parseAttrMap(attrs))
+			fmt.Println(it.ItemID)
+		},
+	}
+	createCmd.Flags().String("owner", "", "item owner")
+	createCmd.Flags().String("name", "", "item name")
+	createCmd.Flags().String("desc", "", "description")
+	createCmd.Flags().String("attrs", "", "attributes key=value pairs")
+	cmd.AddCommand(createCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <itemID> <newOwner>",
+		Short: "Transfer item",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := itemReg.TransferItem(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("transferred")
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	attrsCmd := &cobra.Command{
+		Use:   "attrs <itemID> <key=value,...>",
+		Short: "Update item attributes",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := itemReg.UpdateAttributes(args[0], parseAttrMap(args[1])); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("updated")
+			}
+		},
+	}
+	cmd.AddCommand(attrsCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <itemID>",
+		Short: "Get item info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			it, ok := itemReg.GetItem(args[0])
+			if !ok {
+				fmt.Println("item not found")
+				return
+			}
+			fmt.Printf("%+v\n", *it)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List items",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, it := range itemReg.ListItems() {
+				fmt.Printf("%+v\n", *it)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2600.go
+++ b/cli/syn2600.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var investorReg = tokens.NewInvestorRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2600",
+		Short: "Investor token registry",
+	}
+
+	issueCmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Issue investor token",
+		Run: func(cmd *cobra.Command, args []string) {
+			asset, _ := cmd.Flags().GetString("asset")
+			owner, _ := cmd.Flags().GetString("owner")
+			shares, _ := cmd.Flags().GetUint64("shares")
+			expiryStr, _ := cmd.Flags().GetString("expiry")
+			expiry, _ := time.Parse(time.RFC3339, expiryStr)
+			tok := investorReg.Issue(asset, owner, shares, expiry)
+			fmt.Println(tok.ID)
+		},
+	}
+	issueCmd.Flags().String("asset", "", "underlying asset")
+	issueCmd.Flags().String("owner", "", "token owner")
+	issueCmd.Flags().Uint64("shares", 0, "share amount")
+	issueCmd.Flags().String("expiry", time.Now().Add(24*time.Hour).Format(time.RFC3339), "expiry time")
+	cmd.AddCommand(issueCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <tokenID> <newOwner>",
+		Short: "Transfer token ownership",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := investorReg.Transfer(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("transferred")
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	returnCmd := &cobra.Command{
+		Use:   "record-return <tokenID> <amount>",
+		Short: "Record investor return",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			if err := investorReg.RecordReturn(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("recorded")
+			}
+		},
+	}
+	cmd.AddCommand(returnCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <tokenID>",
+		Short: "Get token info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			tok, ok := investorReg.Get(args[0])
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			fmt.Printf("%+v\n", *tok)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, tok := range investorReg.List() {
+				fmt.Printf("%+v\n", *tok)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2800.go
+++ b/cli/syn2800.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var lifeReg = tokens.NewLifePolicyRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2800",
+		Short: "Life insurance policies",
+	}
+
+	issueCmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Issue policy",
+		Run: func(cmd *cobra.Command, args []string) {
+			insured, _ := cmd.Flags().GetString("insured")
+			beneficiary, _ := cmd.Flags().GetString("beneficiary")
+			coverage, _ := cmd.Flags().GetUint64("coverage")
+			premium, _ := cmd.Flags().GetUint64("premium")
+			startStr, _ := cmd.Flags().GetString("start")
+			endStr, _ := cmd.Flags().GetString("end")
+			start, _ := time.Parse(time.RFC3339, startStr)
+			end, _ := time.Parse(time.RFC3339, endStr)
+			p := lifeReg.IssuePolicy(insured, beneficiary, coverage, premium, start, end)
+			fmt.Println(p.PolicyID)
+		},
+	}
+	issueCmd.Flags().String("insured", "", "insured party")
+	issueCmd.Flags().String("beneficiary", "", "beneficiary")
+	issueCmd.Flags().Uint64("coverage", 0, "coverage amount")
+	issueCmd.Flags().Uint64("premium", 0, "premium amount")
+	issueCmd.Flags().String("start", time.Now().Format(time.RFC3339), "start time")
+	issueCmd.Flags().String("end", time.Now().Add(24*time.Hour).Format(time.RFC3339), "end time")
+	cmd.AddCommand(issueCmd)
+
+	payCmd := &cobra.Command{
+		Use:   "pay-premium <policyID> <amount>",
+		Short: "Record premium payment",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			if err := lifeReg.PayPremium(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("payment recorded")
+			}
+		},
+	}
+	cmd.AddCommand(payCmd)
+
+	claimCmd := &cobra.Command{
+		Use:   "file-claim <policyID> <amount>",
+		Short: "File a claim",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			c, err := lifeReg.FileClaim(args[0], amt)
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println(c.ClaimID)
+			}
+		},
+	}
+	cmd.AddCommand(claimCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <policyID>",
+		Short: "Get policy info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := lifeReg.GetPolicy(args[0])
+			if !ok {
+				fmt.Println("policy not found")
+				return
+			}
+			fmt.Printf("%+v\n", *p)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List policies",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, p := range lifeReg.ListPolicies() {
+				fmt.Printf("%+v\n", *p)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn3400.go
+++ b/cli/syn3400.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var forexReg = tokens.NewForexRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3400",
+		Short: "Forex pair registry",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register forex pair",
+		Run: func(cmd *cobra.Command, args []string) {
+			base, _ := cmd.Flags().GetString("base")
+			quote, _ := cmd.Flags().GetString("quote")
+			rate, _ := cmd.Flags().GetFloat64("rate")
+			p := forexReg.Register(base, quote, rate)
+			fmt.Println(p.PairID)
+		},
+	}
+	registerCmd.Flags().String("base", "", "base currency")
+	registerCmd.Flags().String("quote", "", "quote currency")
+	registerCmd.Flags().Float64("rate", 1.0, "exchange rate")
+	cmd.AddCommand(registerCmd)
+
+	updateCmd := &cobra.Command{
+		Use:   "update-rate <pairID> <rate>",
+		Short: "Update exchange rate",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var rate float64
+			fmt.Sscanf(args[1], "%f", &rate)
+			if err := forexReg.UpdateRate(args[0], rate); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("updated")
+			}
+		},
+	}
+	cmd.AddCommand(updateCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <pairID>",
+		Short: "Get pair info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := forexReg.Get(args[0])
+			if !ok {
+				fmt.Println("pair not found")
+				return
+			}
+			fmt.Printf("%+v\n", *p)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List pairs",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, p := range forexReg.List() {
+				fmt.Printf("%+v\n", *p)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn4200_token.go
+++ b/cli/syn4200_token.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var charityTok = tokens.NewSYN4200Token()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn4200",
+		Short: "Charity token utilities",
+	}
+
+	donateCmd := &cobra.Command{
+		Use:   "donate <symbol> <from> <amount>",
+		Short: "Donate to campaign",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			purpose, _ := cmd.Flags().GetString("purpose")
+			charityTok.Donate(args[0], args[1], amt, purpose)
+			fmt.Println("donated")
+		},
+	}
+	donateCmd.Flags().String("purpose", "", "campaign purpose")
+	cmd.AddCommand(donateCmd)
+
+	progressCmd := &cobra.Command{
+		Use:   "progress <symbol>",
+		Short: "Show campaign progress",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, ok := charityTok.CampaignProgress(args[0])
+			if !ok {
+				fmt.Println("campaign not found")
+				return
+			}
+			fmt.Println(amt)
+		},
+	}
+	cmd.AddCommand(progressCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info <symbol>",
+		Short: "Show campaign info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			c, ok := charityTok.Campaign(args[0])
+			if !ok {
+				fmt.Println("campaign not found")
+				return
+			}
+			fmt.Printf("%+v\n", *c)
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn4700.go
+++ b/cli/syn4700.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var legalReg = tokens.NewLegalTokenRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn4700",
+		Short: "Legal token registry",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create legal token",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetString("id")
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			doctype, _ := cmd.Flags().GetString("doctype")
+			hash, _ := cmd.Flags().GetString("hash")
+			owner, _ := cmd.Flags().GetString("owner")
+			expiryStr, _ := cmd.Flags().GetString("expiry")
+			supply, _ := cmd.Flags().GetUint64("supply")
+			partiesStr, _ := cmd.Flags().GetString("parties")
+			expiry, _ := time.Parse(time.RFC3339, expiryStr)
+			parties := []string{}
+			if partiesStr != "" {
+				parties = strings.Split(partiesStr, ",")
+			}
+			t := tokens.NewLegalToken(id, name, symbol, doctype, hash, owner, expiry, supply, parties)
+			legalReg.Add(t)
+			fmt.Println("created")
+		},
+	}
+	createCmd.Flags().String("id", "", "token id")
+	createCmd.Flags().String("name", "", "token name")
+	createCmd.Flags().String("symbol", "", "token symbol")
+	createCmd.Flags().String("doctype", "", "document type")
+	createCmd.Flags().String("hash", "", "document hash")
+	createCmd.Flags().String("owner", "", "owner address")
+	createCmd.Flags().String("expiry", time.Now().Add(24*time.Hour).Format(time.RFC3339), "expiry time")
+	createCmd.Flags().Uint64("supply", 0, "token supply")
+	createCmd.Flags().String("parties", "", "comma separated parties")
+	cmd.AddCommand(createCmd)
+
+	signCmd := &cobra.Command{
+		Use:   "sign <id> <party> <sig>",
+		Short: "Add party signature",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			t, ok := legalReg.Get(args[0])
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			if err := t.Sign(args[1], args[2]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("signed")
+			}
+		},
+	}
+	cmd.AddCommand(signCmd)
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke <id> <party>",
+		Short: "Revoke party signature",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			t, ok := legalReg.Get(args[0])
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			t.RevokeSignature(args[1])
+			fmt.Println("revoked")
+		},
+	}
+	cmd.AddCommand(revokeCmd)
+
+	statusCmd := &cobra.Command{
+		Use:   "status <id> <status>",
+		Short: "Update token status",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			t, ok := legalReg.Get(args[0])
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			t.UpdateStatus(tokens.LegalTokenStatus(args[1]))
+			fmt.Println("updated")
+		},
+	}
+	cmd.AddCommand(statusCmd)
+
+	disputeCmd := &cobra.Command{
+		Use:   "dispute <id> <action> [result]",
+		Short: "Record dispute action",
+		Args:  cobra.RangeArgs(2, 3),
+		Run: func(cmd *cobra.Command, args []string) {
+			t, ok := legalReg.Get(args[0])
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			res := ""
+			if len(args) == 3 {
+				res = args[2]
+			}
+			t.Dispute(args[1], res)
+			fmt.Println("disputed")
+		},
+	}
+	cmd.AddCommand(disputeCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get token info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			t, ok := legalReg.Get(args[0])
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			fmt.Printf("%+v\n", *t)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List legal tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, t := range legalReg.List() {
+				fmt.Printf("%+v\n", *t)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn70.go
+++ b/cli/syn70.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var syn70Tok *tokens.SYN70Token
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn70",
+		Short: "SYN70 in-game assets",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise SYN70 token",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := cmd.Flags().GetUint64("id")
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			dec, _ := cmd.Flags().GetUint64("decimals")
+			syn70Tok = tokens.NewSYN70Token(tokens.TokenID(id), name, symbol, uint8(dec))
+			fmt.Println("token initialised")
+		},
+	}
+	initCmd.Flags().Uint64("id", 0, "token id")
+	initCmd.Flags().String("name", "", "token name")
+	initCmd.Flags().String("symbol", "", "token symbol")
+	initCmd.Flags().Uint64("decimals", 0, "decimal places")
+	cmd.AddCommand(initCmd)
+
+	regCmd := &cobra.Command{
+		Use:   "register-asset",
+		Short: "Register asset",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70Tok == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			id, _ := cmd.Flags().GetString("id")
+			owner, _ := cmd.Flags().GetString("owner")
+			name, _ := cmd.Flags().GetString("name")
+			game, _ := cmd.Flags().GetString("game")
+			if err := syn70Tok.RegisterAsset(id, owner, name, game); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("asset registered")
+			}
+		},
+	}
+	regCmd.Flags().String("id", "", "asset id")
+	regCmd.Flags().String("owner", "", "asset owner")
+	regCmd.Flags().String("name", "", "asset name")
+	regCmd.Flags().String("game", "", "game name")
+	cmd.AddCommand(regCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer-asset <assetID> <newOwner>",
+		Short: "Transfer asset",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70Tok == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn70Tok.TransferAsset(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("transferred")
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	attrCmd := &cobra.Command{
+		Use:   "set-attr <assetID> <key> <value>",
+		Short: "Set asset attribute",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70Tok == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn70Tok.SetAttribute(args[0], args[1], args[2]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("attribute set")
+			}
+		},
+	}
+	cmd.AddCommand(attrCmd)
+
+	achCmd := &cobra.Command{
+		Use:   "add-achievement <assetID> <name>",
+		Short: "Add asset achievement",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70Tok == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn70Tok.AddAchievement(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("achievement added")
+			}
+		},
+	}
+	cmd.AddCommand(achCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info <assetID>",
+		Short: "Show asset info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70Tok == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			asset, err := syn70Tok.AssetInfo(args[0])
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Printf("%+v\n", asset)
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List assets",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70Tok == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			for _, a := range syn70Tok.ListAssets() {
+				fmt.Printf("%+v\n", a)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn845.go
+++ b/cli/syn845.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var debtReg = tokens.NewDebtRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn845",
+		Short: "Debt token registry",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create-token",
+		Short: "Create debt token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			owner, _ := cmd.Flags().GetString("owner")
+			supply, _ := cmd.Flags().GetUint64("supply")
+			id, _ := debtReg.CreateToken(name, symbol, owner, supply)
+			fmt.Println(id)
+		},
+	}
+	createCmd.Flags().String("name", "", "token name")
+	createCmd.Flags().String("symbol", "", "token symbol")
+	createCmd.Flags().String("owner", "", "owner address")
+	createCmd.Flags().Uint64("supply", 0, "token supply")
+	cmd.AddCommand(createCmd)
+
+	issueCmd := &cobra.Command{
+		Use:   "issue <tokenID> <debtID> <borrower> <principal> <rate> <penalty> <due>",
+		Short: "Issue debt instrument",
+		Args:  cobra.ExactArgs(7),
+		Run: func(cmd *cobra.Command, args []string) {
+			var principal uint64
+			var rate, penalty float64
+			fmt.Sscanf(args[3], "%d", &principal)
+			fmt.Sscanf(args[4], "%f", &rate)
+			fmt.Sscanf(args[5], "%f", &penalty)
+			due, _ := time.Parse(time.RFC3339, args[6])
+			if err := debtReg.IssueDebt(args[0], args[1], args[2], principal, rate, penalty, due); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("issued")
+			}
+		},
+	}
+	cmd.AddCommand(issueCmd)
+
+	payCmd := &cobra.Command{
+		Use:   "pay <tokenID> <debtID> <amount>",
+		Short: "Record debt payment",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := debtReg.RecordPayment(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			} else {
+				fmt.Println("payment recorded")
+			}
+		},
+	}
+	cmd.AddCommand(payCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <tokenID> <debtID>",
+		Short: "Get debt info",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			d, err := debtReg.GetDebt(args[0], args[1])
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Printf("%+v\n", *d)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add CLI for carbon credit registry (SYN200)
- implement virtual item, investor token, and life policy CLIs
- expose forex, charity, legal, game asset, and debt token commands

## Testing
- `go test ./...` *(fails: contractVM and contractRegistry redeclared in cli package)*

------
https://chatgpt.com/codex/tasks/task_e_68915fadd9608320b3c056ed5819cc6a