### PR TITLE
Add comprehensive tests for SYN223 token

### DIFF
--- a/core/syn223_token_test.go
+++ b/core/syn223_token_test.go
@@ -1,0 +1,61 @@
+package core
+
+import "testing"
+
+func TestSYN223TokenTransfer(t *testing.T) {
+    token := NewSYN223Token("SYN223", "S223", "alice", 100)
+    token.AddToWhitelist("bob")
+    if err := token.Transfer("alice", "bob", 40); err != nil {
+        t.Fatalf("transfer: %v", err)
+    }
+    if bal := token.BalanceOf("alice"); bal != 60 {
+        t.Fatalf("unexpected alice balance %d", bal)
+    }
+    if bal := token.BalanceOf("bob"); bal != 40 {
+        t.Fatalf("unexpected bob balance %d", bal)
+    }
+}
+
+func TestSYN223TokenWhitelistBlacklist(t *testing.T) {
+    token := NewSYN223Token("SYN223", "S223", "owner", 100)
+    // Whitelist recipient and perform transfer
+    token.AddToWhitelist("carol")
+    if err := token.Transfer("owner", "carol", 10); err != nil {
+        t.Fatalf("transfer to carol failed: %v", err)
+    }
+    // Removing from whitelist should block further transfers
+    token.RemoveFromWhitelist("carol")
+    if err := token.Transfer("owner", "carol", 5); err == nil {
+        t.Fatalf("expected failure for unwhitelisted recipient")
+    }
+    // Blacklist recipient
+    token.AddToWhitelist("dave")
+    token.AddToBlacklist("dave")
+    if err := token.Transfer("owner", "dave", 5); err == nil {
+        t.Fatalf("expected failure for blacklisted recipient")
+    }
+    // Remove from blacklist to allow transfer
+    token.RemoveFromBlacklist("dave")
+    if err := token.Transfer("owner", "dave", 5); err != nil {
+        t.Fatalf("transfer to dave after unblacklist failed: %v", err)
+    }
+    // Blacklist sender should block transfer
+    token.AddToWhitelist("eve")
+    token.AddToBlacklist("owner")
+    if err := token.Transfer("owner", "eve", 5); err == nil {
+        t.Fatalf("expected failure for blacklisted sender")
+    }
+    token.RemoveFromBlacklist("owner")
+    if err := token.Transfer("owner", "eve", 5); err != nil {
+        t.Fatalf("transfer after removing sender blacklist failed: %v", err)
+    }
+}
+
+func TestSYN223TokenInsufficientBalance(t *testing.T) {
+    token := NewSYN223Token("SYN223", "S223", "alice", 10)
+    token.AddToWhitelist("bob")
+    if err := token.Transfer("alice", "bob", 20); err == nil {
+        t.Fatalf("expected transfer to fail due to insufficient balance")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add thorough unit tests for SYN223 token covering whitelist, blacklist, and balance checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891680f2f708320abc961dbbaf008bd