### PR TITLE
Add end-to-end network harness test and docs for Stage 46

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 42 adds CLI integration tests validating command wiring.
 - Stage 43 provides GUI wallet integration tests ensuring end-to-end flows.
 - Stage 44 ships smart contract tests for the token faucet template via the CLI and VM.
+- Stage 45 adds script tests validating automated contract deployment workflows.
+- Stage 46 introduces an end-to-end network harness to exercise node, wallet and CLI interoperability.
 - The virtual machine supports smart contracts compiled from WebAssembly, Go, JavaScript, Solidity, Rust, Python and Yul, ensuring opcode compatibility across ecosystems.
 
 ## Repository layout

--- a/Whitepaper_detailed/How to use the CLI.md
+++ b/Whitepaper_detailed/How to use the CLI.md
@@ -16,3 +16,7 @@ synnergy liquidity_views info TOKENA-TOKENB
 ```
 
 Most commands accept the `--json` flag to produce machine readable output for GUIs.
+
+For comprehensive regression coverage the Stage 46 network harness exercises
+CLI commands against live wallet services and in-memory nodes, ensuring end-to-end
+flows operate consistently across releases.

--- a/Whitepaper_detailed/Network.md
+++ b/Whitepaper_detailed/Network.md
@@ -1,3 +1,8 @@
 # Network
 
-This is a placeholder for Network.
+The Synnergy network is composed of heterogeneous nodes coordinated through a
+gas-aware consensus layer.  Stage 46 introduces an end-to-end network harness
+used during development to automatically spin up wallet services and in-memory
+nodes, broadcast transactions and assert propagation.  The harness provides a
+repeatable way to validate fault tolerance, address handling and gas
+accounting across the virtual machine and CLI interfaces.

--- a/Whitepaper_detailed/Opcodes and gas.md
+++ b/Whitepaper_detailed/Opcodes and gas.md
@@ -3,3 +3,7 @@
 Stage 39 introduces opcodes for querying liquidity pools. `Liquidity_Pool`
 returns a single pool view while `Liquidity_Pools` lists all pools. Each opcode
 has a default gas cost of 1 as recorded in `gas_table_list.md`.
+
+To guard against regressions, the Stage 46 network harness captures a JSON
+snapshot of the gas table during end-to-end tests so that opcode pricing can be
+validated by external dashboards and wallets.

--- a/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -52,6 +52,9 @@ Stage 38 introduces a token creation tool GUI that generates token contracts thr
 Stage 39 adds a DEX Screener GUI that leverages `liquidity_views` commands so interfaces can stream pool reserves and fees.
 Stage 40 introduces administrative dashboards for authority node indexing and cross-chain management, exposing node and bridge status through CLI-driven views.
 Stage 44 adds a smart contract test harness exercising the token faucet template through the CLI, ensuring contract modules function reliably across the function web.
+Stage 46 introduces an automated network harness that assembles wallet services
+and in-memory nodes to verify end-to-end transaction propagation and gas
+accounting from the CLI through the consensus layer.
 
 ## Diagram
 

--- a/tests/e2e/network_harness_test.go
+++ b/tests/e2e/network_harness_test.go
@@ -1,0 +1,137 @@
+package tests
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	synn "synnergy"
+	"synnergy/cli"
+	"synnergy/core"
+)
+
+// execCLI executes the Synnergy CLI command and returns combined output.
+func execCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := cli.RootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	cmd.SetArgs(args)
+	_, err := cmd.ExecuteC()
+	cmd.SetArgs([]string{})
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	r.Close()
+	return strings.TrimSpace(buf.String() + string(out)), err
+}
+
+// TestNetworkHarness spins up core components and exercises a full flow
+// from wallet creation through transaction broadcast, demonstrating
+// interoperability between CLI, wallet server and in-memory nodes.
+func TestNetworkHarness(t *testing.T) {
+	synn.LoadGasTable()
+
+	// Start wallet server in a subprocess so HTTP endpoints are available
+	srv := exec.Command("go", "run", "./walletserver")
+	srv.Dir = ".."
+	if err := srv.Start(); err != nil {
+		t.Skipf("start wallet server: %v", err)
+	}
+	defer srv.Process.Kill()
+
+	// Wait for wallet server health endpoint
+	for i := 0; i < 20; i++ {
+		time.Sleep(200 * time.Millisecond)
+		resp, err := http.Get("http://localhost:8080/health")
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		if i == 19 {
+			t.Skipf("wallet server not responding: %v", err)
+		}
+	}
+
+	// Create a wallet via HTTP as GUI would
+	resp, err := http.Post("http://localhost:8080/wallet/new", "application/json", nil)
+	if err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+	var data struct{ Address string }
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if data.Address == "" {
+		t.Fatal("empty address returned")
+	}
+
+	// Use CLI to validate the wallet address
+	if out, err := execCLI(t, "address", "parse", data.Address); err != nil || strings.TrimPrefix(out, "0x") != strings.TrimPrefix(data.Address, "0x") {
+		t.Fatalf("cli address parse failed: %v %s", err, out)
+	}
+
+	// Build an in-memory network with biometric authentication
+	svc := core.NewBiometricService()
+	network := core.NewNetwork(svc)
+	n1 := core.NewNode("n1", "addr1", core.NewLedger())
+	n2 := core.NewNode("n2", "addr2", core.NewLedger())
+	network.AddNode(n1)
+	network.AddNode(n2)
+	n1.Ledger.Credit(data.Address, 100)
+	n2.Ledger.Credit(data.Address, 100)
+
+	// Enrol biometric data for the new wallet
+	bio := []byte("finger")
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	svc.Enroll(data.Address, bio, &key.PublicKey)
+	h := sha256.Sum256(bio)
+	sig, err := ecdsa.SignASN1(rand.Reader, key, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	// Broadcast a simple transaction through the network
+	tx := core.NewTransaction(data.Address, "recipient", 1, 1, 1)
+	if err := network.Broadcast(tx, data.Address, bio, sig); err != nil {
+		t.Fatalf("broadcast failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if len(n1.Mempool) != 1 || len(n2.Mempool) != 1 {
+		t.Fatalf("transaction not received by all nodes")
+	}
+
+	// Ensure gas snapshot CLI command returns data
+	out, err := execCLI(t, "gas", "snapshot", "--json")
+	if err != nil {
+		t.Fatalf("gas snapshot failed: %v", err)
+	}
+	var m map[string]uint64
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(m) == 0 {
+		t.Fatalf("expected non-empty gas snapshot")
+	}
+}


### PR DESCRIPTION
## Summary
- add e2e network harness test exercising wallet server, nodes, CLI and gas snapshot
- document Stage 46 in README and whitepaper guides

## Testing
- `go test ./tests/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b8e09d27608320b494a7a4211d7a67