### PR TITLE
feat: enhance SYN1000 token with precise reserve accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 16 introduces a concurrency-safe token registry and base token with micro-benchmarks to track transfer throughput.
 - Stage 17 delivers standard token contracts including CBDC, pausable utility and gaming asset tokens. Each implementation is thread-safe and accessible via dedicated CLI modules.
 - Stage 18 expands the token library with investor share registries, life and general insurance policies, forex pairs, fiat‑pegged currencies, index funds, charity campaigns and legal document tokens, all validated and manageable through the CLI.
+- Stage 19 adds a reserve-backed stablecoin (`SYN1000`) with an index manager and high-precision, thread-safe reserve accounting accessible through dedicated CLI commands.
 
 ## Repository layout
 ```

--- a/cli/syn1000.go
+++ b/cli/syn1000.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/spf13/cobra"
 	"synnergy/internal/tokens"
 )
@@ -41,8 +43,11 @@ func init() {
 				fmt.Println("token not initialised")
 				return
 			}
-			var amt float64
-			fmt.Sscanf(args[1], "%f", &amt)
+			amt, ok := new(big.Rat).SetString(args[1])
+			if !ok {
+				fmt.Println("invalid amount")
+				return
+			}
 			syn1000.AddReserve(args[0], amt)
 			fmt.Println("reserve added")
 		},
@@ -58,8 +63,11 @@ func init() {
 				fmt.Println("token not initialised")
 				return
 			}
-			var price float64
-			fmt.Sscanf(args[1], "%f", &price)
+			price, ok := new(big.Rat).SetString(args[1])
+			if !ok {
+				fmt.Println("invalid price")
+				return
+			}
 			syn1000.SetReservePrice(args[0], price)
 			fmt.Println("price updated")
 		},
@@ -74,7 +82,7 @@ func init() {
 				fmt.Println("token not initialised")
 				return
 			}
-			fmt.Println(syn1000.TotalReserveValue())
+			fmt.Println(syn1000.TotalReserveValue().FloatString(2))
 		},
 	}
 	cmd.AddCommand(valueCmd)

--- a/cli/syn1000_index.go
+++ b/cli/syn1000_index.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/spf13/cobra"
 	"synnergy/internal/tokens"
 )
@@ -33,9 +35,12 @@ func init() {
 		Args:  cobra.ExactArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
 			var id uint64
-			var amt float64
 			fmt.Sscanf(args[0], "%d", &id)
-			fmt.Sscanf(args[2], "%f", &amt)
+			amt, ok := new(big.Rat).SetString(args[2])
+			if !ok {
+				fmt.Println("invalid amount")
+				return
+			}
 			if err := syn1000Index.AddReserve(tokens.TokenID(id), args[1], amt); err != nil {
 				fmt.Println("error:", err)
 				return
@@ -51,9 +56,12 @@ func init() {
 		Args:  cobra.ExactArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
 			var id uint64
-			var price float64
 			fmt.Sscanf(args[0], "%d", &id)
-			fmt.Sscanf(args[2], "%f", &price)
+			price, ok := new(big.Rat).SetString(args[2])
+			if !ok {
+				fmt.Println("invalid price")
+				return
+			}
 			if err := syn1000Index.SetReservePrice(tokens.TokenID(id), args[1], price); err != nil {
 				fmt.Println("error:", err)
 				return
@@ -75,7 +83,7 @@ func init() {
 				fmt.Println("error:", err)
 				return
 			}
-			fmt.Println(v)
+			fmt.Println(v.FloatString(2))
 		},
 	}
 	cmd.AddCommand(valueCmd)

--- a/docs/guides/cli_guide.md
+++ b/docs/guides/cli_guide.md
@@ -10437,7 +10437,7 @@ synnergy syn10 transfer <from> <to> <amt> [flags]
 
 ## synnergy syn1000
 
-SYN1000 stablecoin operations
+SYN1000 stablecoin operations. Amounts and prices must be provided as decimal strings to preserve precision.
 
 ### Options
 
@@ -10459,7 +10459,7 @@ SYN1000 stablecoin operations
 
 ## synnergy syn1000 add-reserve
 
-Add reserve asset
+Add reserve asset (amount as decimal string)
 
 ```
 synnergy syn1000 add-reserve <asset> <amount> [flags]
@@ -10538,7 +10538,7 @@ synnergy syn1000 mint <to> <amt> [flags]
 
 ## synnergy syn1000 set-price
 
