### PR TITLE
Register SNVM opcodes in VM

### DIFF
--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -1,6 +1,9 @@
 package synnergy
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestSimpleVMLifecycle(t *testing.T) {
 	vm := NewSimpleVM()
@@ -18,5 +21,25 @@ func TestSimpleVMLifecycle(t *testing.T) {
 	}
 	if vm.Status() {
 		t.Fatalf("expected stopped VM")
+	}
+}
+
+func TestSNVMOpcodeExecution(t *testing.T) {
+	if len(SNVMOpcodes) == 0 {
+		t.Fatalf("no opcodes defined")
+	}
+	vm := NewSimpleVM()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	code := SNVMOpcodes[0].Code
+	wasm := []byte{byte(code >> 16), byte(code >> 8), byte(code)}
+	args := []byte{0xAA, 0xBB}
+	out, _, err := vm.Execute(wasm, "", args, 10)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Equal(out, args) {
+		t.Fatalf("opcode should echo args")
 	}
 }


### PR DESCRIPTION
## Summary
- preload SimpleVM with every opcode listed in snvm_opcodes.go
- allow custom opcode handlers via RegisterOpcode
- test that a sample SNVM opcode executes as expected

## Testing
- `go test -run TestSNVMOpcodeExecution -v`
- `go test ./... | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6891880f0e808320bff5eae49f6ee548