### PR TITLE
Harden consensus validator selection and sub-block validation

### DIFF
--- a/core/consensus.go
+++ b/core/consensus.go
@@ -142,9 +142,15 @@ func (sc *SynnergyConsensus) SelectValidator(stakes map[string]uint64) string {
 	if len(stakes) == 0 {
 		return ""
 	}
-	var total uint64
+	var total, max uint64
 	for _, s := range stakes {
 		total += s
+		if s > max {
+			max = s
+		}
+	}
+	if len(stakes) > 1 && max*2 > total {
+		return ""
 	}
 	limit := new(big.Int).SetUint64(total)
 	rBig, err := rand.Int(rand.Reader, limit)
@@ -162,10 +168,14 @@ func (sc *SynnergyConsensus) SelectValidator(stakes map[string]uint64) string {
 	return ""
 }
 
-// ValidateSubBlock performs POS and POH validation on a sub-block.  For the
-// prototype this simply returns true.
+// ValidateSubBlock performs simple PoS and PoH validation on a sub-block.
+// It verifies that the sub-block is non-nil, contains transactions and has a
+// valid signature from its declared validator.
 func (sc *SynnergyConsensus) ValidateSubBlock(sb *SubBlock) bool {
-	return true
+	if sb == nil || len(sb.Transactions) == 0 {
+		return false
+	}
+	return sb.VerifySignature()
 }
 
 // MineBlock performs a simple SHA-256 proof-of-work using the provided

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -1,55 +1,75 @@
 package core
 
 import (
-    "math"
-    "testing"
+	"math"
+	"testing"
 )
 
 func TestThreshold(t *testing.T) {
-    sc := NewSynnergyConsensus()
-    if sc.Threshold(2, 3) != sc.Alpha*2+sc.Beta*3 {
-        t.Fatalf("threshold calculation incorrect")
-    }
+	sc := NewSynnergyConsensus()
+	if sc.Threshold(2, 3) != sc.Alpha*2+sc.Beta*3 {
+		t.Fatalf("threshold calculation incorrect")
+	}
 }
 
 func TestAdjustWeightsAndAvailability(t *testing.T) {
-    sc := NewSynnergyConsensus()
-    sc.SetAvailability(true, false, true)
-    sc.AdjustWeights(0.5, 0.5)
-    if sc.Weights.PoS != 0 {
-        t.Fatalf("PoS weight should be zero when unavailable")
-    }
-    total := sc.Weights.PoW + sc.Weights.PoS + sc.Weights.PoH
-    if math.Abs(total-1) > 1e-9 {
-        t.Fatalf("weights not normalized")
-    }
+	sc := NewSynnergyConsensus()
+	sc.SetAvailability(true, false, true)
+	sc.AdjustWeights(0.5, 0.5)
+	if sc.Weights.PoS != 0 {
+		t.Fatalf("PoS weight should be zero when unavailable")
+	}
+	total := sc.Weights.PoW + sc.Weights.PoS + sc.Weights.PoH
+	if math.Abs(total-1) > 1e-9 {
+		t.Fatalf("weights not normalized")
+	}
 }
 
 func TestTransitionThreshold(t *testing.T) {
-    sc := NewSynnergyConsensus()
-    tt := sc.TransitionThreshold(1, 2, 3)
-    expected := sc.Tload(1) + sc.Tsecurity(2) + sc.Tstake(3)
-    if tt != expected {
-        t.Fatalf("transition threshold mismatch")
-    }
+	sc := NewSynnergyConsensus()
+	tt := sc.TransitionThreshold(1, 2, 3)
+	expected := sc.Tload(1) + sc.Tsecurity(2) + sc.Tstake(3)
+	if tt != expected {
+		t.Fatalf("transition threshold mismatch")
+	}
 }
 
 func TestDifficultyAdjust(t *testing.T) {
-    sc := NewSynnergyConsensus()
-    if sc.DifficultyAdjust(1, 20, 10) != 2 {
-        t.Fatalf("difficulty adjust incorrect")
-    }
+	sc := NewSynnergyConsensus()
+	if sc.DifficultyAdjust(1, 20, 10) != 2 {
+		t.Fatalf("difficulty adjust incorrect")
+	}
 }
 
 func TestSelectValidator(t *testing.T) {
-    sc := NewSynnergyConsensus()
-    stakes := map[string]uint64{"a": 1, "b": 2}
-    addr := sc.SelectValidator(stakes)
-    if addr != "a" && addr != "b" {
-        t.Fatalf("unexpected validator: %s", addr)
-    }
-    if sc.SelectValidator(map[string]uint64{}) != "" {
-        t.Fatalf("expected empty string when no stakes")
-    }
+	sc := NewSynnergyConsensus()
+	stakes := map[string]uint64{"a": 1, "b": 1}
+	addr := sc.SelectValidator(stakes)
+	if addr != "a" && addr != "b" {
+		t.Fatalf("unexpected validator: %s", addr)
+	}
+	if sc.SelectValidator(map[string]uint64{}) != "" {
+		t.Fatalf("expected empty string when no stakes")
+	}
 }
 
+func TestSelectValidatorMajorityStake(t *testing.T) {
+	sc := NewSynnergyConsensus()
+	stakes := map[string]uint64{"a": 60, "b": 40}
+	if sc.SelectValidator(stakes) != "" {
+		t.Fatalf("expected no validator selected due to majority stake")
+	}
+}
+
+func TestValidateSubBlock(t *testing.T) {
+	sc := NewSynnergyConsensus()
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "val")
+	if !sc.ValidateSubBlock(sb) {
+		t.Fatalf("expected valid sub-block")
+	}
+	sb.Signature = "bad"
+	if sc.ValidateSubBlock(sb) {
+		t.Fatalf("expected invalid sub-block")
+	}
+}

--- a/core/node.go
+++ b/core/node.go
@@ -65,7 +65,7 @@ func (n *Node) MineBlock() *Block {
 		return nil
 	}
 	sb := NewSubBlock(n.Mempool, validator)
-	if !sb.VerifySignature() {
+	if !n.Consensus.ValidateSubBlock(sb) {
 		return nil
 	}
 	n.Mempool = nil
@@ -89,6 +89,7 @@ func (n *Node) MineBlock() *Block {
 	shares := ShareProportional(pool, weights)
 	contract := NewFeeDistributionContract(n.Ledger)
 	contract.Distribute(shares)
+	n.Stakes[validator]++ // reward validator with additional stake
 	return block
 }
 


### PR DESCRIPTION
## Summary
- prevent 51% stake dominance when selecting validators
- validate sub-block signatures and contents via consensus engine
- reward validators with stake after successful block mining
- add unit tests for majority stake detection and sub-block validation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b137f77c888320b750e5a13f501963