### PR TITLE
feat: add gas table JSON snapshot and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 25 adds comprehensive node management. Full, light, mining, mobile,
   optimisation, staking, watchtower and warfare nodes expose JSON emitting CLI
   operations for integration with GUIs and automation.
+- Stage 26 enhances operational utilities. Gas table management now allows
+  runtime opcode price adjustments and JSON snapshots so dashboards and
+  governance tools can consume pricing data directly from the CLI.
 
 ## Repository layout
 ```

--- a/cli/gas_table.go
+++ b/cli/gas_table.go
@@ -29,16 +29,27 @@ func init() {
 		},
 	}
 
+	var jsonOut bool
 	snapCmd := &cobra.Command{
 		Use:   "snapshot",
 		Short: "Print current gas table snapshot",
 		Run: func(cmd *cobra.Command, args []string) {
+			if jsonOut {
+				data, err := core.GasTableSnapshotJSON()
+				if err != nil {
+					fmt.Println("error generating snapshot:", err)
+					return
+				}
+				fmt.Println(string(data))
+				return
+			}
 			snapshot := core.GasTableSnapshot()
 			for op, cost := range snapshot {
 				fmt.Printf("%v: %d\n", op, cost)
 			}
 		},
 	}
+	snapCmd.Flags().BoolVar(&jsonOut, "json", false, "output JSON")
 
 	gasCmd.AddCommand(setCmd)
 	gasCmd.AddCommand(snapCmd)

--- a/cli/gas_table_cli_test.go
+++ b/cli/gas_table_cli_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestGasSnapshotJSON ensures the snapshot command emits valid JSON and reflects
+// runtime updates made via the set subcommand.
+func TestGasSnapshotJSON(t *testing.T) {
+	if _, err := execCommand("gas", "set", "1", "5"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	out, err := execCommand("gas", "snapshot", "--json")
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	var m map[string]uint64
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(m) == 0 {
+		t.Fatalf("expected non-empty snapshot")
+	}
+}

--- a/core/gas_table.go
+++ b/core/gas_table.go
@@ -3,6 +3,8 @@ package core
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,6 +85,23 @@ func GasTableSnapshot() GasTable {
 		snapshot[op] = c
 	}
 	return snapshot
+}
+
+// GasTableSnapshotJSON serialises the current gas schedule to JSON.  Opcode keys
+// are rendered in hexadecimal ("0x000000") form so external tooling does not
+// need awareness of internal catalogue names.  The function never returns an
+// error; JSON marshaling on simple map types is deterministic.
+func GasTableSnapshotJSON() ([]byte, error) {
+	snap := GasTableSnapshot()
+	out := make(map[string]uint64, len(snap))
+	for op, cost := range snap {
+		out[fmt.Sprintf("0x%06X", op)] = cost
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 // GasCostByName returns the gas price for an exported function name. It

--- a/synnergy_network_function_web.md
+++ b/synnergy_network_function_web.md
@@ -22,6 +22,10 @@ Stage 25 finalises node operations. Full, light, mining, mobile, optimisation,
 staking, watchtower and warfare nodes offer JSON emitting commands allowing the
 function web and external dashboards to orchestrate infrastructure with defined
 gas costs.
+Stage 26 extends operational visibility with gas table controls. Operators can
+adjust opcode pricing on the fly and export the entire schedule as JSON,
+enabling governance portals and monitoring systems to consume pricing data
+directly from the CLI.
 
 ## Diagram
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -45,6 +45,10 @@ Stage 25 focuses on operational tooling. Node management commands for full,
 light, mining, mobile, optimisation, staking, watchtower and warfare roles now
 emit structured JSON and have explicit gas pricing so that enterprise dashboards
 can monitor and orchestrate infrastructure reliably.
+Stage 26 extends these tools with runtime gas table management. Operators can
+adjust opcode costs without recompiling the network and export the entire
+schedule as JSON, giving auditors and governance systems direct visibility into
+fee policies.
 
 ### Wallets and Network Monitoring
 Stage 12 introduces a hardened wallet with hex-encoded addressing and ECDSA signatures for transaction authorization.  Alongside the wallet, new warfare and watchtower node roles extend the network with logistics tracking and real-time fork detection.  These modules expose CLI endpoints and feed telemetry back into the consensus layer for improved operational awareness.


### PR DESCRIPTION
## Summary
- add `GasTableSnapshotJSON` helper for exporting gas schedules in machine-readable form
- extend `synnergy gas snapshot` with `--json` output support
- document runtime gas table management in README, whitepaper, and function web

## Testing
- `go test ./cli -run TestGasSnapshotJSON -count=1 -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8b0d365c48320b420ee6730f39981