### PR TITLE
feat: add debug flag for opcode logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ export SYN_CONFIG=configs/dev.yaml
 ```
 Helper scripts in `scripts/` can launch multi‑node devnets or testnets for experimentation.
 
+To inspect the opcode catalogue during startup, set `SYN_DEBUG_OPCODES=1` before running the binary.  By default opcode details are suppressed to keep the CLI output concise.
+
 ## Testing and security checks
 Run the unit tests and static analysis tools before submitting changes:
 ```

--- a/cmd/synnergy/main.go
+++ b/cmd/synnergy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,8 @@ import (
 func main() {
 	// Load variables from .env if present to mirror the setup guides.
 	gotenv.Load()
+
+	printBanner()
 
 	cfgPath := os.Getenv("SYN_CONFIG")
 	if cfgPath == "" {
@@ -36,4 +39,10 @@ func main() {
 	if err := cli.Execute(); err != nil {
 		logrus.Fatal(err)
 	}
+}
+
+func printBanner() {
+	fmt.Println("==============================")
+	fmt.Println("      Synnergy Network CLI     ")
+	fmt.Println("==============================")
 }

--- a/core/opcode.go
+++ b/core/opcode.go
@@ -31,6 +31,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"os"
 	"sync"
 )
 
@@ -1612,6 +1613,8 @@ func init() {
 	// next keeps track of the next ordinal for each category byte.
 	next := make(map[byte]uint32)
 
+	debug := os.Getenv("SYN_DEBUG_OPCODES") != ""
+
 	for i, entry := range catalogue {
 		// Derive the category from the high byte of the provided opcode.
 		cat := byte(entry.op >> 16)
@@ -1624,15 +1627,18 @@ func init() {
 		nameToOp[entry.name] = op
 		Register(op, wrap(entry.name))
 
-		bin := []byte{byte(op >> 16), byte(op >> 8), byte(op)}
-		log.Printf("[OPCODES] %-32s = %08b = 0x%06X",
-			entry.name, bin, op)
+		if debug {
+			bin := []byte{byte(op >> 16), byte(op >> 8), byte(op)}
+			log.Printf("[OPCODES] %-32s = %08b = 0x%06X",
+				entry.name, bin, op)
+		}
 	}
 
 	// Build the gas table once opcodes have been normalised.
 	initGasTable()
-
-	log.Printf("[OPCODES] %d opcodes registered; %d gas-priced", len(opcodeTable), len(gasTable))
+	if debug {
+		log.Printf("[OPCODES] %d opcodes registered; %d gas-priced", len(opcodeTable), len(gasTable))
+	}
 }
 
 // Hex returns the canonical hexadecimal representation (upper-case, 6 digits).

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -35,6 +35,8 @@ compression allows historic segments of the chain to be archived efficiently.
 A transaction distribution service splits fees between block producers and
 community pools.
 
+The ledger is maintained as an append‑only chain of blocks rather than a general‑purpose database.  Every state transition is derived from block execution, preserving the blockchain's immutable history.
+
 ### Virtual Machine and Gas Accounting
 Smart contracts execute inside a dedicated virtual machine. Every protocol
 function is assigned a 24‑bit opcode and priced using a deterministic gas table.


### PR DESCRIPTION
## Summary
- gate opcode catalogue logging behind `SYN_DEBUG_OPCODES`
- print simple Synnergy banner on CLI startup
- document opcode debug flag and clarify ledger description

## Testing
- `go test ./core`
- `go test ./cli`
- `go test ./cmd/synnergy`


------
https://chatgpt.com/codex/tasks/task_e_68961100dbf48320a8f60f454f4a3b6b