### PR TITLE
Add financial price prediction models and docs

### DIFF
--- a/docs/financial_models.md
+++ b/docs/financial_models.md
@@ -1,0 +1,25 @@
+# Financial Modelling for Synthron Coin
+
+This document outlines common algorithms for forecasting the price of the Synthron coin and provides guidance on implementing predictions within the Synnergy blockchain.
+
+## Algorithms
+
+- **Moving Average**: Smooths short‑term fluctuations and projects future prices using the average of the last *N* observations.
+- **Linear Regression**: Fits a straight line to historical price data and extrapolates into the future.
+- **Autoregressive (AR) Models**: Predict future values based on previous values in the series. The provided code includes an AR(1) example.
+- **ARIMA**: Combines autoregression, differencing, and moving averages. Suitable for non‑stationary series.
+- **LSTM Neural Networks**: Recurrent neural networks capable of capturing complex temporal dynamics.
+- **Monte Carlo Simulation**: Uses random sampling to simulate possible future price paths and derive probabilistic forecasts.
+
+## Running Forecasts
+
+The package `financial_prediction.go` provides simple implementations of moving average, linear regression, and AR(1) models. Example usage:
+
+```go
+prices := []float64{10, 12, 14, 16, 18}
+model := MovingAverageModel{Window: 3}
+forecast, _ := model.Forecast(prices, 6) // 6‑month forecast
+```
+
+To integrate forecasts on-chain, store historical price data in a smart contract or oracle. Nodes can run the forecasting models off-chain and submit results back to the blockchain for transparency and further processing.
+

--- a/financial_prediction.go
+++ b/financial_prediction.go
@@ -1,0 +1,108 @@
+package synnergy
+
+import (
+	"errors"
+)
+
+// PriceModel defines interface for forecasting future prices.
+type PriceModel interface {
+	Forecast(data []float64, months int) ([]float64, error)
+}
+
+// MovingAverageModel predicts future prices using simple moving average.
+type MovingAverageModel struct {
+	Window int
+}
+
+// Forecast generates predictions for the next `months` months based on a moving average.
+func (m MovingAverageModel) Forecast(data []float64, months int) ([]float64, error) {
+	if m.Window <= 0 {
+		return nil, errors.New("window must be positive")
+	}
+	if len(data) < m.Window {
+		return nil, errors.New("not enough data for the specified window")
+	}
+	result := make([]float64, months)
+	series := append([]float64{}, data...)
+	for i := 0; i < months; i++ {
+		sum := 0.0
+		for j := len(series) - m.Window; j < len(series); j++ {
+			sum += series[j]
+		}
+		next := sum / float64(m.Window)
+		result[i] = next
+		series = append(series, next)
+	}
+	return result, nil
+}
+
+// LinearRegressionModel predicts prices by fitting a line to historical data
+// and extrapolating into the future. It uses ordinary least squares.
+type LinearRegressionModel struct{}
+
+// Forecast returns linear regression predictions for the next `months` months.
+func (LinearRegressionModel) Forecast(data []float64, months int) ([]float64, error) {
+	if len(data) == 0 {
+		return nil, errors.New("no data provided")
+	}
+	n := float64(len(data))
+	var sumX, sumY, sumXY, sumX2 float64
+	for i, y := range data {
+		x := float64(i)
+		sumX += x
+		sumY += y
+		sumXY += x * y
+		sumX2 += x * x
+	}
+	denom := n*sumX2 - sumX*sumX
+	if denom == 0 {
+		return nil, errors.New("cannot compute regression")
+	}
+	b := (n*sumXY - sumX*sumY) / denom
+	a := (sumY - b*sumX) / n
+	result := make([]float64, months)
+	for i := 0; i < months; i++ {
+		x := float64(len(data) + i)
+		result[i] = a + b*x
+	}
+	return result, nil
+}
+
+// AR1Model performs a simple autoregressive forecasting of order 1.
+// It estimates the coefficient from data and projects future values.
+type AR1Model struct{}
+
+// Forecast predicts future prices using AR(1) model.
+func (AR1Model) Forecast(data []float64, months int) ([]float64, error) {
+	if len(data) < 2 {
+		return nil, errors.New("need at least two data points")
+	}
+	var sumXX, sumXY float64
+	for i := 1; i < len(data); i++ {
+		x := data[i-1]
+		y := data[i]
+		sumXX += x * x
+		sumXY += x * y
+	}
+	if sumXX == 0 {
+		return nil, errors.New("zero variance in data")
+	}
+	phi := sumXY / sumXX
+	last := data[len(data)-1]
+	result := make([]float64, months)
+	for i := 0; i < months; i++ {
+		next := phi * last
+		result[i] = next
+		last = next
+	}
+	return result, nil
+}
+
+// ForecastSeries selects a model and returns predictions for `months` months.
+// Passing a nil model defaults to a MovingAverageModel with window 3.
+func ForecastSeries(model PriceModel, data []float64, months int) ([]float64, error) {
+	if model == nil {
+		model = MovingAverageModel{Window: 3}
+	}
+	return model.Forecast(data, months)
+}

--- a/financial_prediction_test.go
+++ b/financial_prediction_test.go
@@ -1,0 +1,65 @@
+package synnergy
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMovingAverageModel(t *testing.T) {
+	model := MovingAverageModel{Window: 3}
+	data := []float64{10, 12, 14, 16, 18}
+	preds, err := model.Forecast(data, 2)
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	if math.Abs(preds[0]-16) > 1e-6 {
+		t.Errorf("expected first prediction 16, got %v", preds[0])
+	}
+	if math.Abs(preds[1]-16.6666667) > 1e-6 {
+		t.Errorf("expected second prediction ~16.67, got %v", preds[1])
+	}
+}
+
+func TestLinearRegressionModel(t *testing.T) {
+	model := LinearRegressionModel{}
+	data := []float64{1, 2, 3, 4}
+	preds, err := model.Forecast(data, 2)
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	if len(preds) != 2 {
+		t.Fatalf("expected two predictions, got %d", len(preds))
+	}
+	if math.Abs(preds[0]-5) > 1e-6 {
+		t.Errorf("expected first prediction 5, got %v", preds[0])
+	}
+	if math.Abs(preds[1]-6) > 1e-6 {
+		t.Errorf("expected second prediction 6, got %v", preds[1])
+	}
+}
+
+func TestAR1Model(t *testing.T) {
+	model := AR1Model{}
+	data := []float64{2, 4, 8}
+	preds, err := model.Forecast(data, 2)
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	if len(preds) != 2 {
+		t.Fatalf("expected two predictions, got %d", len(preds))
+	}
+	if math.Abs(preds[0]-16) > 1e-6 {
+		t.Errorf("expected first prediction 16, got %v", preds[0])
+	}
+}
+
+func TestForecastSeriesDefault(t *testing.T) {
+	data := []float64{1, 2, 3, 4, 5}
+	preds, err := ForecastSeries(nil, data, 1)
+	if err != nil {
+		t.Fatalf("forecast error: %v", err)
+	}
+	if len(preds) != 1 {
+		t.Fatalf("expected one prediction, got %d", len(preds))
+	}
+}


### PR DESCRIPTION
## Summary
- implement moving average, linear regression, and AR(1) price forecasting models
- add unit tests covering each model and forecasting helper
- document common financial modelling algorithms and on-chain integration

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8f234d678832083d036a0b13219c6