### PR TITLE
Add CLI support for rollups, sharding, sidechains, and WebRTC RPC

### DIFF
--- a/cli/rollup_management.go
+++ b/cli/rollup_management.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "rollupmgr",
+		Short: "Control the rollup aggregator",
+	}
+
+	pauseCmd := &cobra.Command{
+		Use:   "pause",
+		Short: "Pause aggregator",
+		Run: func(cmd *cobra.Command, args []string) {
+			rollupMgr.Pause()
+		},
+	}
+
+	resumeCmd := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume aggregator",
+		Run: func(cmd *cobra.Command, args []string) {
+			rollupMgr.Resume()
+		},
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show pause status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if rollupMgr.Status() {
+				fmt.Println("paused")
+			} else {
+				fmt.Println("running")
+			}
+		},
+	}
+
+	cmd.AddCommand(pauseCmd, resumeCmd, statusCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/rollups.go
+++ b/cli/rollups.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	rollupAgg = core.NewRollupAggregator()
+	rollupMgr = core.NewRollupManager(rollupAgg)
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "rollups",
+		Short: "Manage rollup batches",
+	}
+
+	submitCmd := &cobra.Command{
+		Use:   "submit [tx ...]",
+		Args:  cobra.MinimumNArgs(1),
+		Short: "Submit a new rollup batch",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, err := rollupAgg.SubmitBatch(args)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(id)
+		},
+	}
+
+	challengeCmd := &cobra.Command{
+		Use:   "challenge [batchID] [txIdx] [proof]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Submit a fraud proof for a batch",
+		Run: func(cmd *cobra.Command, args []string) {
+			idx, err := strconv.Atoi(args[1])
+			if err != nil {
+				fmt.Println("invalid index")
+				return
+			}
+			if err := rollupAgg.ChallengeBatch(args[0], idx, []byte(args[2])); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	finalizeCmd := &cobra.Command{
+		Use:   "finalize [batchID] [valid]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Finalize or revert a batch",
+		Run: func(cmd *cobra.Command, args []string) {
+			valid, err := strconv.ParseBool(args[1])
+			if err != nil {
+				fmt.Println("invalid bool")
+				return
+			}
+			if err := rollupAgg.FinalizeBatch(args[0], valid); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	infoCmd := &cobra.Command{
+		Use:   "info [batchID]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Display batch header and state",
+		Run: func(cmd *cobra.Command, args []string) {
+			b, ok := rollupAgg.BatchInfo(args[0])
+			if !ok {
+				fmt.Println("not found")
+				return
+			}
+			out, _ := json.MarshalIndent(b, "", "  ")
+			fmt.Println(string(out))
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List recent batches",
+		Run: func(cmd *cobra.Command, args []string) {
+			bs := rollupAgg.ListBatches()
+			out, _ := json.MarshalIndent(bs, "", "  ")
+			fmt.Println(string(out))
+		},
+	}
+
+	txsCmd := &cobra.Command{
+		Use:   "txs [batchID]",
+		Args:  cobra.ExactArgs(1),
+		Short: "List transactions in a batch",
+		Run: func(cmd *cobra.Command, args []string) {
+			txs, err := rollupAgg.BatchTransactions(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			for _, tx := range txs {
+				fmt.Println(tx)
+			}
+		},
+	}
+
+	pauseCmd := &cobra.Command{
+		Use:   "pause",
+		Short: "Pause the rollup aggregator",
+		Run: func(cmd *cobra.Command, args []string) {
+			rollupMgr.Pause()
+		},
+	}
+
+	resumeCmd := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume the rollup aggregator",
+		Run: func(cmd *cobra.Command, args []string) {
+			rollupMgr.Resume()
+		},
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show aggregator status",
+		Run: func(cmd *cobra.Command, args []string) {
+			if rollupMgr.Status() {
+				fmt.Println("paused")
+			} else {
+				fmt.Println("running")
+			}
+		},
+	}
+
+	cmd.AddCommand(submitCmd, challengeCmd, finalizeCmd, infoCmd, listCmd, txsCmd, pauseCmd, resumeCmd, statusCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/rpc_webrtc.go
+++ b/cli/rpc_webrtc.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	webrtcRPC = core.NewWebRTCRPC()
+	peerChans = map[string]<-chan []byte{}
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "rpcwebrtc",
+		Short: "Simulate WebRTC RPC messaging",
+	}
+
+	connectCmd := &cobra.Command{
+		Use:   "connect [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Connect a peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			ch := webrtcRPC.Connect(args[0])
+			peerChans[args[0]] = ch
+		},
+	}
+
+	sendCmd := &cobra.Command{
+		Use:   "send [id] [msg]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Send message to peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			if webrtcRPC.Send(args[0], []byte(args[1])) {
+				fmt.Println("sent")
+			} else {
+				fmt.Println("failed")
+			}
+		},
+	}
+
+	recvCmd := &cobra.Command{
+		Use:   "recv [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Receive a message for peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			ch, ok := peerChans[args[0]]
+			if !ok {
+				fmt.Println("not connected")
+				return
+			}
+			select {
+			case msg := <-ch:
+				fmt.Println(string(msg))
+			default:
+				fmt.Println("no message")
+			}
+		},
+	}
+
+	disconnectCmd := &cobra.Command{
+		Use:   "disconnect [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Disconnect a peer",
+		Run: func(cmd *cobra.Command, args []string) {
+			webrtcRPC.Disconnect(args[0])
+			delete(peerChans, args[0])
+		},
+	}
+
+	cmd.AddCommand(connectCmd, sendCmd, recvCmd, disconnectCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/sharding.go
+++ b/cli/sharding.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var shardMgr = core.NewShardManager(2)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "sharding",
+		Short: "Manage shard assignments",
+	}
+
+	leaderCmd := &cobra.Command{
+		Use:   "leader",
+		Short: "Query or set shard leaders",
+	}
+
+	leaderGet := &cobra.Command{
+		Use:   "get [shardID]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Show the leader for a shard",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.Atoi(args[0])
+			if addr, ok := shardMgr.GetLeader(id); ok {
+				fmt.Println(addr)
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	leaderSet := &cobra.Command{
+		Use:   "set [shardID] [addr]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Set the leader address for a shard",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.Atoi(args[0])
+			shardMgr.SetLeader(id, args[1])
+		},
+	}
+
+	leaderCmd.AddCommand(leaderGet, leaderSet)
+
+	mapCmd := &cobra.Command{
+		Use:   "map",
+		Short: "List shard-to-leader mappings",
+		Run: func(cmd *cobra.Command, args []string) {
+			m := shardMgr.LeaderMap()
+			out, _ := json.MarshalIndent(m, "", "  ")
+			fmt.Println(string(out))
+		},
+	}
+
+	submitCmd := &cobra.Command{
+		Use:   "submit [fromShard] [toShard] [txHash]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Submit a cross-shard transaction header",
+		Run: func(cmd *cobra.Command, args []string) {
+			from, _ := strconv.Atoi(args[0])
+			to, _ := strconv.Atoi(args[1])
+			shardMgr.SubmitCrossShardTx(from, to, args[2])
+		},
+	}
+
+	pullCmd := &cobra.Command{
+		Use:   "pull [shardID]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Pull receipts for a shard",
+		Run: func(cmd *cobra.Command, args []string) {
+			id, _ := strconv.Atoi(args[0])
+			rec := shardMgr.PullReceipts(id)
+			for _, tx := range rec {
+				fmt.Println(tx)
+			}
+		},
+	}
+
+	reshardCmd := &cobra.Command{
+		Use:   "reshard [newBits]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Increase the shard count",
+		Run: func(cmd *cobra.Command, args []string) {
+			bits, _ := strconv.Atoi(args[0])
+			shardMgr.Reshard(uint8(bits))
+		},
+	}
+
+	rebalanceCmd := &cobra.Command{
+		Use:   "rebalance [threshold]",
+		Args:  cobra.ExactArgs(1),
+		Short: "List shards exceeding load threshold",
+		Run: func(cmd *cobra.Command, args []string) {
+			th, _ := strconv.Atoi(args[0])
+			heavy := shardMgr.Rebalance(th)
+			if len(heavy) == 0 {
+				fmt.Println("none")
+				return
+			}
+			for _, id := range heavy {
+				fmt.Println(id)
+			}
+		},
+	}
+
+	cmd.AddCommand(leaderCmd, mapCmd, submitCmd, pullCmd, reshardCmd, rebalanceCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/sidechain_ops.go
+++ b/cli/sidechain_ops.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "sidechainops",
+		Short: "Side-chain escrow helpers",
+	}
+
+	depositCmd := &cobra.Command{
+		Use:   "deposit [chainID] [from] [amount]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Deposit tokens to escrow",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			if err := sideOps.Deposit(args[0], args[1], amt); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	withdrawCmd := &cobra.Command{
+		Use:   "withdraw [chainID] [from] [amount] [proof]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Withdraw from escrow with proof",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			if err := sideOps.Withdraw(args[0], args[1], amt, args[3]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	balanceCmd := &cobra.Command{
+		Use:   "balance [chainID] [addr]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Show escrow balance for address",
+		Run: func(cmd *cobra.Command, args []string) {
+			bal, err := sideOps.EscrowBalance(args[0], args[1])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(bal)
+		},
+	}
+
+	cmd.AddCommand(depositCmd, withdrawCmd, balanceCmd)
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/sidechains.go
+++ b/cli/sidechains.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"synnergy/core"
+)
+
+var (
+	sideReg = core.NewSidechainRegistry()
+	sideOps = core.NewSidechainOps(sideReg)
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "sidechain",
+		Short: "Manage side-chains",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register [id] [meta] [validators...]",
+		Args:  cobra.MinimumNArgs(2),
+		Short: "Register a new side-chain",
+		Run: func(cmd *cobra.Command, args []string) {
+			sc, err := sideReg.Register(args[0], args[1], args[2:])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			out, _ := json.MarshalIndent(sc, "", "  ")
+			fmt.Println(string(out))
+		},
+	}
+
+	headerCmd := &cobra.Command{
+		Use:   "header [id] [header]",
+		Args:  cobra.ExactArgs(2),
+		Short: "Submit a side-chain header",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sideReg.SubmitHeader(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	getHeaderCmd := &cobra.Command{
+		Use:   "get-header [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Fetch a submitted side-chain header",
+		Run: func(cmd *cobra.Command, args []string) {
+			if h, ok := sideReg.GetHeader(args[0]); ok {
+				fmt.Println(h)
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	metaCmd := &cobra.Command{
+		Use:   "meta [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Display side-chain metadata",
+		Run: func(cmd *cobra.Command, args []string) {
+			if sc, ok := sideReg.Meta(args[0]); ok {
+				out, _ := json.MarshalIndent(sc, "", "  ")
+				fmt.Println(string(out))
+			} else {
+				fmt.Println("not found")
+			}
+		},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered side-chains",
+		Run: func(cmd *cobra.Command, args []string) {
+			scs := sideReg.List()
+			out, _ := json.MarshalIndent(scs, "", "  ")
+			fmt.Println(string(out))
+		},
+	}
+
+	pauseCmd := &cobra.Command{
+		Use:   "pause [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Pause a side-chain",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sideReg.Pause(args[0]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	resumeCmd := &cobra.Command{
+		Use:   "resume [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Resume a paused side-chain",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sideReg.Resume(args[0]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	updateCmd := &cobra.Command{
+		Use:   "update-validators [id] [validators...]",
+		Args:  cobra.MinimumNArgs(2),
+		Short: "Update side-chain validator set",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sideReg.UpdateValidators(args[0], args[1:]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	removeCmd := &cobra.Command{
+		Use:   "remove [id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a side-chain and all data",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sideReg.Remove(args[0]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	depositCmd := &cobra.Command{
+		Use:   "deposit [chainID] [from] [amount]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Deposit tokens to a side-chain escrow",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			if err := sideOps.Deposit(args[0], args[1], amt); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	withdrawCmd := &cobra.Command{
+		Use:   "withdraw [chainID] [from] [amount] [proof]",
+		Args:  cobra.ExactArgs(4),
+		Short: "Verify a withdrawal proof",
+		Run: func(cmd *cobra.Command, args []string) {
+			amt, err := strconv.ParseUint(args[2], 10, 64)
+			if err != nil {
+				fmt.Println("invalid amount")
+				return
+			}
+			if err := sideOps.Withdraw(args[0], args[1], amt, args[3]); err != nil {
+				fmt.Println("error:", err)
+			}
+		},
+	}
+
+	cmd.AddCommand(registerCmd, headerCmd, getHeaderCmd, metaCmd, listCmd, pauseCmd, resumeCmd, updateCmd, removeCmd, depositCmd, withdrawCmd)
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add `rollups` CLI to submit, manage, and audit rollup batches
- expose dedicated `rollupmgr` controls for pausing/resuming aggregators
- implement sharding, sidechain registry & escrow, and WebRTC RPC CLI helpers

## Testing
- `go test ./cli/...` *(fails: syntax error in cli/watchtower.go)*

------
https://chatgpt.com/codex/tasks/task_e_6891642ac840832083a2ae2ff241d848