### PR TITLE
Enhance Stage 18 token registries with validation and deactivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 15 expands internal node variants with in-memory forensic, geospatial, historical and elected authority nodes, enabling richer diagnostics and data services across the network.
 - Stage 16 introduces a concurrency-safe token registry and base token with micro-benchmarks to track transfer throughput.
 - Stage 17 delivers standard token contracts including CBDC, pausable utility and gaming asset tokens. Each implementation is thread-safe and accessible via dedicated CLI modules.
+- Stage 18 expands the token library with investor share registries, life and general insurance policies, forex pairs, fiat‑pegged currencies, index funds, charity campaigns and legal document tokens, all validated and manageable through the CLI.
 
 ## Repository layout
 ```

--- a/cli/syn2600.go
+++ b/cli/syn2600.go
@@ -25,7 +25,11 @@ func init() {
 			shares, _ := cmd.Flags().GetUint64("shares")
 			expStr, _ := cmd.Flags().GetString("expiry")
 			expiry, _ := time.Parse(time.RFC3339, expStr)
-			tok := investorRegistry.Issue(asset, owner, shares, expiry)
+			tok, err := investorRegistry.Issue(asset, owner, shares, expiry)
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
 			fmt.Println(tok.ID)
 		},
 	}
@@ -90,6 +94,18 @@ func init() {
 		},
 	}
 	cmd.AddCommand(listCmd)
+
+	deactivateCmd := &cobra.Command{
+		Use:   "deactivate <id>",
+		Short: "Deactivate an investor token",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := investorRegistry.Deactivate(args[0]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(deactivateCmd)
 
 	rootCmd.AddCommand(cmd)
 }

--- a/cli/syn2800.go
+++ b/cli/syn2800.go
@@ -28,7 +28,11 @@ func init() {
 			endStr, _ := cmd.Flags().GetString("end")
 			start, _ := time.Parse(time.RFC3339, startStr)
 			end, _ := time.Parse(time.RFC3339, endStr)
-			p := lifeRegistry.IssuePolicy(insured, beneficiary, coverage, premium, start, end)
+			p, err := lifeRegistry.IssuePolicy(insured, beneficiary, coverage, premium, start, end)
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
 			fmt.Println(p.PolicyID)
 		},
 	}
@@ -97,6 +101,18 @@ func init() {
 		},
 	}
 	cmd.AddCommand(listCmd)
+
+	deactivateCmd := &cobra.Command{
+		Use:   "deactivate <policy>",
+		Short: "Deactivate a life policy",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := lifeRegistry.Deactivate(args[0]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(deactivateCmd)
 
 	rootCmd.AddCommand(cmd)
 }

--- a/cli/syn2900.go
+++ b/cli/syn2900.go
@@ -5,22 +5,21 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"synnergy/core"
+	"synnergy/internal/tokens"
 )
 
-var policy *core.TokenInsurancePolicy
+var insuranceRegistry = tokens.NewInsuranceRegistry()
 
 func init() {
 	cmd := &cobra.Command{
 		Use:   "syn2900",
-		Short: "Token insurance policies",
+		Short: "General insurance policies",
 	}
 
 	issueCmd := &cobra.Command{
 		Use:   "issue",
 		Short: "Issue a new policy",
 		Run: func(cmd *cobra.Command, args []string) {
-			id, _ := cmd.Flags().GetString("id")
 			holder, _ := cmd.Flags().GetString("holder")
 			coverage, _ := cmd.Flags().GetString("coverage")
 			premium, _ := cmd.Flags().GetUint64("premium")
@@ -31,11 +30,14 @@ func init() {
 			endStr, _ := cmd.Flags().GetString("end")
 			start, _ := time.Parse(time.RFC3339, startStr)
 			end, _ := time.Parse(time.RFC3339, endStr)
-			policy = core.NewTokenInsurancePolicy(id, holder, coverage, premium, payout, deductible, limit, start, end)
-			fmt.Println("policy issued")
+			p, err := insuranceRegistry.IssuePolicy(holder, coverage, premium, payout, deductible, limit, start, end)
+			if err != nil {
+				fmt.Printf("error: %v\n", err)
+				return
+			}
+			fmt.Println(p.PolicyID)
 		},
 	}
-	issueCmd.Flags().String("id", "", "policy id")
 	issueCmd.Flags().String("holder", "", "policy holder")
 	issueCmd.Flags().String("coverage", "", "coverage type")
 	issueCmd.Flags().Uint64("premium", 0, "premium amount")
@@ -46,36 +48,61 @@ func init() {
 	issueCmd.Flags().String("end", time.Now().Add(24*time.Hour).Format(time.RFC3339), "end time")
 	cmd.AddCommand(issueCmd)
 
-	activeCmd := &cobra.Command{
-		Use:   "active",
-		Short: "Check if policy is active",
-		Run: func(cmd *cobra.Command, args []string) {
-			if policy == nil {
-				fmt.Println("no policy")
-				return
-			}
-			fmt.Println(policy.IsActive(time.Now()))
-		},
-	}
-	cmd.AddCommand(activeCmd)
-
 	claimCmd := &cobra.Command{
-		Use:   "claim",
-		Short: "Claim the policy",
+		Use:   "claim <policy> <desc> <amount>",
+		Short: "File a claim",
+		Args:  cobra.ExactArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
-			if policy == nil {
-				fmt.Println("no policy")
-				return
-			}
-			amt, err := policy.Claim(time.Now())
-			if err != nil {
+			var amt uint64
+			fmt.Sscanf(args[2], "%d", &amt)
+			if _, err := insuranceRegistry.FileClaim(args[0], args[1], amt); err != nil {
 				fmt.Printf("error: %v\n", err)
-				return
 			}
-			fmt.Printf("payout %d\n", amt)
 		},
 	}
 	cmd.AddCommand(claimCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get <policy>",
+		Short: "Get policy info",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, ok := insuranceRegistry.GetPolicy(args[0])
+			if !ok {
+				fmt.Println("policy not found")
+				return
+			}
+			fmt.Printf("ID:%s Holder:%s Coverage:%s Premium:%d Payout:%d Active:%t\n", p.PolicyID, p.Holder, p.Coverage, p.Premium, p.Payout, p.Active)
+			for _, c := range p.Claims {
+				fmt.Printf("claim %s %d %s settled:%t\n", c.ClaimID, c.Amount, c.Time.Format(time.RFC3339), c.Settled)
+			}
+		},
+	}
+	cmd.AddCommand(getCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List policies",
+		Run: func(cmd *cobra.Command, args []string) {
+			policies := insuranceRegistry.ListPolicies()
+			for _, p := range policies {
+				fmt.Printf("%s %s %s %d %d\n", p.PolicyID, p.Holder, p.Coverage, p.Premium, p.Payout)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
+
+	deactivateCmd := &cobra.Command{
+		Use:   "deactivate <policy>",
+		Short: "Deactivate a policy",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := insuranceRegistry.Deactivate(args[0]); err != nil {
+				fmt.Printf("error: %v\n", err)
+			}
+		},
+	}
+	cmd.AddCommand(deactivateCmd)
 
 	rootCmd.AddCommand(cmd)
 }

--- a/docs/guides/token_guide.md
+++ b/docs/guides/token_guide.md
@@ -17,6 +17,11 @@ utility tokens and in‑game asset registries. These implementations embed the
 thread‑safe base token and expose dedicated CLI commands for minting and
 transfer operations.
 
+Stage 18 extends the library with investor share tokens, multiple insurance
+registries, forex pairs, fiat‑pegged currencies, index funds, charity campaigns
+and legal document tokens. Each contract validates inputs and allows
+administrators to deactivate assets through the CLI.
+
 ## Package layout
 
 Token code lives under `internal/tokens`.  Key files are:

--- a/internal/tokens/advanced_tokens_test.go
+++ b/internal/tokens/advanced_tokens_test.go
@@ -40,7 +40,10 @@ func TestSYN200CarbonRegistry(t *testing.T) {
 func TestSYN2600InvestorRegistry(t *testing.T) {
 	reg := NewInvestorRegistry()
 	expiry := time.Now().Add(24 * time.Hour)
-	tok := reg.Issue("AssetA", "alice", 100, expiry)
+	tok, err := reg.Issue("AssetA", "alice", 100, expiry)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
 	if err := reg.Transfer(tok.ID, "bob"); err != nil {
 		t.Fatalf("transfer: %v", err)
 	}
@@ -55,13 +58,19 @@ func TestSYN2600InvestorRegistry(t *testing.T) {
 	if len(tokens) != 1 {
 		t.Fatalf("expected 1 token got %d", len(tokens))
 	}
+	if _, err := reg.Issue("", "", 0, time.Now()); err == nil {
+		t.Fatalf("expected validation error")
+	}
 }
 
 func TestSYN2800LifePolicyRegistry(t *testing.T) {
 	reg := NewLifePolicyRegistry()
 	start := time.Now()
 	end := start.Add(365 * 24 * time.Hour)
-	policy := reg.IssuePolicy("alice", "bob", 1000, 100, start, end)
+	policy, err := reg.IssuePolicy("alice", "bob", 1000, 100, start, end)
+	if err != nil {
+		t.Fatalf("issue policy: %v", err)
+	}
 	if err := reg.PayPremium(policy.PolicyID, 50); err != nil {
 		t.Fatalf("pay premium: %v", err)
 	}
@@ -76,13 +85,19 @@ func TestSYN2800LifePolicyRegistry(t *testing.T) {
 	if len(policies) != 1 {
 		t.Fatalf("expected 1 policy got %d", len(policies))
 	}
+	if _, err := reg.IssuePolicy("", "", 0, 0, end, start); err == nil {
+		t.Fatalf("expected validation error")
+	}
 }
 
 func TestSYN2900InsuranceRegistry(t *testing.T) {
 	reg := NewInsuranceRegistry()
 	start := time.Now()
 	end := start.Add(365 * 24 * time.Hour)
-	policy := reg.IssuePolicy("alice", "fire", 100, 1000, 10, 1000, start, end)
+	policy, err := reg.IssuePolicy("alice", "fire", 100, 1000, 10, 1000, start, end)
+	if err != nil {
+		t.Fatalf("issue policy: %v", err)
+	}
 	if _, err := reg.FileClaim(policy.PolicyID, "damage", 500); err != nil {
 		t.Fatalf("file claim: %v", err)
 	}
@@ -93,6 +108,9 @@ func TestSYN2900InsuranceRegistry(t *testing.T) {
 	policies := reg.ListPolicies()
 	if len(policies) != 1 {
 		t.Fatalf("expected 1 policy got %d", len(policies))
+	}
+	if _, err := reg.IssuePolicy("", "", 0, 0, 0, 0, end, start); err == nil {
+		t.Fatalf("expected validation error")
 	}
 }
 

--- a/synnergy_network_function_web.md
+++ b/synnergy_network_function_web.md
@@ -3,7 +3,9 @@
 This document provides a high-level function web for the Synnergy network, outlining major modules and their core functions. Stage 8 expands cross-chain registries and bridge managers with CLI access and gas‑priced opcodes. Stage 9 adds governance primitives, custodial nodes and cross-consensus network management. Stage 14 introduces a unified `internal/nodes` package with light, watchtower and logistics implementations. Stage 15 extends this package with forensic, geospatial, historical and holographic nodes for richer diagnostics and data distribution.
 Stage 17 standardises token contracts for CBDCs, pausable utility assets and
 gaming items, all backed by the thread-safe base token and accessible through
-the CLI.
+the CLI. Stage 18 adds investor share registries, insurance policies, forex
+pairs, fiat-pegged currencies, index funds, charity campaigns and legal document
+tokens with validation and CLI-driven deactivation.
 
 ## Diagram
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -51,6 +51,12 @@ digital currencies, pausable utility assets and game items. Each implementation
 embeds the concurrency‑safe base token and surfaces dedicated CLI commands for
 minting, transferring and querying balances.
 
+Stage 18 builds on this foundation with advanced financial instruments. New
+registries manage investor share tokens, life and general insurance policies,
+foreign‑exchange pairs, fiat‑pegged currencies, index funds, charity campaigns
+and legal document tokens. All contracts enforce input validation, support
+explicit deactivation and are accessible through dedicated CLI modules.
+
 ### Virtual Machine and Gas Accounting
 Smart contracts execute inside a dedicated virtual machine. Every protocol
 function is assigned a 24‑bit opcode and priced using a deterministic gas table.


### PR DESCRIPTION
## Summary
- validate inputs and support deactivation for SYN2600 investor, SYN2800 life, and SYN2900 insurance tokens
- expose new deactivate commands and error handling in corresponding CLI modules
- document Stage 18 advanced tokens across README, token guide, whitepaper, and function web

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8968ccc8483208489cf33ddf3b974