### PR TITLE
Add Kubernetes deployment manifests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 45 adds script tests validating automated contract deployment workflows.
 - Stage 46 introduces an end-to-end network harness to exercise node, wallet and CLI interoperability.
 - Stage 47 provides Dockerfiles and a compose configuration for containerised nodes and the wallet server, enabling reproducible deployments.
+- Stage 48 adds Kubernetes manifests for the node and wallet server, allowing fault-tolerant cluster deployments via `kubectl`.
 - The virtual machine supports smart contracts compiled from WebAssembly, Go, JavaScript, Solidity, Rust, Python and Yul, ensuring opcode compatibility across ecosystems.
 
 ## Repository layout

--- a/Whitepaper_detailed/architecture/kubernetes_architecture.md
+++ b/Whitepaper_detailed/architecture/kubernetes_architecture.md
@@ -1,0 +1,16 @@
+# Kubernetes Architecture
+
+The Synnergy network can be deployed on Kubernetes to provide automated
+scaling, self‑healing and declarative configuration.  The manifests in
+`deploy/k8s/` define two core components:
+
+- **Node Deployment** – Runs replicated validator or full nodes. Each pod
+  exposes P2P and RPC ports and uses liveness/readiness probes so failed
+  instances are replaced automatically.
+- **Wallet Server Deployment** – Hosts the HTTP wallet API behind a
+  `ClusterIP` service. Probes and resource quotas ensure responsive
+  behaviour under load.
+
+Configuration is supplied via ConfigMaps and mounted into the containers.
+Operators can extend the manifests with ingress controllers, persistent
+storage or PodDisruptionBudgets to satisfy their reliability targets.

--- a/Whitepaper_detailed/guide/cli_guide.md
+++ b/Whitepaper_detailed/guide/cli_guide.md
@@ -21102,3 +21102,15 @@ go test ./tests/contracts
 ```
 
 to validate the token faucet template and future contract modules.
+
+## Kubernetes deployment
+Stage 48 adds manifests under `deploy/k8s/` for running the node and wallet
+server inside a Kubernetes cluster. Apply them with `kubectl`:
+
+```bash
+kubectl apply -f deploy/k8s/node.yaml
+kubectl apply -f deploy/k8s/wallet.yaml
+```
+
+These manifests include health probes and resource limits so clusters can
+maintain availability automatically.

--- a/Whitepaper_detailed/guide/opcode_and_gas_guide.md
+++ b/Whitepaper_detailed/guide/opcode_and_gas_guide.md
@@ -2905,3 +2905,9 @@ Operations exposed by the Stage 34 marketplace GUI.
 ### Contract Test Harness
 
 Stage 44 adds regression tests that deploy the `token_faucet` template via the CLI and VM. These tests confirm opcode resolution and gas prices for contract templates remain stable over time.
+
+### Kubernetes deployment
+Stage 48 introduces Kubernetes manifests for running nodes and the wallet
+server. The orchestration layer does not alter opcode semantics or gas
+pricing but ensures resources are isolated so gas accounting remains
+predictable across replicas.

--- a/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -205,5 +205,11 @@ graph TD
 - **Network** services provide message propagation and peer discovery feeding
   transactions into the consensus workflow.
 
+## Kubernetes deployment
+Stage 48 introduces manifests for orchestrating the node and wallet server on
+Kubernetes. Deploying these components with `kubectl` preserves all module
+relationships illustrated above while adding automated restarts and
+scalability for the web-facing services.
+
 This visualization can be rendered using any Mermaid-compatible Markdown viewer.
 

--- a/Whitepaper_detailed/guide/token_guide.md
+++ b/Whitepaper_detailed/guide/token_guide.md
@@ -156,6 +156,12 @@ rights alongside registered financial institutions.
 
 Stage 44 introduces contract-level tests for the token faucet template deployed via the CLI and VM, providing a blueprint for verifying future token modules.
 
+## Kubernetes deployment
+Tokens interact with network services regardless of the execution
+environment. When running nodes on Kubernetes using the manifests in
+`deploy/k8s/`, token transactions and registry operations are available
+through the wallet server and CLI just as in bare‑metal setups.
+
 ## Testing
 
 Unit tests for the token package can be executed with:

--- a/Whitepaper_detailed/whitepaper.md
+++ b/Whitepaper_detailed/whitepaper.md
@@ -219,6 +219,9 @@ Scripts such as `devnet_start.sh` and `testnet_start.sh` help launch local or
 multi‑node networks, while the `docker/` directory provides multi-stage
 Dockerfiles and a compose setup for running the node and wallet server
 in isolated containers for rapid deployment.
+Stage 48 supplies Kubernetes manifests in `deploy/k8s/` so clusters can
+orchestrate replicated nodes and the wallet server with health probes and
+resource quotas for enterprise deployments.
 
 ## Roadmap
 Development is guided by a staged plan documented in `AGENTS.md`. Early stages

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,18 @@
+# Kubernetes Manifests
+
+This directory contains example Kubernetes manifests for deploying Synnergy components.
+
+- `node.yaml` defines a `Deployment` and `Service` for a replicated Synnergy node.
+- `wallet.yaml` provides a `Deployment` and `Service` for the wallet server.
+
+Both manifests include resource requests/limits and HTTP health probes for
+fault‑tolerant operation. Apply them with `kubectl`:
+
+```bash
+kubectl apply -f deploy/k8s/node.yaml
+kubectl apply -f deploy/k8s/wallet.yaml
+```
+
+Configuration is expected to be provided via ConfigMaps named
+`syn-node-config` and `syn-wallet-config` respectively. Adjust images and
+ports as needed for your environment.

--- a/deploy/k8s/node.yaml
+++ b/deploy/k8s/node.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synnergy-node
+  labels:
+    app: synnergy-node
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: synnergy-node
+  template:
+    metadata:
+      labels:
+        app: synnergy-node
+    spec:
+      containers:
+      - name: node
+        image: synnergy/node:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 30303
+          name: p2p
+        - containerPort: 8080
+          name: rpc
+        env:
+        - name: SYN_CONFIG
+          value: /etc/synnergy/config.yaml
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        volumeMounts:
+        - name: config
+          mountPath: /etc/synnergy
+      volumes:
+      - name: config
+        configMap:
+          name: syn-node-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: synnergy-node
+  labels:
+    app: synnergy-node
+spec:
+  selector:
+    app: synnergy-node
+  ports:
+  - name: p2p
+    port: 30303
+    targetPort: 30303
+  - name: rpc
+    port: 8080
+    targetPort: 8080

--- a/deploy/k8s/wallet.yaml
+++ b/deploy/k8s/wallet.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synnergy-wallet
+  labels:
+    app: synnergy-wallet
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: synnergy-wallet
+  template:
+    metadata:
+      labels:
+        app: synnergy-wallet
+    spec:
+      containers:
+      - name: wallet
+        image: synnergy/walletserver:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8081
+          name: http
+        env:
+        - name: SYN_CONFIG
+          value: /etc/synnergy/config.yaml
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8081
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        volumeMounts:
+        - name: config
+          mountPath: /etc/synnergy
+      volumes:
+      - name: config
+        configMap:
+          name: syn-wallet-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: synnergy-wallet
+  labels:
+    app: synnergy-wallet
+spec:
+  selector:
+    app: synnergy-wallet
+  ports:
+  - name: http
+    port: 8081
+    targetPort: 8081
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add Kubernetes manifests for Synnergy node and wallet server
- document Kubernetes architecture and update guides to reference cluster deployment
- mention Kubernetes support in README and whitepaper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3a654ec8320ab2d4a4f1f4c1c82