### PR TITLE
Add wallet server backend

### DIFF
--- a/walletserver/README.md
+++ b/walletserver/README.md
@@ -1,0 +1,28 @@
+# Wallet Server
+
+The wallet server exposes a minimal HTTP interface for generating
+wallets used by the Synnergy network. It provides endpoints for
+health checks and wallet creation and is intended to be consumed by
+CLI tools and future GUI applications.
+
+## Building and Running
+
+```bash
+go run ./walletserver
+```
+
+By default the server listens on `:8080`.
+
+## API
+
+### `GET /health`
+Returns `{ "status": "ok" }` when the service is running.
+
+### `POST /wallet/new`
+Generates a new wallet and responds with a JSON object containing the
+wallet address.
+
+```json
+{ "address": "<hex address>" }
+```
+

--- a/walletserver/handlers.go
+++ b/walletserver/handlers.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"synnergy/core"
+	"synnergy/internal/log"
+)
+
+type server struct{}
+
+func newServer() *server { return &server{} }
+
+func (s *server) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *server) newWalletHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	wallet, err := core.NewWallet()
+	if err != nil {
+		log.Error("wallet creation failed", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"address": wallet.Address})
+}

--- a/walletserver/handlers_test.go
+++ b/walletserver/handlers_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewWalletHandler(t *testing.T) {
+	srv := newServer()
+	req := httptest.NewRequest(http.MethodPost, "/wallet/new", nil)
+	w := httptest.NewRecorder()
+	srv.newWalletHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", w.Code)
+	}
+	var resp struct{ Address string }
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Address == "" {
+		t.Fatal("address empty")
+	}
+}
+
+func TestHealthHandler(t *testing.T) {
+	srv := newServer()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	srv.healthHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", w.Code)
+	}
+}

--- a/walletserver/main.go
+++ b/walletserver/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"synnergy/internal/log"
+)
+
+func main() {
+	srv := newServer()
+	http.HandleFunc("/health", srv.healthHandler)
+	http.HandleFunc("/wallet/new", srv.newWalletHandler)
+
+	addr := ":8080"
+	log.Info("wallet server listening", "addr", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Error("server shutdown", "err", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add wallet server with health and wallet creation endpoints
- document server usage and API
- include unit tests for wallet handlers

## Testing
- `go test ./walletserver`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9e8ad4c8320838e370d0f6dc275