### PR TITLE
Add Stage 33 AI Marketplace GUI

### DIFF
--- a/GUI/ai-marketplace/README.md
+++ b/GUI/ai-marketplace/README.md
@@ -1,0 +1,18 @@
+# Synnergy AI Marketplace
+
+A minimal TypeScript interface for deploying AI-enhanced contracts through the Synnergy CLI.
+
+## Usage
+
+```
+npm install
+npm start <wasm_file> <model_hash> <manifest> <gas_limit> <owner>
+```
+
+The marketplace shells out to `synnergy ai_contract deploy` and prints the resulting contract address. Ensure the `synnergy` binary is on your `PATH` and a node is running.
+
+## Testing
+
+```
+npm test
+```

--- a/GUI/ai-marketplace/package.json
+++ b/GUI/ai-marketplace/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "synnergy-ai-marketplace",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ts-node src/main.ts",
+    "test": "ts-node src/main.test.ts"
+  },
+  "dependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/GUI/ai-marketplace/src/main.test.ts
+++ b/GUI/ai-marketplace/src/main.test.ts
@@ -1,0 +1,6 @@
+import { parseDeploy } from './main';
+import assert from 'assert';
+
+const addr = parseDeploy('contract: 0xabc');
+assert.strictEqual(addr, '0xabc');
+console.log('parseDeploy test passed');

--- a/GUI/ai-marketplace/src/main.ts
+++ b/GUI/ai-marketplace/src/main.ts
@@ -1,0 +1,29 @@
+import { execSync } from 'child_process';
+
+export function parseDeploy(out: string): string {
+  return out.trim().split(/\s+/).pop() || '';
+}
+
+export function deploy(wasm: string, modelHash: string, manifest: string, gas: string, owner: string): string {
+  const cmd = `synnergy ai_contract deploy ${wasm} ${modelHash} ${manifest} ${gas} ${owner}`;
+  const out = execSync(cmd, { encoding: 'utf8' });
+  return parseDeploy(out);
+}
+
+async function main() {
+  const [, , wasm, modelHash, manifest, gas, owner] = process.argv;
+  if (!wasm || !modelHash || !manifest || !gas || !owner) {
+    console.error('usage: ts-node main.ts <wasm> <model_hash> <manifest> <gas_limit> <owner>');
+    process.exit(1);
+  }
+  try {
+    const addr = deploy(wasm, modelHash, manifest, gas, owner);
+    console.log(`contract address: ${addr}`);
+  } catch (err) {
+    console.error('deployment failed', err);
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/GUI/ai-marketplace/tsconfig.json
+++ b/GUI/ai-marketplace/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "strict": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 30 introduces utility smart contract modules including escrow payments, cross-chain bridges, multisig wallets and regulatory compliance contracts. Each template ships precompiled as WASM and can be deployed through the CLI and VM.
 - Stage 31 debuts a TypeScript GUI wallet that interacts with the CLI. Wallets are generated locally, encrypted with scrypt-derived AES-GCM keys and can query ledger balances through JSON emitting commands.
 - Stage 32 adds a CLI-backed Explorer GUI that displays chain height and block data.
+- Stage 33 introduces an AI Marketplace GUI that deploys AI-enhanced contracts through the CLI.
 - The virtual machine supports smart contracts compiled from WebAssembly, Go, JavaScript, Solidity, Rust, Python and Yul, ensuring opcode compatibility across ecosystems.
 
 ## Repository layout

--- a/Whitepaper_detailed/GUIs.md
+++ b/Whitepaper_detailed/GUIs.md
@@ -6,3 +6,5 @@ wallet GUI (Stage 31) generates encrypted wallets and queries balances.  Stage
 blockchain state such as chain height and block details.  These tools provide a
 foundation for richer dashboards and can be extended to visualise transactions,
 addresses and node health.
+
+Stage 33 adds an AI Marketplace GUI that deploys AI-enhanced contracts through the CLI. Users supply a WebAssembly module, model hash, manifest and gas limit, and the interface returns the on-chain contract address. This marketplace demonstrates how advanced contract workflows can be wrapped in thin, CLI-driven front ends.

--- a/Whitepaper_detailed/architecture/README.md
+++ b/Whitepaper_detailed/architecture/README.md
@@ -15,5 +15,9 @@ This directory contains architecture overviews for major module groups. Each fil
 11. [Compliance and Regulatory](compliance_architecture.md)
 12. [Monitoring and Logging](monitoring_logging_architecture.md)
 13. [Specialized Features](specialized_architecture.md)
+14. GUI Modules
+   - [Wallet](wallet_architecture.md)
+   - [Explorer](explorer_architecture.md)
+   - [AI Marketplace](ai_marketplace_architecture.md)
 
-There are **13** distinct module groups.
+There are **14** distinct module groups.

--- a/Whitepaper_detailed/architecture/ai_marketplace_architecture.md
+++ b/Whitepaper_detailed/architecture/ai_marketplace_architecture.md
@@ -1,0 +1,3 @@
+# AI Marketplace Architecture
+
+The AI Marketplace GUI is a thin TypeScript layer that invokes the `synnergy ai_contract deploy` command. Users provide a WebAssembly module, model hash, manifest and gas limit; the GUI executes the CLI and parses the returned contract address. The interface avoids key management and relies on the CLI for virtual machine, consensus and wallet integration, allowing AI-enhanced contracts to be deployed from a web context with minimal surface area.


### PR DESCRIPTION
## Summary
- introduce TypeScript AI Marketplace GUI that deploys AI-enhanced contracts via the CLI
- document AI marketplace in README, whitepaper GUI section, and new architecture notes
- outline GUI modules in architecture index for easier navigation

## Testing
- `npm install` (GUI/ai-marketplace)
- `npm test` (GUI/ai-marketplace)
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8c7a8ba388320836ee2ddbd1e2428