### PR TITLE
Add stage 9 CLI support

### DIFF
--- a/cli/instruction.go
+++ b/cli/instruction.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+func parseOpcode(arg string) (core.Opcode, error) {
+	if n, err := strconv.ParseUint(arg, 10, 32); err == nil {
+		return core.Opcode(n), nil
+	}
+	for op, name := range core.Opcodes() {
+		if strings.EqualFold(name, arg) {
+			return op, nil
+		}
+	}
+	return 0, fmt.Errorf("unknown opcode %s", arg)
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "instruction",
+		Short: "Work with VM instructions",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "new [opcode] [value]",
+		Args:  cobra.RangeArgs(1, 2),
+		Short: "Create an instruction",
+		Run: func(cmd *cobra.Command, args []string) {
+			op, err := parseOpcode(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			var val int64
+			if len(args) == 2 {
+				v, err := strconv.ParseInt(args[1], 10, 64)
+				if err != nil {
+					fmt.Println("invalid value")
+					return
+				}
+				val = v
+			}
+			inst := core.Instruction{Op: op, Value: val}
+			b, _ := json.Marshal(inst)
+			fmt.Println(string(b))
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List registered opcodes",
+		Run: func(cmd *cobra.Command, args []string) {
+			cat := core.Catalogue()
+			b, _ := json.MarshalIndent(cat, "", "  ")
+			fmt.Println(string(b))
+		},
+	})
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/kademlia.go
+++ b/cli/kademlia.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var kademlia = core.NewKademlia()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "kademlia",
+		Short: "Interact with the Kademlia DHT",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "store [key] [value]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Store a key/value pair",
+		Run: func(cmd *cobra.Command, args []string) {
+			val, err := hex.DecodeString(args[1])
+			if err != nil {
+				val = []byte(args[1])
+			}
+			kademlia.Store(args[0], val)
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "get [key]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Retrieve a value",
+		Run: func(cmd *cobra.Command, args []string) {
+			if v, ok := kademlia.FindValue(args[0]); ok {
+				fmt.Println(string(v))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "closest [target] [n]",
+		Args:  cobra.ExactArgs(2),
+		Short: "List n closest keys to target",
+		Run: func(cmd *cobra.Command, args []string) {
+			n, _ := strconv.Atoi(args[1])
+			keys := kademlia.Closest(args[0], n)
+			for _, k := range keys {
+				fmt.Println(k)
+			}
+		},
+	})
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/liquidity_pools.go
+++ b/cli/liquidity_pools.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var poolRegistry = core.NewLiquidityPoolRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "liquidity_pools",
+		Short: "Manage liquidity pools",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "create [tokenA] [tokenB] [feeBps]",
+		Args:  cobra.RangeArgs(2, 3),
+		Short: "Create a new liquidity pool",
+		Run: func(cmd *cobra.Command, args []string) {
+			fee := uint16(30)
+			if len(args) == 3 {
+				f, err := strconv.Atoi(args[2])
+				if err != nil {
+					fmt.Println("invalid fee")
+					return
+				}
+				fee = uint16(f)
+			}
+			id := fmt.Sprintf("%s-%s", args[0], args[1])
+			if _, err := poolRegistry.Create(id, args[0], args[1], fee); err != nil {
+				fmt.Println("error:", err)
+			} else {
+				fmt.Println("created", id)
+			}
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "add [poolID] [provider] [amtA] [amtB]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Add liquidity to a pool",
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := poolRegistry.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			a, _ := strconv.ParseUint(args[2], 10, 64)
+			b, _ := strconv.ParseUint(args[3], 10, 64)
+			lp, err := p.AddLiquidity(args[1], a, b)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(lp)
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "swap [poolID] [tokenIn] [amtIn] [minOut]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Swap tokens within a pool",
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := poolRegistry.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			amtIn, _ := strconv.ParseUint(args[2], 10, 64)
+			minOut, _ := strconv.ParseUint(args[3], 10, 64)
+			out, err := p.Swap(args[1], amtIn, minOut)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(out)
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "remove [poolID] [provider] [lpTokens]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Remove liquidity from a pool",
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := poolRegistry.Get(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			lp, _ := strconv.ParseUint(args[2], 10, 64)
+			a, b, err := p.RemoveLiquidity(args[1], lp)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Printf("%d %d\n", a, b)
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "info [poolID]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show pool state",
+		Run: func(cmd *cobra.Command, args []string) {
+			if view, ok := poolRegistry.PoolInfo(args[0]); ok {
+				b, _ := json.MarshalIndent(view, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List all pools",
+		Run: func(cmd *cobra.Command, args []string) {
+			views := poolRegistry.PoolViews()
+			b, _ := json.MarshalIndent(views, "", "  ")
+			fmt.Println(string(b))
+		},
+	})
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/liquidity_views.go
+++ b/cli/liquidity_views.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "liquidity_views",
+		Short: "Inspect liquidity pool views",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "info [poolID]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show pool state",
+		Run: func(cmd *cobra.Command, args []string) {
+			if view, ok := poolRegistry.PoolInfo(args[0]); ok {
+				b, _ := json.MarshalIndent(view, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List all pools",
+		Run: func(cmd *cobra.Command, args []string) {
+			views := poolRegistry.PoolViews()
+			b, _ := json.MarshalIndent(views, "", "  ")
+			fmt.Println(string(b))
+		},
+	})
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/loanpool_management.go
+++ b/cli/loanpool_management.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var loanMgr = core.NewLoanPoolManager(loanPool)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "loanmgr",
+		Short: "Administrative loan pool controls",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "pause",
+		Short: "Pause new proposals",
+		Run:   func(cmd *cobra.Command, args []string) { loanMgr.Pause() },
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "resume",
+		Short: "Resume proposal submissions",
+		Run:   func(cmd *cobra.Command, args []string) { loanMgr.Resume() },
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "stats",
+		Short: "Display treasury and proposal stats",
+		Run: func(cmd *cobra.Command, args []string) {
+			stats := loanMgr.Stats()
+			b, _ := json.MarshalIndent(stats, "", "  ")
+			fmt.Println(string(b))
+		},
+	})
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/loanpool_proposal.go
+++ b/cli/loanpool_proposal.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	proposals      = make(map[uint64]*core.LoanProposal)
+	nextProposalID uint64
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "loanproposal",
+		Short: "Work with standalone loan proposals",
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "new [creator] [recipient] [type] [amount] [desc] [durationHours]",
+		Args:  cobra.ExactArgs(6),
+		Short: "Create a loan proposal",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, _ := strconv.ParseUint(args[3], 10, 64)
+			dur, _ := strconv.Atoi(args[5])
+			nextProposalID++
+			p := core.NewLoanProposal(nextProposalID, args[0], args[1], args[2], amt, args[4], time.Duration(dur)*time.Hour)
+			proposals[nextProposalID] = p
+			fmt.Println(nextProposalID)
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "vote [id] [voter]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Cast a vote on a proposal",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			if p, ok := proposals[id]; ok {
+				p.Vote(args[1])
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "votes [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show vote count",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			if p, ok := proposals[id]; ok {
+				fmt.Println(p.VoteCount())
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "expired [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Check if proposal has expired",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			if p, ok := proposals[id]; ok {
+				fmt.Println(p.IsExpired(time.Now()))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "get [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show proposal details",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.ParseUint(args[0], 10, 64)
+			if p, ok := proposals[id]; ok {
+				b, _ := json.MarshalIndent(p, "", "  ")
+				fmt.Println(string(b))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	})
+
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- implement ledger CLI with block, balance, UTXO, mint and transfer helpers
- add instruction, kademlia and loan management CLI tooling
- expose liquidity pool creation, swapping and view commands

## Testing
- `go test ./...` *(fails: cli/watchtower.go:32:1: syntax error: non-declaration statement outside function body)*

------
https://chatgpt.com/codex/tasks/task_e_6891641e0fa883209f960b24271fe98a