### PR TITLE
Add smart contract language compatibility listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 28 introduces release packaging, documentation generation, CI setup and ledger backup scripts for reproducible builds and disaster recovery.
 - Stage 29 adds deployable smart contract templates for token faucets, storage markets, DAO governance, NFT minting and AI model marketplaces. These templates are accessible via CLI with gas-priced opcodes.
 - Stage 30 introduces utility smart contract modules including escrow payments, cross-chain bridges, multisig wallets and regulatory compliance contracts. Each template ships precompiled as WASM and can be deployed through the CLI and VM.
+- The virtual machine supports smart contracts compiled from WebAssembly, Go, JavaScript, Solidity, Rust, Python and Yul, ensuring opcode compatibility across ecosystems.
 
 ## Repository layout
 ```

--- a/contract_language_compatibility.go
+++ b/contract_language_compatibility.go
@@ -1,0 +1,28 @@
+package synnergy
+
+import "strings"
+
+// SupportedContractLanguages enumerates the smart contract languages that the
+// Synnergy virtual machine recognises. Contracts authored in these languages
+// can be compiled to bytecode compatible with the VM's opcode set.
+var SupportedContractLanguages = []string{
+	"wasm",
+	"golang",
+	"javascript",
+	"solidity",
+	"rust",
+	"python",
+	"yul",
+}
+
+// IsLanguageSupported reports whether the supplied language is recognised as
+// compatible with the VM. The check is case-insensitive.
+func IsLanguageSupported(lang string) bool {
+	lang = strings.ToLower(lang)
+	for _, l := range SupportedContractLanguages {
+		if l == lang {
+			return true
+		}
+	}
+	return false
+}

--- a/contract_language_compatibility_test.go
+++ b/contract_language_compatibility_test.go
@@ -1,0 +1,24 @@
+package synnergy
+
+import "testing"
+
+func TestIsLanguageSupported(t *testing.T) {
+	cases := []struct {
+		lang string
+		want bool
+	}{
+		{"wasm", true},
+		{"golang", true},
+		{"javascript", true},
+		{"solidity", true},
+		{"rust", true},
+		{"python", true},
+		{"yul", true},
+		{"haskell", false},
+	}
+	for _, c := range cases {
+		if got := IsLanguageSupported(c.lang); got != c.want {
+			t.Errorf("%s: expected %v got %v", c.lang, c.want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- document VM-supported smart contract languages
- expose and test `IsLanguageSupported` helper for contract language checks

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8b83eb9a48320b53bb72d1ac6ed6a