### PR TITLE
refactor: standardize shell scripts

### DIFF
--- a/scripts/ai_setup.sh
+++ b/scripts/ai_setup.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-if [ $# -lt 5 ]; then
-  echo "Usage: $0 <wasm_file> <model_hash> <manifest> <gas_limit> <owner>"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+if [[ $# -lt 5 ]]; then
+  echo "Usage: $0 <wasm_file> <model_hash> <manifest> <gas_limit> <owner>" >&2
   exit 1
 fi
+
 "$BIN" ai_contract deploy "$1" "$2" "$3" "$4" "$5"

--- a/scripts/authority_node_setup.sh
+++ b/scripts/authority_node_setup.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-if [ $# -lt 2 ]; then
-  echo "Usage: $0 <address> <role>"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <address> <role>" >&2
   exit 1
 fi
+
 "$BIN" authority register "$1" "$2"

--- a/scripts/compliance_setup.sh
+++ b/scripts/compliance_setup.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-if [ -z "$1" ]; then
-  echo "Usage: $0 <kyc.json>"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: $0 <kyc.json>" >&2
   exit 1
 fi
+
 "$BIN" compliance validate "$1"

--- a/scripts/devnet_start.sh
+++ b/scripts/devnet_start.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-N=${1:-1}
-for i in $(seq 1 "$N"); do
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+readonly N="${1:-1}"
+for ((i=1; i<=N; i++)); do
   "$BIN" network start --port $((3030+i)) &
 done
 trap 'kill 0' INT TERM

--- a/scripts/governance_setup.sh
+++ b/scripts/governance_setup.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-if [ $# -lt 2 ]; then
-  echo "Usage: $0 <title> <proposal_file>"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <title> <proposal_file>" >&2
   exit 1
 fi
+
 "$BIN" governance propose "$1" "$2"

--- a/scripts/network_bootstrap.sh
+++ b/scripts/network_bootstrap.sh
@@ -1,19 +1,27 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+
 # Build the synnergy CLI
-GO111MODULE=on go build -trimpath -o synnergy ./cmd/synnergy
+GO111MODULE=on go build -trimpath -o "$ROOT_DIR/synnergy" "$ROOT_DIR/cmd/synnergy"
+
 # Use network configuration and genesis file
-export SYN_CONFIG=../configs/network.yaml
+export SYN_CONFIG="$ROOT_DIR/configs/network.yaml"
+
 # Show configured genesis wallets for operators
-./synnergy genesis show
+"$ROOT_DIR/synnergy" genesis show
+
 # Stake initial validator, authority and host nodes
-./synnergy node stake d22b7fffcb6a72c94713f5c2e2f2142565b8402299842eb4c1039cea3c293ff0 1000000
-./synnergy node stake 5baf968c0972eab52046bbca74763d61c923d6e81e549f0f7f0db66f8cfddad9 500000
-./synnergy node stake 20d2698d356868e08411ce2ea8ac824d07011aebe788a6458d33e244172b8c34 500000
+"$ROOT_DIR/synnergy" node stake d22b7fffcb6a72c94713f5c2e2f2142565b8402299842eb4c1039cea3c293ff0 1000000
+"$ROOT_DIR/synnergy" node stake 5baf968c0972eab52046bbca74763d61c923d6e81e549f0f7f0db66f8cfddad9 500000
+"$ROOT_DIR/synnergy" node stake 20d2698d356868e08411ce2ea8ac824d07011aebe788a6458d33e244172b8c34 500000
+
 # Launch network and consensus services
-./synnergy network start &
+"$ROOT_DIR/synnergy" network start &
 NET_PID=$!
-./synnergy consensus-service start 3000 &
+"$ROOT_DIR/synnergy" consensus-service start 3000 &
 CONS_PID=$!
-trap 'kill $NET_PID $CONS_PID' INT TERM
+trap 'kill "$NET_PID" "$CONS_PID"' INT TERM
 wait

--- a/scripts/node_setup.sh
+++ b/scripts/node_setup.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-PORT=${1:-3030}
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+PORT="${1:-3030}"
 "$BIN" network start --port "$PORT"

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-set -e
-SCRIPT_DIR="$(dirname "$0")/../cmd/scripts"
-"$SCRIPT_DIR/start_synnergy_network.sh" "$@"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/../cmd/scripts/start_synnergy_network.sh"
+"$TARGET" "$@"

--- a/scripts/storage_setup.sh
+++ b/scripts/storage_setup.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-if [ -z "$1" ]; then
-  echo "Usage: $0 <file> [provider] [price] [capacity]"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: $0 <file> [provider] [price] [capacity]" >&2
   exit 1
 fi
-if [ -n "$2" ]; then
-  provider=$2
-  price=${3:-0}
-  capacity=${4:-0}
+
+if [[ -n "${2:-}" ]]; then
+  provider="$2"
+  price="${3:-0}"
+  capacity="${4:-0}"
   "$BIN" marketplace pin "$1" "$provider" "$price" "$capacity"
 else
   "$BIN" storage pin "$1"

--- a/scripts/testnet_start.sh
+++ b/scripts/testnet_start.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-if [ -z "$1" ]; then
-  echo "Usage: $0 path/to/testnet.yaml"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: $0 path/to/testnet.yaml" >&2
   exit 1
 fi
+
 "$BIN" network start --config "$1"

--- a/scripts/token_create.sh
+++ b/scripts/token_create.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-set -e
-BIN="$(dirname "$0")/../cmd/scripts/synnergy"
-if [ $# -lt 5 ]; then
-  echo "Usage: $0 <name> <symbol> <owner> <decimals> <supply>"
+set -euo pipefail
+IFS=$'\n\t'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../cmd/scripts/synnergy"
+
+if [[ $# -lt 5 ]]; then
+  echo "Usage: $0 <name> <symbol> <owner> <decimals> <supply>" >&2
   exit 1
 fi
+
 "$BIN" syn500 create --name "$1" --symbol "$2" --owner "$3" --dec "$4" --supply "$5"


### PR DESCRIPTION
## Summary
- harden project scripts with `set -euo pipefail`, consistent `SCRIPT_DIR` resolution, and clearer usage checks
- rebuild network bootstrap to operate from repo root and manage process lifecycle

## Testing
- `shellcheck scripts/*.sh`
- `go test ./...` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6893920530908320bab429786db43e60