### PR TITLE
docs: expand stage8 cross-chain guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All guides and architecture decision records are located under the `docs/` direc
   tracking.
 - Structured JSON logging with pluggable backends for compliance, connection and consensus modules.
 - Stage 7 adds a unified errors package and OpenTelemetry tracing for consensus and contract management components, improving diagnostics across the CLI and services.
+- Stage 8 introduces a contract registry and cross‑chain transaction managers with full CLI access and gas‑priced opcodes for deterministic execution.
 
 ## Repository layout
 ```

--- a/architectures/cross_chain_architecture.md
+++ b/architectures/cross_chain_architecture.md
@@ -21,3 +21,8 @@ Cross-chain modules enable interoperability with external networks through bridg
 - cli/cross_consensus_scaling_networks.go
 
 These components coordinate communication and asset transfers across multiple blockchains.
+
+Stage 8 hardens these modules for production use.  Each manager is concurrency
+safe, exposes deterministic gas‑priced opcodes and is accessible through the
+`synnergy` CLI.  Registries and bridge transfers persist in memory but are
+designed to be swapped with database backends for fault‑tolerant deployments.

--- a/cmd/synnergy/main.go
+++ b/cmd/synnergy/main.go
@@ -46,6 +46,16 @@ func main() {
 	_ = core.NewAuthorityNodeRegistry()
 	_ = core.NewBankInstitutionalNode("init", "init", core.NewLedger())
 
+	// Preload stage 8 modules to expose contract and cross-chain managers via CLI.
+	vm := core.NewSimpleVM()
+	_ = vm.Start()
+	_ = core.NewContractRegistry(vm)
+	_ = core.NewBridgeRegistry()
+	_ = core.NewBridgeTransferManager()
+	_ = core.NewChainConnectionManager()
+	_ = core.NewProtocolRegistry()
+	_ = core.NewCrossChainTxManager(core.NewLedger())
+
 	logrus.Infof("starting Synnergy in %s mode on %s:%d", cfg.Environment, cfg.Server.Host, cfg.Server.Port)
 
 	if err := cli.Execute(); err != nil {

--- a/docs/guides/cli_guide.md
+++ b/docs/guides/cli_guide.md
@@ -7,6 +7,7 @@ Synnergy blockchain CLI
 > Stage 6 introduces structured logging for compliance, connection pool and consensus commands.
 >
 > Stage 7 adds coded error handling and OpenTelemetry tracing for consensus and contract management commands.
+> Stage 8 exposes contract and cross-chain modules through persistent CLI commands and gas table integration.
 
 ### Options
 

--- a/docs/guides/opcode_and_gas_guide.md
+++ b/docs/guides/opcode_and_gas_guide.md
@@ -336,31 +336,25 @@ Operations related to cross-chain.
 | Opcode | Gas Cost |
 |---|---|
 | `RegisterBridge` | `2000` |
-| `AssertRelayer` | `500` |
-| `Iterator` | `200` |
-| `LockAndMint` | `3000` |
-| `BurnAndRelease` | `3000` |
+| `AuthorizeRelayer` | `500` |
+| `RevokeRelayer` | `500` |
+| `LockMint` | `3000` |
+| `BurnRelease` | `3000` |
 | `GetBridge` | `100` |
-| `RegisterXContract` | `2200` |
-| `GetXContract` | `100` |
-| `ListXContracts` | `120` |
-| `RemoveXContract` | `500` |
-| `RecordCrossChainTx` | `2500` |
-| `GetCrossChainTx` | `200` |
-| `ListCrossChainTx` | `300` |
-| `OpenChainConnection` | `1000` |
-| `CloseChainConnection` | `500` |
-| `GetChainConnection` | `100` |
-| `ListChainConnections` | `200` |
+| `ListBridges` | `120` |
+| `RegisterMapping` | `2200` |
+| `GetMapping` | `100` |
+| `ListMappings` | `120` |
+| `RemoveMapping` | `500` |
+| `GetTransfer` | `100` |
+| `ListTransfers` | `200` |
+| `OpenConnection` | `1000` |
+| `CloseConnection` | `500` |
+| `GetConnection` | `100` |
+| `ListConnections` | `200` |
 | `RegisterProtocol` | `2000` |
 | `ListProtocols` | `200` |
 | `GetProtocol` | `100` |
-| `ProtocolDeposit` | `3000` |
-| `ProtocolWithdraw` | `3000` |
-| `StartBridgeTransfer` | `2500` |
-| `CompleteBridgeTransfer` | `2500` |
-| `GetBridgeTransfer` | `100` |
-| `ListBridgeTransfers` | `200` |
 
 
 ### Cross-Consensus Scaling Networks

--- a/docs/guides/token_guide.md
+++ b/docs/guides/token_guide.md
@@ -7,6 +7,7 @@ built-in token standards provided by the project.
 Stage 6 integrates compliance checks into token operations via the new logging subsystem, allowing auditors to trace token transactions.
 
 Stage 7 adds coded error handling and telemetry spans to token registry and CLI interactions, enabling operators to correlate failures across services.
+Stage 8 introduces cross‑chain token bridging via the `CrossChainTxManager`, allowing assets to move between ledgers through gas‑priced CLI calls.
 
 ## Package layout
 

--- a/gas_table_list.md
+++ b/gas_table_list.md
@@ -92,6 +92,11 @@
 | `Delete` | `1` |
 | `Deploy` | `1` |
 | `DeployAIContract` | `5000` |
+| `ContractInfo` | `100` |
+| `InitContracts` | `1500` |
+| `PauseContract` | `300` |
+| `ResumeContract` | `300` |
+| `UpgradeContract` | `2000` |
 | `Deposit` | `1` |
 | `Deregister` | `1` |
 | `DialSeed` | `1` |

--- a/synnergy_network_function_web.md
+++ b/synnergy_network_function_web.md
@@ -1,6 +1,6 @@
 # Synnergy Network Function Web
 
-This document provides a high-level function web for the Synnergy network, outlining major modules and their core functions.
+This document provides a high-level function web for the Synnergy network, outlining major modules and their core functions. Stage 8 expands cross-chain registries and bridge managers with CLI access and gas‑priced opcodes.
 
 ## Diagram
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -82,6 +82,10 @@ connections to external networks, register contract mappings and relay
 transactions. An agnostic protocol layer enables heterogeneous chains to
 communicate without trusting a central intermediary.
 
+Stage 8 elevates these components with gas‑priced opcodes and accompanying CLI
+commands. Registries for bridges, contracts and transfers are concurrency safe
+and can be backed by persistent stores for fault‑tolerant deployments.
+
 ### Authority and Banking Nodes
 Stage 3 introduces governance‑focused modules. The `AuthorityNodeRegistry` and
 `AuthorityApplicationManager` coordinate admission of validator candidates with


### PR DESCRIPTION
## Summary
- document contract lifecycle opcodes in gas table
- align cross-chain opcode guide and architecture notes
- preload Stage 8 registries and bridge managers in CLI entrypoint

## Testing
- `go test ./...` *(fails: command terminated without output)*


------
https://chatgpt.com/codex/tasks/task_e_68b879cd9fc883209eeecf147ef43812