### PR TITLE
Add genesis block creation with Synnergy consensus

### DIFF
--- a/core/genesis_block.go
+++ b/core/genesis_block.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+        "errors"
+
+        ilog "synnergy/internal/log"
+)
+
+// GenesisStats contains summary information about the chain after genesis
+// block creation.
+type GenesisStats struct {
+        Height      uint64
+        Hash        string
+        Circulating uint64
+        Remaining   uint64
+        Weights     ConsensusWeights
+}
+
+// InitGenesis creates the genesis block using the node's Synnergy consensus.
+// It credits the creator wallet with the GenesisAllocation and mines the first
+// block. An error is returned if a block already exists.
+func (n *Node) InitGenesis(wallets GenesisWallets) (GenesisStats, *Block, error) {
+        if len(n.Blockchain) != 0 {
+                return GenesisStats{}, nil, errors.New("genesis already exists")
+        }
+        n.Ledger.Credit(wallets.CreatorWallet, GenesisAllocation)
+        sb := NewSubBlock(nil, wallets.Genesis)
+        block := NewBlock([]*SubBlock{sb}, "")
+        n.Consensus.MineBlock(block, 1)
+        n.Blockchain = append(n.Blockchain, block)
+        n.Ledger.AddBlock(block)
+        stats := GenesisStats{
+                Height:      1,
+                Hash:        block.Hash,
+                Circulating: CirculatingSupply(0),
+                Remaining:   RemainingSupply(0),
+                Weights:     n.Consensus.Weights,
+        }
+        ilog.Info("genesis_init", "hash", block.Hash, "circulating", stats.Circulating, "remaining", stats.Remaining)
+        return stats, block, nil
+}
+

--- a/core/genesis_block_test.go
+++ b/core/genesis_block_test.go
@@ -1,0 +1,32 @@
+package core
+
+import "testing"
+
+func TestInitGenesis(t *testing.T) {
+        ledger := NewLedger()
+        node := NewNode("n1", "addr", ledger)
+        wallets := DefaultGenesisWallets()
+        stats, block, err := node.InitGenesis(wallets)
+        if err != nil {
+                t.Fatalf("init genesis: %v", err)
+        }
+        if block == nil || block.Hash == "" {
+                t.Fatalf("expected block hash, got %v", block)
+        }
+        if h, _ := ledger.Head(); h != 1 {
+                t.Fatalf("expected ledger height 1, got %d", h)
+        }
+        if bal := ledger.GetBalance(wallets.CreatorWallet); bal != GenesisAllocation {
+                t.Fatalf("creator balance %d", bal)
+        }
+        if stats.Circulating != GenesisAllocation {
+                t.Fatalf("circulating %d", stats.Circulating)
+        }
+        if stats.Remaining != MaxSupply-GenesisAllocation {
+                t.Fatalf("remaining %d", stats.Remaining)
+        }
+        if _, _, err := node.InitGenesis(wallets); err == nil {
+                t.Fatalf("expected error on second init")
+        }
+}
+


### PR DESCRIPTION
## Summary
- implement `InitGenesis` to mine a genesis block using Synnergy consensus and allocate initial supply
- capture circulation and remaining supply stats via `GenesisStats`
- test genesis block initialization and repeat-init safeguards

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8b92e85308320bbf4e83289cb769d