### PR TITLE
test: add coverage for contract opcodes

### DIFF
--- a/contracts_opcodes_test.go
+++ b/contracts_opcodes_test.go
@@ -1,0 +1,53 @@
+package synnergy
+
+import "testing"
+
+// TestContractOpcodesValues ensures that all contract opcodes remain stable
+// and match their documented hexadecimal representations.
+func TestContractOpcodesValues(t *testing.T) {
+	tests := []struct {
+		name string
+		op   uint32
+		want uint32
+	}{
+		{"OpInitContracts", OpInitContracts, 0x010000},
+		{"OpPauseContract", OpPauseContract, 0x010001},
+		{"OpResumeContract", OpResumeContract, 0x010002},
+		{"OpUpgradeContract", OpUpgradeContract, 0x010003},
+		{"OpContractInfo", OpContractInfo, 0x010004},
+		{"OpDeployAIContract", OpDeployAIContract, 0x010005},
+		{"OpInvokeAIContract", OpInvokeAIContract, 0x010006},
+	}
+	for _, tt := range tests {
+		if tt.op != tt.want {
+			t.Errorf("%s = %#x, want %#x", tt.name, tt.op, tt.want)
+		}
+		if tt.op == 0 {
+			t.Errorf("%s opcode must be non-zero", tt.name)
+		}
+	}
+}
+
+// TestContractOpcodesSequential verifies the opcodes are sequential and unique.
+func TestContractOpcodesSequential(t *testing.T) {
+	ops := []uint32{
+		OpInitContracts,
+		OpPauseContract,
+		OpResumeContract,
+		OpUpgradeContract,
+		OpContractInfo,
+		OpDeployAIContract,
+		OpInvokeAIContract,
+	}
+
+	seen := make(map[uint32]struct{}, len(ops))
+	for i, op := range ops {
+		if _, ok := seen[op]; ok {
+			t.Fatalf("duplicate opcode value %#x", op)
+		}
+		seen[op] = struct{}{}
+		if i > 0 && op != ops[i-1]+1 {
+			t.Fatalf("opcode %#x not sequential after %#x", op, ops[i-1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add tests ensuring contract opcode constants retain documented values
- validate opcode uniqueness and sequential ordering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689167919fe4832088f547f4928d7086