-Set reserve price
+Set reserve price (decimal string)
 
 ```
 synnergy syn1000 set-price <asset> <price> [flags]
@@ -10614,7 +10614,7 @@ Manage multiple SYN1000 tokens
 
 ## synnergy syn1000index add-reserve
 
-Add reserve asset to token
+Add reserve asset to token (amount as decimal string)
 
 ```
 synnergy syn1000index add-reserve <id> <asset> <amount> [flags]
@@ -10653,7 +10653,7 @@ synnergy syn1000index create <name> <symbol> [flags]
 
 ## synnergy syn1000index set-price
 
-Set reserve price
+Set reserve price (decimal string)
 
 ```
 synnergy syn1000index set-price <id> <asset> <price> [flags]

--- a/docs/guides/opcode_and_gas_guide.md
+++ b/docs/guides/opcode_and_gas_guide.md
@@ -29,6 +29,8 @@ Complex logic can be decomposed into multiple small opcodes or combined into a b
 
 Gas prices are defined in [`gas_table.go`](gas_table.go).  Each opcode has a deterministic base cost reflecting CPU, storage and network impact.  From Stage 11 the table is populated at start-up by parsing [`gas_table_list.md`](../../gas_table_list.md), allowing operators to override prices without recompiling binaries.  Missing entries are charged `DefaultGasCost`.
 
+Stage 19 introduces additional opcodes for the reserve‑backed `SYN1000` stablecoin and its index manager. Gas costs for creating tokens, adjusting reserves and computing valuations are explicitly defined to ensure predictable execution fees.
+
 The VM charges gas **before** executing an opcode.  Dynamic portions – such as per‑word memory fees or refunds for resource release – are handled by the VM's gas meter.
 
 ```go

--- a/docs/guides/token_guide.md
+++ b/docs/guides/token_guide.md
@@ -76,7 +76,7 @@ how specialised assets can be modelled on top of the base abstractions:
 | `syn223_token.go` | Secure transfer token that enforces whitelist and blacklist rules. |
 | `syn300_token.go` | Governance token supporting delegation and on‑chain proposals. |
 | `syn845.go` | Debt token registry for recording loans and repayments. |
-| `syn1000.go` & `syn1000_index.go` | Reserve‑backed stablecoin and index for managing multiple instances. |
+| `syn1000.go` & `syn1000_index.go` | Thread‑safe reserve‑backed stablecoin with high‑precision accounting and an index for managing multiple instances. |
 | `syn1100.go` | Healthcare record storage with access control lists. |
 | `syn2369.go` | Virtual item registry for metaverse assets. |
 | `syn2500_token.go` | DAO membership registry with voting power metadata. |

--- a/gas_table_list.md
+++ b/gas_table_list.md
@@ -663,3 +663,13 @@
 | `core_regulatory_node_ApproveTransaction` | `8` |
 | `core_regulatory_node_FlagEntity` | `2` |
 | `core_regulatory_node_Logs` | `3` |
+| `internal_tokens_syn1000_NewSYN1000Token` | `5` |
+| `internal_tokens_syn1000_AddReserve` | `3` |
+| `internal_tokens_syn1000_SetReservePrice` | `3` |
+| `internal_tokens_syn1000_TotalReserveValue` | `2` |
+| `internal_tokens_syn1000_index_NewSYN1000Index` | `5` |
+| `internal_tokens_syn1000_index_Create` | `6` |
+| `internal_tokens_syn1000_index_Token` | `2` |
+| `internal_tokens_syn1000_index_AddReserve` | `3` |
+| `internal_tokens_syn1000_index_SetReservePrice` | `3` |
+| `internal_tokens_syn1000_index_TotalValue` | `2` |

