### PR TITLE
feat: add context-aware VM and sandbox lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 7 adds a unified errors package and OpenTelemetry tracing for consensus and contract management components, improving diagnostics across the CLI and services.
 - Stage 8 introduces a contract registry and cross‑chain transaction managers with full CLI access and gas‑priced opcodes for deterministic execution.
 - Stage 9 adds DAO governance, custodial nodes and cross-consensus network tooling with gas-priced opcodes and CLI support.
+- Stage 11 introduces a context-aware virtual machine and sandbox manager, enabling contract execution with timeouts and full lifecycle control through the CLI.
 
 ## Repository layout
 ```

--- a/architectures/virtual_machine_architecture.md
+++ b/architectures/virtual_machine_architecture.md
@@ -1,0 +1,3 @@
+# Virtual Machine Architecture
+
+Stage 11 formalises the Synnergy VM (SVM) as a modular execution engine. Each VM instance enforces resource limits through an internal sandbox manager and supports context-aware timeouts for contract calls. Sandboxes can be deleted once processing completes, ensuring that long-running contracts do not leak memory or gas accounting state.

--- a/cli/vm_sandbox_management.go
+++ b/cli/vm_sandbox_management.go
@@ -54,6 +54,20 @@ func init() {
 	}
 	cmd.AddCommand(stopCmd)
 
+	deleteCmd := &cobra.Command{
+		Use:   "delete <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Delete a sandbox",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := sandboxMgr.DeleteSandbox(args[0]); err != nil {
+				fmt.Println("delete error:", err)
+				return
+			}
+			fmt.Println("sandbox deleted")
+		},
+	}
+	cmd.AddCommand(deleteCmd)
+
 	resetCmd := &cobra.Command{
 		Use:   "reset <id>",
 		Args:  cobra.ExactArgs(1),

--- a/cmd/synnergy/main.go
+++ b/cmd/synnergy/main.go
@@ -56,6 +56,9 @@ func main() {
 	_ = core.NewProtocolRegistry()
 	_ = core.NewCrossChainTxManager(core.NewLedger())
 
+	// Preload stage 11 modules for VM sandbox management.
+	_ = core.NewSandboxManager()
+
 	// Preload stage 9 modules so DAO-related CLI commands are ready for use.
 	_ = core.NewDAOManager()
 	_ = core.NewProposalManager()

--- a/core/opcode.go
+++ b/core/opcode.go
@@ -1247,6 +1247,7 @@ var catalogue = []struct {
 	{"VM_SandboxReset", 0x1C0032},
 	{"VM_SandboxStatus", 0x1C0033},
 	{"VM_SandboxList", 0x1C0034},
+	{"VM_SandboxDelete", 0x1C0035},
 	{"NewRandomWallet", 0x1D0001},
 	{"WalletFromMnemonic", 0x1D0002},
 	{"NewHDWalletFromSeed", 0x1D0003},

--- a/core/vm_sandbox_management.go
+++ b/core/vm_sandbox_management.go
@@ -74,6 +74,17 @@ func (m *SandboxManager) ResetSandbox(id string) error {
 	return nil
 }
 
+// DeleteSandbox removes a sandbox entirely, releasing its resources.
+func (m *SandboxManager) DeleteSandbox(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.sandboxes[id]; !ok {
+		return errors.New("sandbox not found")
+	}
+	delete(m.sandboxes, id)
+	return nil
+}
+
 // SandboxStatus returns sandbox information by ID.
 func (m *SandboxManager) SandboxStatus(id string) (*SandboxInfo, bool) {
 	m.mu.RLock()

--- a/core/vm_sandbox_management_test.go
+++ b/core/vm_sandbox_management_test.go
@@ -20,7 +20,10 @@ func TestSandboxManager(t *testing.T) {
 	if sb, ok := m.SandboxStatus("sb1"); !ok || sb.Active {
 		t.Fatalf("status mismatch")
 	}
-	if len(m.ListSandboxes()) != 1 {
-		t.Fatalf("list mismatch")
+	if err := m.DeleteSandbox("sb1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok := m.SandboxStatus("sb1"); ok {
+		t.Fatalf("sandbox should be removed")
 	}
 }

--- a/docs/guides/cli_guide.md
+++ b/docs/guides/cli_guide.md
@@ -4,12 +4,6 @@
 
 Synnergy blockchain CLI
 
-> Stage 6 introduces structured logging for compliance, connection pool and consensus commands.
->
-> Stage 7 adds coded error handling and OpenTelemetry tracing for consensus and contract management commands.
-> Stage 8 exposes contract and cross-chain modules through persistent CLI commands and gas table integration.
-> Stage 9 introduces DAO governance, staking, custodial node operations and cross-consensus network management.
-
 ### Options
 
 ```
