### PR TITLE
Add tests for mining node components

### DIFF
--- a/mining_node_test.go
+++ b/mining_node_test.go
@@ -1,0 +1,51 @@
+package synnergy
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMiningNodeLifecycle(t *testing.T) {
+	m := NewMiningNode("miner1", 1)
+	if m.ID() != "miner1" {
+		t.Fatalf("ID mismatch: %s", m.ID())
+	}
+	if m.HashRate() != 1 {
+		t.Fatalf("hash rate mismatch")
+	}
+	m.Start()
+	if !m.IsRunning() {
+		t.Fatalf("expected running after Start")
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if lb := m.LastBlock(); lb == "" {
+		t.Fatalf("expected mined block hash")
+	}
+	m.Stop()
+	if m.IsRunning() {
+		t.Fatalf("expected not running after Stop")
+	}
+}
+
+func TestMiningNodeMineBlock(t *testing.T) {
+	m := NewMiningNode("miner", 0)
+	hash, err := m.MineBlock(4)
+	if err != nil {
+		t.Fatalf("mine: %v", err)
+	}
+	if !strings.HasPrefix(hash, "0") {
+		t.Fatalf("hash does not meet difficulty: %s", hash)
+	}
+	if _, err := m.MineBlock(-1); err == nil {
+		t.Fatalf("expected error for negative difficulty")
+	}
+}
+
+func TestMiningNodeSubmitBlock(t *testing.T) {
+	m := NewMiningNode("miner", 0)
+	m.SubmitBlock("abc")
+	if lb := m.LastBlock(); lb != "abc" {
+		t.Fatalf("last block mismatch: %s", lb)
+	}
+}

--- a/mobile_mining_node_test.go
+++ b/mobile_mining_node_test.go
@@ -1,0 +1,50 @@
+package synnergy
+
+import (
+	"testing"
+)
+
+func TestMobileMiningNodeBatteryThreshold(t *testing.T) {
+	m := NewMobileMiningNode("m1", 1, 0.5, 0.3)
+	if err := m.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !m.IsRunning() {
+		t.Fatalf("expected running")
+	}
+	m.UpdateBattery(0.2)
+	if m.IsRunning() {
+		t.Fatalf("expected stopped after low battery")
+	}
+	if m.Battery() != 0.2 {
+		t.Fatalf("battery not updated: %v", m.Battery())
+	}
+	m.UpdateBattery(0.8)
+	if err := m.Start(); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	if !m.IsRunning() {
+		t.Fatalf("expected running after restart")
+	}
+	if m.Threshold() != 0.3 {
+		t.Fatalf("threshold mismatch")
+	}
+	m.SetThreshold(0.9)
+	if m.Threshold() != 0.9 {
+		t.Fatalf("threshold not updated")
+	}
+	m.UpdateBattery(0.8)
+	if m.IsRunning() {
+		t.Fatalf("expected stopped after threshold raise")
+	}
+}
+
+func TestMobileMiningNodeStartError(t *testing.T) {
+	m := NewMobileMiningNode("m2", 1, 0.2, 0.5)
+	if err := m.Start(); err == nil {
+		t.Fatalf("expected error for low battery")
+	}
+	if m.IsRunning() {
+		t.Fatalf("should not be running")
+	}
+}


### PR DESCRIPTION
## Summary
- add lifecycle, mining, and submission tests for MiningNode
- cover battery threshold enforcement and restart logic in MobileMiningNode

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68916ade986c8320b50378f47619feff