--- a/internal/tokens/base_test.go
+++ b/internal/tokens/base_test.go
@@ -3,6 +3,7 @@ package tokens
 import (
 	"encoding/hex"
 	"errors"
+	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -60,15 +61,15 @@ func TestSYN10Info(t *testing.T) {
 func TestSYN1000ReserveValue(t *testing.T) {
 	idx := NewSYN1000Index()
 	id := idx.Create("Stable", "STBL", 2)
-	if err := idx.AddReserve(id, "USD", 100); err != nil {
+	if err := idx.AddReserve(id, "USD", big.NewRat(100, 1)); err != nil {
 		t.Fatalf("add reserve: %v", err)
 	}
-	if err := idx.SetReservePrice(id, "USD", 1.0); err != nil {
+	if err := idx.SetReservePrice(id, "USD", big.NewRat(1, 1)); err != nil {
 		t.Fatalf("set price: %v", err)
 	}
 	val, err := idx.TotalValue(id)
-	if err != nil || val != 100 {
-		t.Fatalf("unexpected value %f err %v", val, err)
+	if err != nil || val.Cmp(big.NewRat(100, 1)) != 0 {
+		t.Fatalf("unexpected value %s err %v", val.String(), err)
 	}
 }
 

--- a/internal/tokens/syn1000_index_test.go
+++ b/internal/tokens/syn1000_index_test.go
@@ -1,0 +1,28 @@
+package tokens
+
+import (
+	"math/big"
+	"testing"
+)
+
+// TestSYN1000Index verifies basic index operations and value calculation.
+func TestSYN1000Index(t *testing.T) {
+	idx := NewSYN1000Index()
+	id := idx.Create("Stable", "STB", 2)
+
+	if err := idx.AddReserve(id, "USD", big.NewRat(100, 1)); err != nil {
+		t.Fatalf("add reserve: %v", err)
+	}
+	if err := idx.SetReservePrice(id, "USD", big.NewRat(1, 1)); err != nil {
+		t.Fatalf("set price: %v", err)
+	}
+
+	v, err := idx.TotalValue(id)
+	if err != nil {
+		t.Fatalf("total value: %v", err)
+	}
+	want := big.NewRat(100, 1)
+	if v.Cmp(want) != 0 {
+		t.Fatalf("want %s got %s", want.String(), v.String())
+	}
+}

--- a/internal/tokens/syn1000_test.go
+++ b/internal/tokens/syn1000_test.go
@@ -1,0 +1,43 @@
+package tokens
+
+import (
+	"math/big"
+	"sync"
+	"testing"
+)
+
+// TestSYN1000TokenReserveValue verifies that reserve additions and price updates
+// are reflected in the calculated total value using high precision arithmetic.
+func TestSYN1000TokenReserveValue(t *testing.T) {
+	tok := NewSYN1000Token(1, "Stable", "STB", 2)
+	tok.AddReserve("USD", big.NewRat(100, 1))
+	tok.SetReservePrice("USD", big.NewRat(1, 1))
+	tok.AddReserve("EUR", big.NewRat(50, 1))
+	tok.SetReservePrice("EUR", big.NewRat(2, 1))
+
+	got := tok.TotalReserveValue()
+	want := big.NewRat(200, 1) // 100*1 + 50*2
+	if got.Cmp(want) != 0 {
+		t.Fatalf("want %s got %s", want.String(), got.String())
+	}
+}
+
+// TestSYN1000TokenConcurrent ensures concurrent reserve updates are safe.
+func TestSYN1000TokenConcurrent(t *testing.T) {
+	tok := NewSYN1000Token(1, "Stable", "STB", 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tok.AddReserve("USD", big.NewRat(1, 1))
+		}()
+	}
+	wg.Wait()
+	tok.SetReservePrice("USD", big.NewRat(1, 1))
+	got := tok.TotalReserveValue()
+	want := big.NewRat(10, 1)
+	if got.Cmp(want) != 0 {
+		t.Fatalf("want %s got %s", want.String(), got.String())
+	}
+}

--- a/synnergy_network_function_web.md
+++ b/synnergy_network_function_web.md
@@ -6,6 +6,7 @@ gaming items, all backed by the thread-safe base token and accessible through
 the CLI. Stage 18 adds investor share registries, insurance policies, forex
 pairs, fiat-pegged currencies, index funds, charity campaigns and legal document
 tokens with validation and CLI-driven deactivation.
+Stage 19 introduces the SYN1000 reserve-backed stablecoin and index manager with precise gas-priced opcodes and CLI integration.
 
 ## Diagram
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -57,6 +57,8 @@ foreign‑exchange pairs, fiat‑pegged currencies, index funds, charity campaig
 and legal document tokens. All contracts enforce input validation, support
 explicit deactivation and are accessible through dedicated CLI modules.
 
+Stage 19 introduces a reserve‑backed stablecoin (SYN1000) and an accompanying index manager. Both leverage high‑precision arithmetic and thread‑safe data structures to track asset backing and valuations across multiple instances.
+
 ### Virtual Machine and Gas Accounting
 Smart contracts execute inside a dedicated virtual machine. Every protocol
 function is assigned a 24‑bit opcode and priced using a deterministic gas table.


### PR DESCRIPTION
## Summary
- use high-precision rational numbers and mutexes for SYN1000 reserve management
- document decimal-based CLI usage and register gas costs for SYN1000 opcodes
- add tests and docs for reserve-backed stablecoin index

## Testing
- `go test ./internal/tokens -run SYN1000`


------
https://chatgpt.com/codex/tasks/task_e_68b8988d86148320a9f54b37de39a12c