### PR TITLE
Add deployment automation scripts and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 26 enhances operational utilities. Gas table management now allows
   runtime opcode price adjustments and JSON snapshots so dashboards and
   governance tools can consume pricing data directly from the CLI.
+- Stage 27 adds developer and testnet automation scripts, covering network bootstrapping, contract deployment, linting and test execution for streamlined workflows.
+- Stage 28 introduces release packaging, documentation generation, CI setup and ledger backup scripts for reproducible builds and disaster recovery.
 
 ## Repository layout
 ```

--- a/architectures/storage_architecture.md
+++ b/architectures/storage_architecture.md
@@ -15,4 +15,7 @@ Storage-related modules handle data operations, secure storage, and sandboxed en
 - cli/state_rw.go
 - cli/zero_trust_data_channels.go
 
+**Scripts**
+- scripts/backup_ledger.sh
+
 These modules provide robust data handling, ensuring integrity and isolation for contract and node storage requirements.

--- a/scripts/backup_ledger.sh
+++ b/scripts/backup_ledger.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") <ledger_dir> <backup_dir>
+Creates a timestamped tar.gz backup of the ledger directory.
+
+Arguments:
+  ledger_dir  Path to the ledger data directory.
+  backup_dir  Destination directory for backups.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 2 ]]; then
+  echo "Missing arguments" >&2
+  usage
+  exit 1
+fi
+
+LEDGER_DIR="$1"
+DEST_DIR="$2"
+
+if [[ ! -d "$LEDGER_DIR" ]]; then
+  echo "Ledger directory not found: $LEDGER_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+ARCHIVE="$DEST_DIR/ledger_backup_$TIMESTAMP.tar.gz"
+
+tar -C "$LEDGER_DIR" -czf "$ARCHIVE" .
+
+echo "Ledger backup created at $ARCHIVE"
+

--- a/scripts/ci_setup.sh
+++ b/scripts/ci_setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0")
+Prepares the repository for continuous integration by tidying modules,
+verifying dependencies, linting, testing and building binaries.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+cd "$ROOT_DIR"
+
+echo "Tidying modules..."
+go mod tidy
+
+echo "Verifying modules..."
+go mod verify
+
+echo "Linting source..."
+"$SCRIPT_DIR/lint.sh"
+
+echo "Running tests..."
+"$SCRIPT_DIR/run_tests.sh"
+
+echo "Building binaries..."
+"$SCRIPT_DIR/build_all.sh"
+
+echo "CI setup complete"
+

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0")
+Builds the project documentation using MkDocs.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+cd "$ROOT_DIR"
+
+if command -v mkdocs >/dev/null 2>&1; then
+  mkdocs build
+  echo "Documentation generated at site/"
+else
+  echo "mkdocs command not found" >&2
+  exit 1
+fi
+

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [version]
+Builds the synnergy binary and packages it with checksums for release.
+
+Arguments:
+  version  Optional version tag to embed in archive name.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+VERSION="${1:-latest}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+DIST_DIR="$ROOT_DIR/dist/$VERSION"
+BIN_NAME="synnergy"
+
+mkdir -p "$DIST_DIR"
+cd "$ROOT_DIR"
+
+echo "Building $BIN_NAME..."
+go build -o "$DIST_DIR/$BIN_NAME" ./cmd/synnergy
+
+echo "Packaging artifacts..."
+tar -C "$DIST_DIR" -czf "$DIST_DIR/${BIN_NAME}_${VERSION}.tar.gz" "$BIN_NAME"
+
+echo "Generating checksums..."
+sha256sum "$DIST_DIR/${BIN_NAME}_${VERSION}.tar.gz" > "$DIST_DIR/${BIN_NAME}_${VERSION}.tar.gz.sha256"
+
+echo "Release package created at $DIST_DIR"

--- a/scripts/scripts_test.go
+++ b/scripts/scripts_test.go
@@ -1,0 +1,34 @@
+package scripts_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func testScriptHelp(t *testing.T, script string) {
+	cmd := exec.Command("bash", script, "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s --help failed: %v\n%s", script, err, out)
+	}
+	if !strings.Contains(string(out), "Usage") {
+		t.Fatalf("expected usage output from %s, got: %s", script, out)
+	}
+}
+
+func TestPackageReleaseHelp(t *testing.T) {
+	testScriptHelp(t, "package_release.sh")
+}
+
+func TestGenerateDocsHelp(t *testing.T) {
+	testScriptHelp(t, "generate_docs.sh")
+}
+
+func TestCIScriptHelp(t *testing.T) {
+	testScriptHelp(t, "ci_setup.sh")
+}
+
+func TestBackupLedgerHelp(t *testing.T) {
+	testScriptHelp(t, "backup_ledger.sh")
+}

--- a/synnergy_network_function_web.md
+++ b/synnergy_network_function_web.md
@@ -26,6 +26,8 @@ Stage 26 extends operational visibility with gas table controls. Operators can
 adjust opcode pricing on the fly and export the entire schedule as JSON,
 enabling governance portals and monitoring systems to consume pricing data
 directly from the CLI.
+Stage 27 layers in automation scripts for devnets and testnets, contract deployment helpers and quality gates, letting dashboards orchestrate network lifecycles through the CLI.
+Stage 28 adds release packaging, documentation generation, CI preparation and ledger backup tooling so user interfaces can trigger builds, publish docs and safeguard chain data via the function web.
 
 ## Diagram
 

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -49,6 +49,8 @@ Stage 26 extends these tools with runtime gas table management. Operators can
 adjust opcode costs without recompiling the network and export the entire
 schedule as JSON, giving auditors and governance systems direct visibility into
 fee policies.
+Stage 27 introduces automation scripts for development and testing networks, including bootstrapping utilities, contract deployment helpers and code quality gates that streamline contributor workflows.
+Stage 28 adds release engineering scripts covering packaging, documentation generation, CI setup and ledger backups, delivering reproducible and auditable deployment processes.
 
 ### Wallets and Network Monitoring
 Stage 12 introduces a hardened wallet with hex-encoded addressing and ECDSA signatures for transaction authorization.  Alongside the wallet, new warfare and watchtower node roles extend the network with logistics tracking and real-time fork detection.  These modules expose CLI endpoints and feed telemetry back into the consensus layer for improved operational awareness.


### PR DESCRIPTION
## Summary
- add packaging, documentation generation, CI setup and ledger backup scripts
- document new deployment automation in README, whitepaper and function web
- expand storage architecture to reference ledger backup tooling

## Testing
- `go test ./scripts`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8b38f655883208fb526030d2e1150