### PR TITLE
Add CLI commands for Stage20 token registries

### DIFF
--- a/cli/syn200.go
+++ b/cli/syn200.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var carbonRegistry = tokens.NewCarbonRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn200",
+		Short: "Carbon credit registry",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a carbon project",
+		Run: func(cmd *cobra.Command, args []string) {
+			owner, _ := cmd.Flags().GetString("owner")
+			name, _ := cmd.Flags().GetString("name")
+			total, _ := cmd.Flags().GetUint64("total")
+			p := carbonRegistry.Register(owner, name, total)
+			fmt.Println(p.ID)
+		},
+	}
+	registerCmd.Flags().String("owner", "", "project owner")
+	registerCmd.Flags().String("name", "", "project name")
+	registerCmd.Flags().Uint64("total", 0, "total credits")
+	cmd.AddCommand(registerCmd)
+
+	issueCmd := &cobra.Command{
+		Use:   "issue <project> <to> <amount>",
+		Short: "Issue carbon credits",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := carbonRegistry.Issue(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(issueCmd)
+
+	retireCmd := &cobra.Command{
+		Use:   "retire <project> <holder> <amount>",
+		Short: "Retire credits from circulation",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := carbonRegistry.Retire(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(retireCmd)
+
+	verifyCmd := &cobra.Command{
+		Use:   "verify <project> <verifier> <recordID> [status]",
+		Short: "Add a verification record",
+		Args:  cobra.RangeArgs(3, 4),
+		Run: func(cmd *cobra.Command, args []string) {
+			status := ""
+			if len(args) == 4 {
+				status = args[3]
+			}
+			if err := carbonRegistry.AddVerification(args[0], args[1], args[2], status); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(verifyCmd)
+
+	verifsCmd := &cobra.Command{
+		Use:   "verifications <project>",
+		Short: "List project verifications",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			verifs, ok := carbonRegistry.Verifications(args[0])
+			if !ok {
+				fmt.Println("project not found")
+				return
+			}
+			for _, v := range verifs {
+				fmt.Printf("%s %s %s %s\n", v.Verifier, v.RecordID, v.Status, v.Time.Format(time.RFC3339))
+			}
+		},
+	}
+	cmd.AddCommand(verifsCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info <project>",
+		Short: "Show project info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := carbonRegistry.ProjectInfo(args[0])
+			if !ok {
+				fmt.Println("project not found")
+				return
+			}
+			fmt.Printf("ID:%s Owner:%s Name:%s Total:%d Issued:%d Retired:%d\n", p.ID, p.Owner, p.Name, p.TotalCredits, p.IssuedCredits, p.RetiredCredits)
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all carbon projects",
+		Run: func(cmd *cobra.Command, args []string) {
+			projects := carbonRegistry.ListProjects()
+			for _, p := range projects {
+				fmt.Printf("%s %s %s %d %d %d\n", p.ID, p.Owner, p.Name, p.TotalCredits, p.IssuedCredits, p.RetiredCredits)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2369.go
+++ b/cli/syn2369.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var itemRegistry = tokens.NewItemRegistry()
+
+func parseAttrs(input string) map[string]string {
+	m := make(map[string]string)
+	if input == "" {
+		return m
+	}
+	for _, kv := range strings.Split(input, ",") {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2369",
+		Short: "Virtual item registry",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a virtual item",
+		Run: func(cmd *cobra.Command, args []string) {
+			owner, _ := cmd.Flags().GetString("owner")
+			name, _ := cmd.Flags().GetString("name")
+			desc, _ := cmd.Flags().GetString("desc")
+			attrs, _ := cmd.Flags().GetString("attrs")
+			it := itemRegistry.CreateItem(owner, name, desc, parseAttrs(attrs))
+			fmt.Println(it.ItemID)
+		},
+	}
+	createCmd.Flags().String("owner", "", "owner address")
+	createCmd.Flags().String("name", "", "item name")
+	createCmd.Flags().String("desc", "", "description")
+	createCmd.Flags().String("attrs", "", "key=value attributes")
+	cmd.AddCommand(createCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <id> <newOwner>",
+		Short: "Transfer item ownership",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := itemRegistry.TransferItem(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	updateCmd := &cobra.Command{
+		Use:   "update-attrs <id> <attrs>",
+		Short: "Update item attributes",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := itemRegistry.UpdateAttributes(args[0], parseAttrs(args[1])); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(updateCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get item info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			it, ok := itemRegistry.GetItem(args[0])
+			if !ok {
+				fmt.Println("item not found")
+				return
+			}
+			fmt.Printf("ID:%s Owner:%s Name:%s Desc:%s\n", it.ItemID, it.Owner, it.Name, it.Description)
+			if len(it.Attributes) > 0 {
+				for k, v := range it.Attributes {
+					fmt.Printf("%s=%s ", k, v)
+				}
+				fmt.Println()
+			}
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List virtual items",
+		Run: func(cmd *cobra.Command, args []string) {
+			items := itemRegistry.ListItems()
+			for _, it := range items {
+				fmt.Printf("%s %s %s\n", it.ItemID, it.Owner, it.Name)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2600.go
+++ b/cli/syn2600.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var investorRegistry = tokens.NewInvestorRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2600",
+		Short: "Investor token registry",
+	}
+
+	issueCmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Issue a new investor token",
+		Run: func(cmd *cobra.Command, args []string) {
+			asset, _ := cmd.Flags().GetString("asset")
+			owner, _ := cmd.Flags().GetString("owner")
+			shares, _ := cmd.Flags().GetUint64("shares")
+			expStr, _ := cmd.Flags().GetString("expiry")
+			expiry, _ := time.Parse(time.RFC3339, expStr)
+			tok := investorRegistry.Issue(asset, owner, shares, expiry)
+			fmt.Println(tok.ID)
+		},
+	}
+	issueCmd.Flags().String("asset", "", "underlying asset")
+	issueCmd.Flags().String("owner", "", "owner address")
+	issueCmd.Flags().Uint64("shares", 0, "share quantity")
+	issueCmd.Flags().String("expiry", time.Now().Add(24*time.Hour).Format(time.RFC3339), "expiry time")
+	cmd.AddCommand(issueCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <id> <newOwner>",
+		Short: "Transfer token ownership",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := investorRegistry.Transfer(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	returnCmd := &cobra.Command{
+		Use:   "return <id> <amount>",
+		Short: "Record a return payment",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			if err := investorRegistry.RecordReturn(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(returnCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get token info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			tok, ok := investorRegistry.Get(args[0])
+			if !ok {
+				fmt.Println("token not found")
+				return
+			}
+			fmt.Printf("ID:%s Asset:%s Owner:%s Shares:%d Active:%t\n", tok.ID, tok.Asset, tok.Owner, tok.Shares, tok.Active)
+			for _, r := range tok.Returns {
+				fmt.Printf("return %d %s\n", r.Amount, r.Time.Format(time.RFC3339))
+			}
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List investor tokens",
+		Run: func(cmd *cobra.Command, args []string) {
+			tokens := investorRegistry.List()
+			for _, tok := range tokens {
+				fmt.Printf("%s %s %s %d\n", tok.ID, tok.Asset, tok.Owner, tok.Shares)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn2800.go
+++ b/cli/syn2800.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var lifeRegistry = tokens.NewLifePolicyRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn2800",
+		Short: "Life insurance policies",
+	}
+
+	issueCmd := &cobra.Command{
+		Use:   "issue",
+		Short: "Issue a life policy",
+		Run: func(cmd *cobra.Command, args []string) {
+			insured, _ := cmd.Flags().GetString("insured")
+			beneficiary, _ := cmd.Flags().GetString("beneficiary")
+			coverage, _ := cmd.Flags().GetUint64("coverage")
+			premium, _ := cmd.Flags().GetUint64("premium")
+			startStr, _ := cmd.Flags().GetString("start")
+			endStr, _ := cmd.Flags().GetString("end")
+			start, _ := time.Parse(time.RFC3339, startStr)
+			end, _ := time.Parse(time.RFC3339, endStr)
+			p := lifeRegistry.IssuePolicy(insured, beneficiary, coverage, premium, start, end)
+			fmt.Println(p.PolicyID)
+		},
+	}
+	issueCmd.Flags().String("insured", "", "insured party")
+	issueCmd.Flags().String("beneficiary", "", "beneficiary")
+	issueCmd.Flags().Uint64("coverage", 0, "coverage amount")
+	issueCmd.Flags().Uint64("premium", 0, "premium amount")
+	issueCmd.Flags().String("start", time.Now().Format(time.RFC3339), "start time")
+	issueCmd.Flags().String("end", time.Now().Add(24*time.Hour).Format(time.RFC3339), "end time")
+	cmd.AddCommand(issueCmd)
+
+	payCmd := &cobra.Command{
+		Use:   "pay <policy> <amount>",
+		Short: "Record premium payment",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			if err := lifeRegistry.PayPremium(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(payCmd)
+
+	claimCmd := &cobra.Command{
+		Use:   "claim <policy> <amount>",
+		Short: "File a claim",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[1], "%d", &amt)
+			if _, err := lifeRegistry.FileClaim(args[0], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(claimCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <policy>",
+		Short: "Get policy info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := lifeRegistry.GetPolicy(args[0])
+			if !ok {
+				fmt.Println("policy not found")
+				return
+			}
+			fmt.Printf("ID:%s Insured:%s Beneficiary:%s Coverage:%d Premium:%d Paid:%d\n", p.PolicyID, p.Insured, p.Beneficiary, p.Coverage, p.Premium, p.PaidPremium)
+			for _, c := range p.Claims {
+				fmt.Printf("claim %s %d %s settled:%t\n", c.ClaimID, c.Amount, c.Time.Format(time.RFC3339), c.Settled)
+			}
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List policies",
+		Run: func(cmd *cobra.Command, args []string) {
+			policies := lifeRegistry.ListPolicies()
+			for _, p := range policies {
+				fmt.Printf("%s %s %s %d %d\n", p.PolicyID, p.Insured, p.Beneficiary, p.Coverage, p.Premium)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn3400.go
+++ b/cli/syn3400.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var forexRegistry = tokens.NewForexRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn3400",
+		Short: "Forex pair registry",
+	}
+
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a forex pair",
+		Run: func(cmd *cobra.Command, args []string) {
+			base, _ := cmd.Flags().GetString("base")
+			quote, _ := cmd.Flags().GetString("quote")
+			rate, _ := cmd.Flags().GetFloat64("rate")
+			p := forexRegistry.Register(base, quote, rate)
+			fmt.Println(p.PairID)
+		},
+	}
+	registerCmd.Flags().String("base", "", "base currency")
+	registerCmd.Flags().String("quote", "", "quote currency")
+	registerCmd.Flags().Float64("rate", 1.0, "exchange rate")
+	cmd.AddCommand(registerCmd)
+
+	updateCmd := &cobra.Command{
+		Use:   "update <id> <rate>",
+		Short: "Update exchange rate",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var r float64
+			fmt.Sscanf(args[1], "%f", &r)
+			if err := forexRegistry.UpdateRate(args[0], r); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(updateCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get pair info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := forexRegistry.Get(args[0])
+			if !ok {
+				fmt.Println("pair not found")
+				return
+			}
+			fmt.Printf("ID:%s %s/%s Rate:%f\n", p.PairID, p.Base, p.Quote, p.Rate)
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List forex pairs",
+		Run: func(cmd *cobra.Command, args []string) {
+			pairs := forexRegistry.List()
+			for _, p := range pairs {
+				fmt.Printf("%s %s/%s %f\n", p.PairID, p.Base, p.Quote, p.Rate)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn70.go
+++ b/cli/syn70.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var syn70 *tokens.SYN70Token
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn70",
+		Short: "SYN70 game asset token",
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialise SYN70 token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			dec, _ := cmd.Flags().GetUint32("decimals")
+			id := tokenRegistry.NextID()
+			syn70 = tokens.NewSYN70Token(id, name, symbol, uint8(dec))
+			tokenRegistry.Register(syn70)
+			fmt.Println("syn70 initialised")
+		},
+	}
+	initCmd.Flags().String("name", "", "token name")
+	initCmd.Flags().String("symbol", "", "token symbol")
+	initCmd.Flags().Uint32("decimals", 0, "decimal places")
+	cmd.AddCommand(initCmd)
+
+	registerCmd := &cobra.Command{
+		Use:   "register <id> <owner> <name> <game>",
+		Short: "Register an in-game asset",
+		Args:  cobra.ExactArgs(4),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn70.RegisterAsset(args[0], args[1], args[2], args[3]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(registerCmd)
+
+	transferCmd := &cobra.Command{
+		Use:   "transfer <id> <newOwner>",
+		Short: "Transfer asset ownership",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn70.TransferAsset(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(transferCmd)
+
+	attrCmd := &cobra.Command{
+		Use:   "setattr <id> <key> <value>",
+		Short: "Set asset attribute",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn70.SetAttribute(args[0], args[1], args[2]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(attrCmd)
+
+	achCmd := &cobra.Command{
+		Use:   "achievement <id> <name>",
+		Short: "Record achievement",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			if err := syn70.AddAchievement(args[0], args[1]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(achCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info <id>",
+		Short: "Show asset info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			a, err := syn70.AssetInfo(args[0])
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Printf("ID:%s Owner:%s Name:%s Game:%s\n", a.ID, a.Owner, a.Name, a.Game)
+			if len(a.Attributes) > 0 {
+				for k, v := range a.Attributes {
+					fmt.Printf("%s=%s ", k, v)
+				}
+				fmt.Println()
+			}
+			if len(a.Achievements) > 0 {
+				fmt.Println("Achievements:", strings.Join(a.Achievements, ","))
+			}
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List assets",
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			assets := syn70.ListAssets()
+			for _, a := range assets {
+				fmt.Printf("%s %s %s %s\n", a.ID, a.Owner, a.Name, a.Game)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	balCmd := &cobra.Command{
+		Use:   "balance <addr>",
+		Short: "Show token balance",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if syn70 == nil {
+				fmt.Println("token not initialised")
+				return
+			}
+			fmt.Println(syn70.BalanceOf(args[0]))
+		},
+	}
+	cmd.AddCommand(balCmd)
+
+	rootCmd.AddCommand(cmd)
+}

--- a/cli/syn845.go
+++ b/cli/syn845.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
+)
+
+var debtRegistry = tokens.NewDebtRegistry()
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "syn845",
+		Short: "Debt instrument tokens",
+	}
+
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a debt token",
+		Run: func(cmd *cobra.Command, args []string) {
+			name, _ := cmd.Flags().GetString("name")
+			symbol, _ := cmd.Flags().GetString("symbol")
+			owner, _ := cmd.Flags().GetString("owner")
+			supply, _ := cmd.Flags().GetUint64("supply")
+			id, _ := debtRegistry.CreateToken(name, symbol, owner, supply)
+			fmt.Println(id)
+		},
+	}
+	createCmd.Flags().String("name", "", "token name")
+	createCmd.Flags().String("symbol", "", "token symbol")
+	createCmd.Flags().String("owner", "", "owner address")
+	createCmd.Flags().Uint64("supply", 0, "initial supply")
+	cmd.AddCommand(createCmd)
+
+	issueCmd := &cobra.Command{
+		Use:   "issue <token> <debtID> <borrower> <principal> <rate> <penalty> <due>",
+		Short: "Issue a debt instrument",
+		Args:  cobra.ExactArgs(7),
+		Run: func(cmd *cobra.Command, args []string) {
+			var principal uint64
+			var rate, penalty float64
+			fmt.Sscanf(args[3], "%d", &principal)
+			fmt.Sscanf(args[4], "%f", &rate)
+			fmt.Sscanf(args[5], "%f", &penalty)
+			due, _ := time.Parse(time.RFC3339, args[6])
+			if err := debtRegistry.IssueDebt(args[0], args[1], args[2], principal, rate, penalty, due); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(issueCmd)
+
+	payCmd := &cobra.Command{
+		Use:   "pay <token> <debtID> <amount>",
+		Short: "Record a payment",
+		Args:  cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if err := debtRegistry.RecordPayment(args[0], args[1], amt); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(payCmd)
+
+	infoCmd := &cobra.Command{
+		Use:   "info <token> <debtID>",
+		Short: "Show debt info",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			d, err := debtRegistry.GetDebt(args[0], args[1])
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Printf("DebtID:%s Borrower:%s Principal:%d Paid:%d Rate:%f Penalty:%f Due:%s\n", d.DebtID, d.Borrower, d.Principal, d.Paid, d.Rate, d.Penalty, d.Due.Format(time.RFC3339))
+		},
+	}
+	cmd.AddCommand(infoCmd)
+
+	rootCmd.AddCommand(cmd)
+}


### PR DESCRIPTION
## Summary
- add syn200 CLI for registering carbon projects and managing credits
- implement syn2369 CLI for virtual item management
- add CLIs for investor tokens, life policies, forex pairs, game assets, and debt instruments

## Testing
- `go test ./...` *(fails: cli/watchtower.go:32:1: syntax error: non-declaration statement outside function body)*

------
https://chatgpt.com/codex/tasks/task_e_68916436c1b48320a08853f6786680a2