### PR TITLE
Add documentation skeleton and community guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots or Logs**
+If applicable, add screenshots or logs to help explain your problem.
+
+**Environment:**
+- OS: [e.g. Ubuntu 22.04]
+- Commit/Version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+defaults:
+  labels: []
+  assignees: []
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/example/synnergy/discussions
+    about: Use GitHub Discussions for questions and general feedback.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+Describe the changes introduced by this pull request.
+
+## Testing
+List the commands you ran and their results.
+
+## Documentation
+- [ ] Documentation updated (if needed)
+
+## Checklist
+- [ ] Code compiles
+- [ ] Tests pass
+- [ ] Linting passes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org) Code of Conduct.
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery and unwelcome sexual attention
+- Trolling, insulting or derogatory comments, and personal attacks
+- Public or private harassment
+- Publishing others' private information without permission
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at [INSERT CONTACT EMAIL]. All complaints
+will be reviewed and investigated promptly and fairly.
+
+Maintainers who do not follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other project
+maintainers.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Synnergy
+
+Thank you for your interest in contributing to Synnergy! The following guidelines
+help maintain a consistent workflow across the project.
+
+## Getting Started
+- Fork the repository and clone your fork.
+- Install Go 1.21+ and Node.js 18+.
+- Run `go test ./...` to ensure the test suite passes before making changes.
+
+## Development Workflow
+1. Create small, focused commits.
+2. Include tests and documentation for any code changes.
+3. Ensure `go fmt` has been run on Go files.
+4. Open a pull request with a clear description of your changes.
+
+## Issue Reporting
+- Use the issue templates when filing bugs or feature requests.
+- Provide reproduction steps and environment details.
+
+## Code Review
+- All submissions require review.
+- Address review comments promptly and keep discussions constructive.
+
+## Documentation
+- Update relevant guides under `docs/` when behavior changes.
+- Cross-link related documents to aid discoverability.
+
+## Community
+- Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+We appreciate your contributions!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Synnergy Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,16 @@
+# API Documentation
+
+This directory contains reference material for Go packages within Synnergy.
+
+To generate HTML documentation locally, run:
+```bash
+go doc ./...
+```
+or use `godoc`:
+```bash
+go install golang.org/x/tools/cmd/godoc@latest
+godoc -http=:6060
+```
+
+## Packages
+- [Core](core.md) – fundamental types and blockchain logic

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,0 +1,13 @@
+# Core Package Reference
+
+The core package implements consensus, transaction processing, and network primitives.
+
+## Key Types
+- `Block` – representation of a blockchain block
+- `Transaction` – basic transaction structure
+
+## Functions
+- `ValidateBlock` – verifies block integrity
+- `ApplyTransaction` – applies a transaction to the current state
+
+For additional details, read the source code under `core/`.

--- a/docs/guides/cli_quickstart.md
+++ b/docs/guides/cli_quickstart.md
@@ -1,0 +1,17 @@
+# CLI Quickstart
+
+The Synnergy CLI allows interaction with the blockchain for common tasks.
+
+## Installation
+Ensure the project is built:
+```bash
+make build
+```
+
+## Common Commands
+- `synnergy wallet create` – generate a new wallet
+- `synnergy tx send` – send a transaction
+- `synnergy node status` – display node synchronization status
+
+## Help
+Run `synnergy --help` or `synnergy <command> --help` for more details.

--- a/docs/guides/developer_guide.md
+++ b/docs/guides/developer_guide.md
@@ -1,0 +1,18 @@
+# Developer Guide
+
+This guide provides best practices for building modules within Synnergy.
+
+## Environment Setup
+- Install Go 1.21+ and Node.js 18+.
+- Run `go mod tidy` to fetch dependencies.
+
+## Coding Standards
+- Follow idiomatic Go style and run `go fmt`.
+- Include unit tests for new functionality.
+
+## Submitting Changes
+1. Create a descriptive branch (do not commit to `main`).
+2. Add tests and documentation.
+3. Open a pull request referencing related issues.
+
+For architectural context, see the detailed whitepaper under `Whitepaper_detailed/`.

--- a/docs/guides/gui_quickstart.md
+++ b/docs/guides/gui_quickstart.md
@@ -1,0 +1,17 @@
+# GUI Quickstart
+
+Several graphical interfaces are available for interacting with Synnergy modules.
+
+## Installing Dependencies
+- Node.js 18+
+- yarn
+
+## Running a GUI Module
+```bash
+cd GUI/wallet
+yarn install
+yarn start
+```
+
+Other modules can be run by changing into their directories under `GUI/` and
+executing `yarn start`.

--- a/docs/guides/network_operations.md
+++ b/docs/guides/network_operations.md
@@ -1,0 +1,17 @@
+# Network Operations Guide
+
+This guide outlines common network operations such as staking and governance.
+
+## Joining the Network
+1. Follow the [Node Setup Guide](node_setup.md).
+2. Register your node on the network using `synnergy node register`.
+
+## Staking
+- Delegate tokens with `synnergy stake add <amount>`.
+- Check staking status with `synnergy stake status`.
+
+## Governance
+- List proposals: `synnergy gov proposals`
+- Vote on a proposal: `synnergy gov vote <id> <yes|no>`
+
+For advanced procedures, consult the whitepaper.

--- a/docs/guides/node_setup.md
+++ b/docs/guides/node_setup.md
@@ -1,0 +1,24 @@
+# Node Setup Guide
+
+This guide walks through installing and running a Synnergy node.
+
+## Prerequisites
+- Go 1.21+
+- Git
+- Access to the Synnergy repository
+
+## Installation
+```bash
+git clone https://github.com/example/synnergy.git
+cd synnergy
+make build
+```
+
+## Running a Node
+```bash
+./synnergy --config configs/example.yaml
+```
+
+## Troubleshooting
+- Ensure ports are open and not blocked by firewalls.
+- Check logs under `logs/` for detailed error messages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,8 @@ The documentation is split into three main sections:
 
 | Path | Description |
 |------|-------------|
-| [`guides/`](guides/) | How‑to articles and conceptual overviews for every major module. Guides are written for developers, node operators and CLI users. |
+| [`guides/`](guides/) | Quickstart and how‑to articles for developers, node operators, and GUI users. |
+| [`api/`](api/) | Package‑level references and instructions for generating API documentation. |
 | [`adr/`](adr/) | Architecture Decision Records describing significant technical choices made during development. |
 | [`performance_benchmarks.md`](performance_benchmarks.md) | Baseline performance figures and instructions for running benchmarks. |
 


### PR DESCRIPTION
## Summary
- add MIT license, contributing guide, and code of conduct
- introduce user guides and API reference stubs under docs/
- provide issue and PR templates for community contributions

## Testing
- `go test ./...` *(fails: signal interrupt in cli and docgen packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f0bdf3288320b50111e8a9a9837d