### PR TITLE
feat: enhance access control and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Extensive CLI built with [Cobra](https://github.com/spf13/cobra) located under `cli/`.
 - AI modules for model management, inference analysis and anomaly detection.
 - Cross‑chain bridge and protocol support.
+- Role‑based access control with validated address utilities.
 - YAML based configuration for development, test and production environments.
 - Web interfaces for wallets, explorers and marketplaces under `GUI/`.
 

--- a/architectures/identity_access_architecture.md
+++ b/architectures/identity_access_architecture.md
@@ -19,4 +19,6 @@ Modules in this group manage user identities, authentication, and permission con
 - cli/biometric_security_node.go
 - cli/biometrics_auth.go
 
-These components provide secure onboarding and identity enforcement across the platform.
+These components provide secure onboarding and identity enforcement across the platform. The access controller exposes
+thread‑safe functions (`GrantRole`, `RevokeRole`, `HasRole`, `ListRoles`) used by the CLI and virtual machine to enforce
+permissions at runtime.

--- a/cli/access.go
+++ b/cli/access.go
@@ -7,8 +7,6 @@ import (
 	"synnergy/core"
 )
 
-var accessCtrl = core.NewAccessController()
-
 func init() {
 	accessCmd := &cobra.Command{Use: "access", Short: "Role based access control"}
 
@@ -17,7 +15,10 @@ func init() {
 		Args:  cobra.ExactArgs(2),
 		Short: "Grant a role to an address",
 		Run: func(cmd *cobra.Command, args []string) {
-			accessCtrl.Grant(args[0], args[1])
+			if err := core.GrantRole(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+				return
+			}
 			fmt.Println("granted")
 		},
 	}
@@ -27,7 +28,10 @@ func init() {
 		Args:  cobra.ExactArgs(2),
 		Short: "Revoke a role from an address",
 		Run: func(cmd *cobra.Command, args []string) {
-			accessCtrl.Revoke(args[0], args[1])
+			if err := core.RevokeRole(args[0], args[1]); err != nil {
+				fmt.Println("error:", err)
+				return
+			}
 			fmt.Println("revoked")
 		},
 	}
@@ -37,7 +41,12 @@ func init() {
 		Args:  cobra.ExactArgs(2),
 		Short: "Check if address has role",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(accessCtrl.HasRole(args[0], args[1]))
+			ok, err := core.HasRole(args[0], args[1])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+			fmt.Println(ok)
 		},
 	}
 
@@ -46,7 +55,11 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Short: "List roles for an address",
 		Run: func(cmd *cobra.Command, args []string) {
-			roles := accessCtrl.List(args[0])
+			roles, err := core.ListRoles(args[0])
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
 			for _, r := range roles {
 				fmt.Println(r)
 			}

--- a/cmd/synnergy/main.go
+++ b/cmd/synnergy/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/subosito/gotenv"
 
+	synn "synnergy"
 	"synnergy/cli"
 	"synnergy/internal/config"
 )
@@ -30,6 +31,9 @@ func main() {
 		logrus.Fatalf("invalid log level: %v", err)
 	}
 	logrus.SetLevel(lvl)
+
+	// Warm up caches for shared resources.
+	synn.LoadGasTable()
 
 	logrus.Infof("starting Synnergy in %s mode on %s:%d", cfg.Environment, cfg.Server.Host, cfg.Server.Port)
 

--- a/core/access_control.go
+++ b/core/access_control.go
@@ -1,30 +1,47 @@
 package core
 
-import "sync"
+import (
+	"errors"
+	"sync"
+)
 
-// AccessController manages role based access permissions.
+// ErrEmptyRole is returned when no role name is supplied.
+var ErrEmptyRole = errors.New("role cannot be empty")
+
+// AccessController manages role based access permissions using validated
+// addresses. All operations are safe for concurrent use.
 type AccessController struct {
 	mu    sync.RWMutex
-	roles map[string]map[string]struct{}
+	roles map[Address]map[string]struct{}
 }
 
 // NewAccessController constructs a new AccessController instance.
 func NewAccessController() *AccessController {
-	return &AccessController{roles: make(map[string]map[string]struct{})}
+	return &AccessController{roles: make(map[Address]map[string]struct{})}
 }
 
-// Grant assigns a role to an address.
-func (a *AccessController) Grant(role, addr string) {
+// Grant assigns a role to an address after basic validation.
+func (a *AccessController) Grant(addr Address, role string) error {
+	if role == "" {
+		return ErrEmptyRole
+	}
+	if addr.IsZero() {
+		return ErrInvalidAddress
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if _, ok := a.roles[addr]; !ok {
 		a.roles[addr] = make(map[string]struct{})
 	}
 	a.roles[addr][role] = struct{}{}
+	return nil
 }
 
-// Revoke removes a role from an address.
-func (a *AccessController) Revoke(role, addr string) {
+// Revoke removes a role from an address. It is a no-op for unknown addresses.
+func (a *AccessController) Revoke(addr Address, role string) error {
+	if role == "" {
+		return ErrEmptyRole
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if roles, ok := a.roles[addr]; ok {
@@ -33,10 +50,11 @@ func (a *AccessController) Revoke(role, addr string) {
 			delete(a.roles, addr)
 		}
 	}
+	return nil
 }
 
-// HasRole checks whether an address has a specific role.
-func (a *AccessController) HasRole(role, addr string) bool {
+// Has reports whether an address holds a role.
+func (a *AccessController) Has(addr Address, role string) bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	roles, ok := a.roles[addr]
@@ -48,7 +66,7 @@ func (a *AccessController) HasRole(role, addr string) bool {
 }
 
 // List returns all roles assigned to an address.
-func (a *AccessController) List(addr string) []string {
+func (a *AccessController) List(addr Address) []string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	roles, ok := a.roles[addr]
@@ -61,3 +79,48 @@ func (a *AccessController) List(addr string) []string {
 	}
 	return out
 }
+
+// GlobalAccess is the package level access controller used by default.
+var GlobalAccess = NewAccessController()
+
+// GrantRole validates inputs and stores the role assignment.
+func GrantRole(role, addr string) error {
+	a, err := StringToAddress(addr)
+	if err != nil {
+		return err
+	}
+	return GlobalAccess.Grant(a, role)
+}
+
+// RevokeRole removes a role from an address if present.
+func RevokeRole(role, addr string) error {
+	a, err := StringToAddress(addr)
+	if err != nil {
+		return err
+	}
+	return GlobalAccess.Revoke(a, role)
+}
+
+// HasRole reports whether an address owns a given role.
+func HasRole(role, addr string) (bool, error) {
+	if role == "" {
+		return false, ErrEmptyRole
+	}
+	a, err := StringToAddress(addr)
+	if err != nil {
+		return false, err
+	}
+	return GlobalAccess.Has(a, role), nil
+}
+
+// ListRoles returns all roles for an address.
+func ListRoles(addr string) ([]string, error) {
+	a, err := StringToAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+	return GlobalAccess.List(a), nil
+}
+
+// ErrInvalidAddress is returned when a provided address fails validation.
+var ErrInvalidAddress = errors.New("invalid address")

--- a/core/access_control_test.go
+++ b/core/access_control_test.go
@@ -3,17 +3,33 @@ package core
 import "testing"
 
 func TestAccessController(t *testing.T) {
-	ac := NewAccessController()
-	ac.Grant("admin", "addr1")
-	if !ac.HasRole("admin", "addr1") {
+	GlobalAccess = NewAccessController()
+	addr := "0x1111111111111111111111111111111111111111"
+	if err := GrantRole("admin", addr); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	ok, err := HasRole("admin", addr)
+	if err != nil || !ok {
 		t.Fatalf("expected role granted")
 	}
-	roles := ac.List("addr1")
-	if len(roles) != 1 || roles[0] != "admin" {
+	roles, err := ListRoles(addr)
+	if err != nil || len(roles) != 1 || roles[0] != "admin" {
 		t.Fatalf("unexpected roles: %v", roles)
 	}
-	ac.Revoke("admin", "addr1")
-	if ac.HasRole("admin", "addr1") {
+	if err := RevokeRole("admin", addr); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	ok, err = HasRole("admin", addr)
+	if err != nil {
+		t.Fatalf("has role: %v", err)
+	}
+	if ok {
 		t.Fatalf("role should be revoked")
+	}
+	if _, err := HasRole("", addr); err == nil {
+		t.Fatalf("expected error for empty role")
+	}
+	if err := GrantRole("admin", "invalid"); err == nil {
+		t.Fatalf("expected invalid address error")
 	}
 }

--- a/core/address.go
+++ b/core/address.go
@@ -1,9 +1,9 @@
 package core
 
 import (
-    "encoding/hex"
-    "fmt"
-    "strings"
+	"encoding/hex"
+	"fmt"
+	"strings"
 )
 
 // Address represents a 20-byte hex encoded identifier for accounts and contracts.
@@ -14,14 +14,14 @@ type Address string
 // Address. An error is returned if the string is not exactly 40 hexadecimal
 // characters.
 func StringToAddress(s string) (Address, error) {
-    s = strings.ToLower(strings.TrimPrefix(s, "0x"))
-    if len(s) != 40 {
-        return "", fmt.Errorf("invalid address length")
-    }
-    if _, err := hex.DecodeString(s); err != nil {
-        return "", fmt.Errorf("invalid address: %w", err)
-    }
-    return Address("0x" + s), nil
+	s = strings.ToLower(strings.TrimPrefix(s, "0x"))
+	if len(s) != 40 {
+		return "", fmt.Errorf("invalid address length")
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return "", fmt.Errorf("invalid address: %w", err)
+	}
+	return Address("0x" + s), nil
 }
 
 // Hex returns the canonical hexadecimal representation of the address.
@@ -30,26 +30,30 @@ func (a Address) Hex() string { return string(a) }
 // Bytes returns the raw 20-byte slice of the address. If the address is
 // malformed an empty slice is returned.
 func (a Address) Bytes() []byte {
-    b, err := hex.DecodeString(strings.TrimPrefix(string(a), "0x"))
-    if err != nil {
-        return []byte{}
-    }
-    return b
+	b, err := hex.DecodeString(strings.TrimPrefix(string(a), "0x"))
+	if err != nil {
+		return []byte{}
+	}
+	return b
 }
 
 // Short returns an abbreviated form of the address suitable for logging.
 // The first six and last four characters are preserved.
 func (a Address) Short() string {
-    h := a.Hex()
-    if len(h) <= 10 {
-        return h
-    }
-    return h[:6] + "..." + h[len(h)-4:]
+	h := a.Hex()
+	if len(h) <= 10 {
+		return h
+	}
+	return h[:6] + "..." + h[len(h)-4:]
 }
 
 // String implements fmt.Stringer.
 func (a Address) String() string { return a.Hex() }
 
+// IsZero reports whether the address equals the canonical zero address.
+func (a Address) IsZero() bool {
+	return strings.EqualFold(a.Hex(), string(AddressZero))
+}
+
 // Hash represents a simple 32-byte value used for identifiers.
 type Hash [32]byte
-

--- a/core/address_zero.go
+++ b/core/address_zero.go
@@ -1,11 +1,14 @@
 package core
 
-import "strings"
-
 // AddressZero represents the zero-value address (all 20 bytes set to zero).
-const AddressZero = "0x0000000000000000000000000000000000000000"
+const AddressZero Address = "0x0000000000000000000000000000000000000000"
 
-// IsZeroAddress returns true if the provided address equals AddressZero.
+// IsZeroAddress parses the supplied string and reports whether it is the zero
+// address. Invalid strings return false.
 func IsZeroAddress(addr string) bool {
-	return strings.ToLower(addr) == AddressZero
+	a, err := StringToAddress(addr)
+	if err != nil {
+		return false
+	}
+	return a.IsZero()
 }

--- a/core/address_zero_test.go
+++ b/core/address_zero_test.go
@@ -3,7 +3,7 @@ package core
 import "testing"
 
 func TestIsZeroAddress(t *testing.T) {
-	if !IsZeroAddress(AddressZero) {
+	if !IsZeroAddress(string(AddressZero)) {
 		t.Fatalf("expected zero address to match")
 	}
 	if IsZeroAddress("0xabc") {

--- a/core/gas.go
+++ b/core/gas.go
@@ -1,21 +1,28 @@
 package core
 
+import "sync"
+
 // GasTable defines the gas cost for each opcode.
 type GasTable map[Opcode]uint64
 
-// gasTable holds the active gas pricing used by the VM. It is initialised
-// from DefaultGasTable and can be modified at runtime via SetGasCost.
-var gasTable = DefaultGasTable()
+var (
+	gasTable = DefaultGasTable()
+	gasMu    sync.RWMutex
+)
 
 // GasCost returns the gas cost for the given opcode. If an opcode is missing
 // from the table it returns zero, allowing callers to treat unpriced opcodes
 // as free but still present in the catalogue.
 func GasCost(op Opcode) uint64 {
+	gasMu.RLock()
+	defer gasMu.RUnlock()
 	return gasTable[op]
 }
 
 // initGasTable resets the global gas table to defaults. It is invoked during
 // opcode initialisation once the catalogue is populated.
 func initGasTable() {
+	gasMu.Lock()
 	gasTable = DefaultGasTable()
+	gasMu.Unlock()
 }

--- a/core/gas_table.go
+++ b/core/gas_table.go
@@ -68,12 +68,16 @@ func parseGasGuide() map[string]uint64 {
 // SetGasCost updates the gas cost for a specific opcode at runtime. This allows
 // governance or tests to tweak opcode pricing without rebuilding the binary.
 func SetGasCost(op Opcode, cost uint64) {
+	gasMu.Lock()
 	gasTable[op] = cost
+	gasMu.Unlock()
 }
 
 // GasTableSnapshot returns a copy of the current gas table. The snapshot can be
 // used for inspection or persistence.
 func GasTableSnapshot() GasTable {
+	gasMu.RLock()
+	defer gasMu.RUnlock()
 	snapshot := make(GasTable, len(gasTable))
 	for op, c := range gasTable {
 		snapshot[op] = c

--- a/core/gas_table_test.go
+++ b/core/gas_table_test.go
@@ -98,3 +98,21 @@ func TestSetGasCostAndSnapshot(t *testing.T) {
 		t.Fatalf("modifying snapshot should not alter gas table")
 	}
 }
+
+func TestAccessControlGasCosts(t *testing.T) {
+	initGasTable()
+	grantOp, ok := nameToOp["GrantRole"]
+	if !ok {
+		t.Fatalf("GrantRole opcode missing")
+	}
+	if GasCost(grantOp) != 100 {
+		t.Fatalf("expected GrantRole cost 100, got %d", GasCost(grantOp))
+	}
+	hasOp, ok := nameToOp["HasRole"]
+	if !ok {
+		t.Fatalf("HasRole opcode missing")
+	}
+	if GasCost(hasOp) != 30 {
+		t.Fatalf("expected HasRole cost 30, got %d", GasCost(hasOp))
+	}
+}

--- a/docs/guides/cli_guide.md
+++ b/docs/guides/cli_guide.md
@@ -174,6 +174,9 @@ Synnergy blockchain CLI
 
 Role based access control
 
+All subcommands validate addresses and provide helpful error messages when input
+is malformed.
+
 ### Options
 
 ```
@@ -192,6 +195,8 @@ Role based access control
 ## synnergy access grant
 
 Grant a role to an address
+
+Returns an error if the role is empty or the address is invalid.
 
 ```
 synnergy access grant [role] [addr] [flags]
@@ -212,6 +217,8 @@ synnergy access grant [role] [addr] [flags]
 
 Check if address has role
 
+Outputs `true` or `false` after validating inputs.
+
 ```
 synnergy access has [role] [addr] [flags]
 ```
@@ -231,6 +238,8 @@ synnergy access has [role] [addr] [flags]
 
 List roles for an address
 
+Displays all roles assigned to a valid address.
+
 ```
 synnergy access list [addr] [flags]
 ```
@@ -249,6 +258,8 @@ synnergy access list [addr] [flags]
 ## synnergy access revoke
 
 Revoke a role from an address
+
+Silently succeeds if the role was not previously granted.
 
 ```
 synnergy access revoke [role] [addr] [flags]

--- a/docs/guides/opcode_and_gas_guide.md
+++ b/docs/guides/opcode_and_gas_guide.md
@@ -2168,7 +2168,8 @@ Operations related to wallet / key-management.
 
 ### Access Control
 
-Operations related to access control.
+Operations related to access control. Addresses are validated before roles are
+assigned or revoked.
 
 
 | Opcode | Gas Cost |

--- a/gas_table_list.md
+++ b/gas_table_list.md
@@ -164,10 +164,11 @@
 | `GetTransfer` | `1` |
 | `Grant` | `1` |
 | `GrantAccess` | `1` |
+| `GrantRole` | `100` |
 | `Handle` | `1` |
 | `HasDrift` | `1` |
 | `HasQuorum` | `1` |
-| `HasRole` | `1` |
+| `HasRole` | `30` |
 | `Hash` | `1` |
 | `HashRateHint` | `1` |
 | `Head` | `1` |
@@ -203,6 +204,7 @@
 | `LatestHeader` | `1` |
 | `Leave` | `1` |
 | `List` | `1` |
+| `ListRoles` | `50` |
 | `ListBridges` | `1` |
 | `ListComponents` | `1` |
 | `ListDocuments` | `1` |
@@ -483,6 +485,7 @@
 | `ReviewTransaction` | `1` |
 | `Revoke` | `1` |
 | `RevokeAccess` | `1` |
+| `RevokeRole` | `100` |
 | `RevokeDelegation` | `1` |
 | `RevokeRelayer` | `1` |
 | `RevokeSignature` | `1` |

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -53,7 +53,8 @@ operations tooling.
 Multiple packages handle identity management and regulatory enforcement.
 `identity_verification.go` and `idwallet_registration.go` register addresses,
 while `compliance.go`, `regulatory_management.go` and related files enforce
-jurisdictional rules. Optional biometric authentication modules provide
+jurisdictional rules. A global access‑control module assigns granular roles to
+validated addresses, and optional biometric authentication modules provide
 additional verification for sensitive workflows.
 
 ### AI Services


### PR DESCRIPTION
## Summary
- add thread-safe access controller with address validation and global helpers
- document access CLI and update gas/opcode catalog
- cache gas table and expose warm-up in main

## Testing
- `go vet ./core`
- `go test ./core -run 'AccessControl|IsZeroAddress|StringToAddress|AccessControlGasCosts'`
- `go test -run ''`


------
https://chatgpt.com/codex/tasks/task_e_68b868c7ba54832087e147b32e18af0a