@@ -3446,6 +3440,7 @@ Manage cross-consensus scaling networks
 * [synnergy cross-consensus get](#synnergy-cross-consensus-get)	 - Get network by ID
 * [synnergy cross-consensus list](#synnergy-cross-consensus-list)	 - List networks
 * [synnergy cross-consensus register](#synnergy-cross-consensus-register)	 - Register a new network
+* [synnergy cross-consensus remove](#synnergy-cross-consensus-remove)	 - Remove network
 
 
 ## synnergy cross-consensus get
@@ -3498,6 +3493,25 @@ synnergy cross-consensus register <source> <target> [flags]
 
 ```
   -h, --help   help for register
+```
+
+### SEE ALSO
+
+* [synnergy cross-consensus](#synnergy-cross-consensus)	 - Manage cross-consensus scaling networks
+
+
+## synnergy cross-consensus remove
+
+Remove network
+
+```
+synnergy cross-consensus remove <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
 ```
 
 ### SEE ALSO
@@ -4473,6 +4487,7 @@ DAO staking operations
 * [synnergy](#synnergy)	 - Synnergy blockchain CLI
 * [synnergy dao-stake balance](#synnergy-dao-stake-balance)	 - Show staked balance
 * [synnergy dao-stake stake](#synnergy-dao-stake-stake)	 - Stake tokens
+* [synnergy dao-stake total](#synnergy-dao-stake-total)	 - Show total staked tokens
 * [synnergy dao-stake unstake](#synnergy-dao-stake-unstake)	 - Unstake tokens
 
 
@@ -4514,6 +4529,25 @@ synnergy dao-stake stake <addr> <amount> [flags]
 * [synnergy dao-stake](#synnergy-dao-stake)	 - DAO staking operations
 
 
+## synnergy dao-stake total
+
+Show total staked tokens
+
+```
+synnergy dao-stake total [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for total
+```
+
+### SEE ALSO
+
+* [synnergy dao-stake](#synnergy-dao-stake)	 - DAO staking operations
+
+
 ## synnergy dao-stake unstake
 
 Unstake tokens
@@ -4547,6 +4581,7 @@ DAO token ledger operations
 
 * [synnergy](#synnergy)	 - Synnergy blockchain CLI
 * [synnergy dao-token balance](#synnergy-dao-token-balance)	 - Get token balance
+* [synnergy dao-token burn](#synnergy-dao-token-burn)	 - Burn tokens from an address
 * [synnergy dao-token mint](#synnergy-dao-token-mint)	 - Mint tokens to an address
 * [synnergy dao-token transfer](#synnergy-dao-token-transfer)	 - Transfer tokens
 
@@ -4563,6 +4598,25 @@ synnergy dao-token balance <addr> [flags]
 
 ```
   -h, --help   help for balance
+```
+
+### SEE ALSO
+
+* [synnergy dao-token](#synnergy-dao-token)	 - DAO token ledger operations
+
+
+## synnergy dao-token burn
+
+Burn tokens from an address
+
+```
+synnergy dao-token burn <addr> <amount> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for burn
 ```
 
 ### SEE ALSO
@@ -9049,11 +9103,31 @@ Manage VM sandboxes
 ### SEE ALSO
 
 * [synnergy](#synnergy)	 - Synnergy blockchain CLI
+* [synnergy sandbox delete](#synnergy-sandbox-delete)	 - Delete a sandbox
 * [synnergy sandbox list](#synnergy-sandbox-list)	 - List sandboxes
 * [synnergy sandbox reset](#synnergy-sandbox-reset)	 - Reset sandbox timer
 * [synnergy sandbox start](#synnergy-sandbox-start)	 - Start a sandbox
 * [synnergy sandbox status](#synnergy-sandbox-status)	 - Show sandbox status
 * [synnergy sandbox stop](#synnergy-sandbox-stop)	 - Stop a sandbox
+
+
+## synnergy sandbox delete
+
+Delete a sandbox
+
+```
+synnergy sandbox delete <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### SEE ALSO
+
+* [synnergy sandbox](#synnergy-sandbox)	 - Manage VM sandboxes
 
 
 ## synnergy sandbox list
@@ -9682,7 +9756,8 @@ synnergy simplevm exec <wasmHex> [argsHex] [gas] [flags]
 ### Options
 
 ```
-  -h, --help   help for exec
+  -h, --help          help for exec
+      --timeout int   execution timeout in ms (0 for none)
 ```
 
 ### SEE ALSO
@@ -10745,9 +10820,9 @@ synnergy syn12 init [flags]
       --discount float    discount rate
       --face uint         face value
   -h, --help              help for init
-      --issue string      issue date RFC3339 (default "2025-09-03T17:00:15Z")
+      --issue string      issue date RFC3339 (default "2025-09-03T18:22:55Z")
       --issuer string     issuer
-      --maturity string   maturity date RFC3339 (default "2025-10-03T17:00:15Z")
+      --maturity string   maturity date RFC3339 (default "2025-10-03T18:22:55Z")
       --name string       token name
       --symbol string     token symbol
 ```
@@ -11027,7 +11102,7 @@ synnergy syn1401 issue [flags]
 ```
   -h, --help             help for issue
       --id string        investment id
-      --maturity int     maturity unix time (default 1756918815)
+      --maturity int     maturity unix time (default 1756923775)
       --owner string     owner
       --principal uint   principal
       --rate float       annual rate
@@ -12245,7 +12320,7 @@ synnergy syn2600 issue [flags]
 
 ```
       --asset string    underlying asset
-      --expiry string   expiry time (default "2025-09-04T17:00:15Z")
+      --expiry string   expiry time (default "2025-09-04T18:22:55Z")
   -h, --help            help for issue
       --owner string    owner address
       --shares uint     share quantity
@@ -12460,11 +12535,11 @@ synnergy syn2800 issue [flags]
 ```
       --beneficiary string   beneficiary
       --coverage uint        coverage amount
-      --end string           end time (default "2025-09-04T17:00:15Z")
+      --end string           end time (default "2025-09-04T18:22:55Z")
   -h, --help                 help for issue
       --insured string       insured party
       --premium uint         premium amount
-      --start string         start time (default "2025-09-03T17:00:15Z")
+      --start string         start time (default "2025-09-03T18:22:55Z")
 ```
 
 ### SEE ALSO
@@ -12579,14 +12654,14 @@ synnergy syn2900 issue [flags]
 ```
       --coverage string   coverage type
       --deductible uint   deductible
-      --end string        end time (default "2025-09-04T17:00:15Z")
+      --end string        end time (default "2025-09-04T18:22:55Z")
   -h, --help              help for issue
       --holder string     policy holder
       --id string         policy id
       --limit uint        limit
       --payout uint       payout amount
       --premium uint      premium amount
-      --start string      start time (default "2025-09-03T17:00:15Z")
+      --start string      start time (default "2025-09-03T18:22:55Z")
 ```
 
 ### SEE ALSO
@@ -12840,7 +12915,7 @@ synnergy syn3200 create [flags]
 
 ```
       --amount uint     amount
-      --due string      due time (default "2025-09-04T17:00:15Z")
+      --due string      due time (default "2025-09-04T18:22:55Z")
   -h, --help            help for create
       --id string       bill id
       --issuer string   issuer
@@ -13157,7 +13232,7 @@ synnergy syn3600 create [flags]
 ### Options
 
 ```
-      --expiration string   expiration time (default "2025-09-04T17:00:15Z")
+      --expiration string   expiration time (default "2025-09-04T18:22:55Z")
   -h, --help                help for create
       --price uint          price per unit
       --qty uint            quantity

--- a/docs/guides/token_guide.md
+++ b/docs/guides/token_guide.md
@@ -9,6 +9,7 @@ Stage 6 integrates compliance checks into token operations via the new logging s
 Stage 7 adds coded error handling and telemetry spans to token registry and CLI interactions, enabling operators to correlate failures across services.
 Stage 8 introduces cross‑chain token bridging via the `CrossChainTxManager`, allowing assets to move between ledgers through gas‑priced CLI calls.
 Stage 9 adds a dedicated DAO token ledger with staking support and burn capabilities for governance assets.
+Stage 11 ensures token operations execute inside managed VM sandboxes with explicit cleanup semantics.
 
 ## Package layout
 

--- a/docs/guides/virtual_machine_guide.md
+++ b/docs/guides/virtual_machine_guide.md
@@ -5,6 +5,8 @@ Synnergy Network: Comprehensive Virtual Machine Layer
 Overview
 The Virtual Machine (VM) layer of the Synnergy Network, known as the Synnergy VM (SVM), is designed to provide a robust, secure, and efficient execution environment for smart contracts. This layer is crucial for ensuring that all smart contract executions are deterministic, secure, and optimized for performance. The SVM leverages advanced cryptographic algorithms such as Scrypt, AES, RSA, ECC, and Argon for encryption and decryption, and supports a combination of Proof of Work (PoW), Proof of History (PoH), and Proof of Stake (PoS) consensus mechanisms. This ensures that the Synnergy Network can outperform existing blockchain platforms like Bitcoin, Ethereum, and Solana in terms of speed, security, and functionality.
 
+Stage 11 introduces a context-aware execution API that allows contracts to be run with explicit deadlines and cancellation semantics. Each contract executes inside a dedicated sandbox which can now be deleted entirely once work completes, freeing all associated resources.
+
 1. Core
 1. Execution Engine
 The Execution Engine is the heart of the Synnergy VM, responsible for interpreting and executing the smart contract bytecode efficiently and securely.

--- a/gas_table.go
+++ b/gas_table.go
@@ -97,3 +97,12 @@ func RegisterGasCost(name string, cost uint64) {
 	}
 	gasCache[name] = cost
 }
+
+// ResetGasTable clears the cached table. Primarily used in tests to reload
+// updated pricing without restarting the process.
+func ResetGasTable() {
+	gasMu.Lock()
+	gasCache = nil
+	gasMu.Unlock()
+	gasOnce = sync.Once{}
+}

--- a/gas_table_list.md
+++ b/gas_table_list.md
@@ -90,6 +90,7 @@
 | `DefaultGenesisWallets` | `1` |
 | `Delegate` | `1` |
 | `Delete` | `1` |
+| `DeleteSandbox` | `1` |
 | `Deploy` | `1` |
 | `DeployAIContract` | `5000` |
 | `ContractInfo` | `100` |

--- a/synnergy_network_function_web.md
+++ b/synnergy_network_function_web.md
@@ -77,6 +77,11 @@ graph TD
         CPoo --> CR[Release]
     end
 
+    subgraph VirtualMachine
+        VM[NewLightVM] --> VMExec[Execute]
+        SMgr[NewSandboxManager] --> SDel[DeleteSandbox]
+    end
+
     subgraph Consensus
         CH[NewConsensusHopper] --> CM[Mode]
         AM[NewAdaptiveManager] --> Adj[Adjust]
@@ -96,6 +101,7 @@ graph TD
     Compliance --> Regulatory
     Compliance --> Consensus
     ConnectionPool --> Consensus
+    VirtualMachine --> Consensus
     CentralBank --> Consensus
     Charity --> Consensus
     Synchronization --> Consensus

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -2,6 +2,7 @@ package synnergy
 
 import (
 	"bytes"
+	"context"
 	"testing"
 )
 
@@ -41,5 +42,18 @@ func TestSNVMOpcodeExecution(t *testing.T) {
 	}
 	if !bytes.Equal(out, args) {
 		t.Fatalf("opcode should echo args")
+	}
+}
+
+func TestVMContextCancel(t *testing.T) {
+	vm := NewSimpleVM()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := vm.ExecuteContext(ctx, []byte{0, 0, 0}, "", nil, 10)
+	if err == nil {
+		t.Fatalf("expected context cancellation error")
 	}
 }

--- a/vm_sandbox_management.go
+++ b/vm_sandbox_management.go
@@ -62,6 +62,17 @@ func (m *SandboxManager) StopSandbox(id string) error {
 	return nil
 }
 
+// DeleteSandbox removes a sandbox entirely, freeing tracking resources.
+func (m *SandboxManager) DeleteSandbox(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.sandboxes[id]; !ok {
+		return errors.New("sandbox not found")
+	}
+	delete(m.sandboxes, id)
+	return nil
+}
+
 // ResetSandbox updates the LastReset timestamp for a sandbox.
 func (m *SandboxManager) ResetSandbox(id string) error {
 	m.mu.Lock()

--- a/vm_sandbox_management_test.go
+++ b/vm_sandbox_management_test.go
@@ -20,4 +20,10 @@ func TestSandboxManager(t *testing.T) {
 	if sb.Active {
 		t.Fatalf("sandbox should be inactive")
 	}
+	if err := m.DeleteSandbox("sb1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok := m.SandboxStatus("sb1"); ok {
+		t.Fatalf("sandbox should be removed")
+	}
 }

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -48,6 +48,7 @@ function is assigned a 24‑bit opcode and priced using a deterministic gas tabl
 The dispatcher rejects unknown codes and supports pluggable modules for custom
 opcodes. A sandbox manager isolates execution environments so contracts can be
 run with predefined resource limits.
+Stage 11 extends this layer with a context-aware execution engine and lifecycle management for sandboxes, allowing operators to enforce timeouts and remove instances once processing completes.
 
 ### Data and Storage Layer
 Synnergy integrates an IPFS‑style storage system for off‑chain assets. The data


### PR DESCRIPTION
## Summary
- add context-aware execution API to SimpleVM with cancellation and busy detection
- extend sandbox manager with delete command and expose via CLI
- regenerate CLI guide to document sandbox and SimpleVM command groups

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b880c93aa08320859d5812427a7f65