### PR TITLE
Add comprehensive tests for supply chain and token registries

### DIFF
--- a/core/syn1300_test.go
+++ b/core/syn1300_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestSupplyChainRegistryRegisterGet(t *testing.T) {
+	reg := NewSupplyChainRegistry()
+	asset, err := reg.Register("asset1", "desc", "alice", "loc1")
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if asset.ID != "asset1" || asset.Owner != "alice" || asset.Location != "loc1" || asset.Status != "created" {
+		t.Fatalf("unexpected asset data: %#v", asset)
+	}
+	if len(asset.History) != 1 {
+		t.Fatalf("expected history length 1 got %d", len(asset.History))
+	}
+	got, ok := reg.Get("asset1")
+	if !ok || got.ID != "asset1" {
+		t.Fatalf("failed to get asset")
+	}
+}
+
+func TestSupplyChainRegistryDuplicate(t *testing.T) {
+	reg := NewSupplyChainRegistry()
+	if _, err := reg.Register("asset1", "d", "a", "loc"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := reg.Register("asset1", "d", "a", "loc"); err == nil {
+		t.Fatalf("expected error for duplicate asset")
+	}
+}
+
+func TestSupplyChainRegistryUpdate(t *testing.T) {
+	reg := NewSupplyChainRegistry()
+	if _, err := reg.Register("asset1", "d", "a", "loc"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := reg.Update("asset1", "loc2", "shipped", "note1"); err != nil {
+		t.Fatalf("update error: %v", err)
+	}
+	asset, _ := reg.Get("asset1")
+	if asset.Location != "loc2" || asset.Status != "shipped" {
+		t.Fatalf("update failed: %#v", asset)
+	}
+	if len(asset.History) != 2 {
+		t.Fatalf("expected history length 2 got %d", len(asset.History))
+	}
+	last := asset.History[len(asset.History)-1]
+	if last.Status != "shipped" || last.Note != "note1" || last.Location != "loc2" {
+		t.Fatalf("unexpected event: %#v", last)
+	}
+}
+
+func TestSupplyChainRegistryUpdateNonexistent(t *testing.T) {
+	reg := NewSupplyChainRegistry()
+	if err := reg.Update("missing", "loc", "status", "note"); err == nil {
+		t.Fatalf("expected error for missing asset")
+	}
+}

--- a/core/syn131_token_test.go
+++ b/core/syn131_token_test.go
@@ -1,0 +1,49 @@
+package core
+
+import "testing"
+
+func TestSYN131RegistryCreateGet(t *testing.T) {
+	reg := NewSYN131Registry()
+	tok, err := reg.Create("t1", "Name", "SYM", "alice", 100)
+	if err != nil {
+		t.Fatalf("create error: %v", err)
+	}
+	if tok.ID != "t1" || tok.Name != "Name" || tok.Symbol != "SYM" || tok.Owner != "alice" || tok.Valuation != 100 {
+		t.Fatalf("unexpected token data: %#v", tok)
+	}
+	got, ok := reg.Get("t1")
+	if !ok || got.ID != "t1" {
+		t.Fatalf("get failed")
+	}
+}
+
+func TestSYN131RegistryDuplicate(t *testing.T) {
+	reg := NewSYN131Registry()
+	if _, err := reg.Create("t1", "n", "s", "o", 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := reg.Create("t1", "n", "s", "o", 1); err == nil {
+		t.Fatalf("expected duplicate error")
+	}
+}
+
+func TestSYN131RegistryUpdateValuation(t *testing.T) {
+	reg := NewSYN131Registry()
+	if _, err := reg.Create("t1", "n", "s", "o", 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := reg.UpdateValuation("t1", 500); err != nil {
+		t.Fatalf("update valuation error: %v", err)
+	}
+	tok, _ := reg.Get("t1")
+	if tok.Valuation != 500 {
+		t.Fatalf("valuation not updated: %d", tok.Valuation)
+	}
+}
+
+func TestSYN131RegistryUpdateNonexistent(t *testing.T) {
+	reg := NewSYN131Registry()
+	if err := reg.UpdateValuation("missing", 10); err == nil {
+		t.Fatalf("expected error for missing token")
+	}
+}


### PR DESCRIPTION
## Summary
- add thorough tests for SupplyChainRegistry covering registration, duplicate handling, updates, and missing asset errors
- add tests for SYN131 token registry verifying creation, duplicate prevention, valuation updates, and retrieval

## Testing
- `go test ./core/...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68916804d11c8320bf7807f4538d59fa