### PR TITLE
Stage50 infrastructure automation with Terraform and Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ All guides and architecture decision records are located under the `docs/` direc
 - Stage 47 provides Dockerfiles and a compose configuration for containerised nodes and the wallet server, enabling reproducible deployments.
 - Stage 48 adds Kubernetes manifests for the node and wallet server, allowing fault-tolerant cluster deployments via `kubectl`.
 - Stage 49 introduces a Helm chart for deploying Synnergy components with opinionated defaults, enabling reproducible cluster deployments via `helm install`.
+- Stage 50 introduces Terraform and Ansible automation for provisioning infrastructure and configuring nodes with fault-tolerant defaults.
 - The virtual machine supports smart contracts compiled from WebAssembly, Go, JavaScript, Solidity, Rust, Python and Yul, ensuring opcode compatibility across ecosystems.
 
 ## Repository layout
@@ -125,6 +126,15 @@ docker compose -f docker/docker-compose.yml up --build
 To deploy Synnergy components with Helm, use the provided chart:
 ```
 helm install synnergy deploy/helm/synnergy
+```
+
+To provision infrastructure with Terraform and configure nodes with Ansible:
+```
+cd deploy/terraform
+terraform init
+terraform apply -var 'ami_id=ami-123456'
+
+ansible-playbook -i <inventory> ../ansible/playbook.yml
 ```
 
 ## Testing and security checks

--- a/Whitepaper_detailed/How to use the CLI.md
+++ b/Whitepaper_detailed/How to use the CLI.md
@@ -20,3 +20,12 @@ Most commands accept the `--json` flag to produce machine readable output for GU
 For comprehensive regression coverage the Stage 46 network harness exercises
 CLI commands against live wallet services and in-memory nodes, ensuring end-to-end
 flows operate consistently across releases.
+## Infrastructure Automation
+Stage 50 introduces Terraform and Ansible support for deploying nodes:
+```bash
+cd deploy/terraform
+terraform init
+terraform apply -var 'ami_id=ami-123456'
+
+ansible-playbook -i inventory ../ansible/playbook.yml
+```

--- a/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -210,6 +210,7 @@ Stage 48 introduces manifests for orchestrating the node and wallet server on
 Kubernetes. Deploying these components with `kubectl` preserves all module
 relationships illustrated above while adding automated restarts and
 scalability for the web-facing services.
+Stage 50 adds Terraform and Ansible automation for provisioning infrastructure and applying configuration, allowing dashboards and the CLI to launch fault-tolerant networks through the function web.
 
 This visualization can be rendered using any Mermaid-compatible Markdown viewer.
 

--- a/Whitepaper_detailed/whitepaper.md
+++ b/Whitepaper_detailed/whitepaper.md
@@ -222,6 +222,7 @@ in isolated containers for rapid deployment.
 Stage 48 supplies Kubernetes manifests in `deploy/k8s/` so clusters can
 orchestrate replicated nodes and the wallet server with health probes and
 resource quotas for enterprise deployments.
+Stage 50 adds Terraform and Ansible automation under `deploy/` to provision cloud infrastructure and configure nodes with Infrastructure as Code, enabling repeatable fault-tolerant deployments.
 
 ## Roadmap
 Development is guided by a staged plan documented in `AGENTS.md`. Early stages

--- a/deploy/ansible/playbook.yml
+++ b/deploy/ansible/playbook.yml
@@ -1,0 +1,45 @@
+---
+- name: Configure Synnergy nodes
+  hosts: nodes
+  become: true
+  vars:
+    synnergy_bin: /usr/local/bin/synnergy
+    network_config: /etc/synnergy/config.yml
+  tasks:
+    - name: Install required packages
+      apt:
+        name:
+          - git
+          - golang
+        update_cache: yes
+
+    - name: Create synnergy user
+      user:
+        name: synnergy
+        system: yes
+        create_home: no
+
+    - name: Upload binary
+      copy:
+        src: "{{ synnergy_bin }}"
+        dest: "/usr/local/bin/synnergy"
+        mode: '0755'
+
+    - name: Deploy configuration
+      template:
+        src: templates/config.yml.j2
+        dest: "{{ network_config }}"
+        mode: '0644'
+      notify: restart synnergy
+
+    - name: Enable and start service
+      systemd:
+        name: synnergy
+        state: started
+        enabled: yes
+
+  handlers:
+    - name: restart synnergy
+      systemd:
+        name: synnergy
+        state: restarted

--- a/deploy/terraform/.terraform.lock.hcl
+++ b/deploy/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,104 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  description = "AWS region to deploy Synnergy Network infrastructure."
+  type        = string
+  default     = "us-east-1"
+}
+
+# Base networking
+resource "aws_vpc" "synnergy" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "synnergy-vpc"
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.synnergy.id
+  cidr_block              = cidrsubnet(aws_vpc.synnergy.cidr_block, 8, count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "synnergy-public-${count.index}"
+  }
+}
+
+# Security group for node communication
+resource "aws_security_group" "node" {
+  name        = "synnergy-node-sg"
+  description = "Security group for Synnergy nodes"
+  vpc_id      = aws_vpc.synnergy.id
+
+  ingress {
+    description = "P2P communication"
+    from_port   = 30303
+    to_port     = 30303
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Launch template for nodes. User data will bootstrap ansible.
+resource "aws_launch_template" "node" {
+  name_prefix   = "synnergy-node-"
+  image_id      = var.ami_id
+  instance_type = "t3.medium"
+
+  user_data = base64encode(<<-EOT
+    #!/bin/bash
+    apt-get update && apt-get install -y python3
+    echo "$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)" >> /tmp/node_ip
+  EOT
+  )
+}
+
+# Auto scaling group for fault-tolerant nodes
+resource "aws_autoscaling_group" "nodes" {
+  name                = "synnergy-nodes"
+  max_size            = 3
+  min_size            = 1
+  desired_capacity    = 1
+  vpc_zone_identifier = aws_subnet.public[*].id
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = "$Latest"
+  }
+  tag {
+    key                 = "Name"
+    value               = "synnergy-node"
+    propagate_at_launch = true
+  }
+}
+
+variable "ami_id" {
+  description = "AMI ID for node instances"
+  type        = string
+}
+
+output "asg_name" {
+  description = "Name of the autoscaling group hosting Synnergy nodes."
+  value       = aws_autoscaling_group.nodes.name
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration for fault-tolerant Synnergy node deployment
- introduce Ansible playbook to configure and run nodes
- document infrastructure automation across README and whitepaper guides

## Testing
- `terraform fmt deploy/terraform/main.tf`
- `terraform -chdir=deploy/terraform init -backend=false`
- `terraform -chdir=deploy/terraform validate`
- `ansible-playbook --syntax-check deploy/ansible/playbook.yml`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8e61700e08320bcd85220e8f3f7b1