### PR TITLE
chore: add setup scripts

### DIFF
--- a/scripts/ai_setup.sh
+++ b/scripts/ai_setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+BIN="$(dirname "$0")/../cmd/scripts/synnergy"
+if [ $# -lt 5 ]; then
+  echo "Usage: $0 <wasm_file> <model_hash> <manifest> <gas_limit> <owner>"
+  exit 1
+fi
+"$BIN" ai_contract deploy "$1" "$2" "$3" "$4" "$5"

--- a/scripts/authority_node_setup.sh
+++ b/scripts/authority_node_setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+BIN="$(dirname "$0")/../cmd/scripts/synnergy"
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <address> <role>"
+  exit 1
+fi
+"$BIN" authority register "$1" "$2"

--- a/scripts/compliance_setup.sh
+++ b/scripts/compliance_setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+BIN="$(dirname "$0")/../cmd/scripts/synnergy"
+if [ -z "$1" ]; then
+  echo "Usage: $0 <kyc.json>"
+  exit 1
+fi
+"$BIN" compliance validate "$1"

--- a/scripts/governance_setup.sh
+++ b/scripts/governance_setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+BIN="$(dirname "$0")/../cmd/scripts/synnergy"
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <title> <proposal_file>"
+  exit 1
+fi
+"$BIN" governance propose "$1" "$2"

--- a/scripts/node_setup.sh
+++ b/scripts/node_setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+BIN="$(dirname "$0")/../cmd/scripts/synnergy"
+PORT=${1:-3030}
+"$BIN" network start --port "$PORT"

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(dirname "$0")/../cmd/scripts"
+"$SCRIPT_DIR/start_synnergy_network.sh" "$@"

--- a/scripts/storage_setup.sh
+++ b/scripts/storage_setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+BIN="$(dirname "$0")/../cmd/scripts/synnergy"
+if [ -z "$1" ]; then
+  echo "Usage: $0 <file> [provider] [price] [capacity]"
+  exit 1
+fi
+if [ -n "$2" ]; then
+  provider=$2
+  price=${3:-0}
+  capacity=${4:-0}
+  "$BIN" marketplace pin "$1" "$provider" "$price" "$capacity"
+else
+  "$BIN" storage pin "$1"
+fi

--- a/scripts/token_create.sh
+++ b/scripts/token_create.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+BIN="$(dirname "$0")/../cmd/scripts/synnergy"
+if [ $# -lt 5 ]; then
+  echo "Usage: $0 <name> <symbol> <owner> <decimals> <supply>"
+  exit 1
+fi
+"$BIN" syn500 create --name "$1" --symbol "$2" --owner "$3" --dec "$4" --supply "$5"


### PR DESCRIPTION
## Summary
- add helper scripts for token creation, storage pinning, governance proposals, AI contract deployment, compliance checks, and authority node registration
- provide node and network startup wrappers

## Testing
- `bash -n scripts/token_create.sh scripts/node_setup.sh scripts/storage_setup.sh scripts/governance_setup.sh scripts/ai_setup.sh scripts/compliance_setup.sh scripts/authority_node_setup.sh scripts/startup.sh`
- `go test ./...` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68938e911fb4832082048ec0c02a946a