### PR TITLE
Add skeleton security systems and CLI scaffolding

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("api gateway CLI placeholder")
+}

--- a/cmd/firewall/main.go
+++ b/cmd/firewall/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("firewall CLI placeholder")
+}

--- a/cmd/governance/main.go
+++ b/cmd/governance/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("governance CLI placeholder")
+}

--- a/cmd/monitoring/main.go
+++ b/cmd/monitoring/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("monitoring CLI placeholder")
+}

--- a/cmd/p2p-node/main.go
+++ b/cmd/p2p-node/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("p2p node CLI placeholder")
+}

--- a/cmd/secrets-manager/main.go
+++ b/cmd/secrets-manager/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("secrets manager CLI placeholder")
+}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,24 @@
+package api
+
+import "testing"
+
+func TestGateway(t *testing.T) {
+	g := NewGateway()
+	if err := g.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	a := &AuthMiddleware{}
+	if !a.Authenticate("token") {
+		t.Fatalf("expected token to be valid")
+	}
+}
+
+func TestRateLimiter(t *testing.T) {
+	r := NewRateLimiter(1)
+	if !r.Allow() || r.Allow() {
+		t.Fatalf("rate limiting failed")
+	}
+}

--- a/internal/api/auth_middleware.go
+++ b/internal/api/auth_middleware.go
@@ -1,0 +1,9 @@
+package api
+
+// AuthMiddleware performs simple token checks.
+type AuthMiddleware struct{}
+
+// Authenticate validates a token.
+func (a *AuthMiddleware) Authenticate(token string) bool {
+	return token != ""
+}

--- a/internal/api/gateway.go
+++ b/internal/api/gateway.go
@@ -1,0 +1,10 @@
+package api
+
+// Gateway represents a minimal API gateway.
+type Gateway struct{}
+
+// NewGateway creates a new Gateway.
+func NewGateway() *Gateway { return &Gateway{} }
+
+// Start begins serving requests (placeholder).
+func (g *Gateway) Start() error { return nil }

--- a/internal/api/rate_limiter.go
+++ b/internal/api/rate_limiter.go
@@ -1,0 +1,26 @@
+package api
+
+import "sync"
+
+// RateLimiter limits requests to a fixed count.
+type RateLimiter struct {
+	mu    sync.Mutex
+	count int
+	limit int
+}
+
+// NewRateLimiter creates a RateLimiter.
+func NewRateLimiter(limit int) *RateLimiter {
+	return &RateLimiter{limit: limit}
+}
+
+// Allow reports if a request is allowed.
+func (r *RateLimiter) Allow() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.count >= r.limit {
+		return false
+	}
+	r.count++
+	return true
+}

--- a/internal/governance/audit_log.go
+++ b/internal/governance/audit_log.go
@@ -1,0 +1,28 @@
+package governance
+
+import "sync"
+
+// AuditLog stores simple string entries.
+type AuditLog struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+// NewAuditLog creates an AuditLog.
+func NewAuditLog() *AuditLog { return &AuditLog{} }
+
+// Append adds an entry to the log.
+func (a *AuditLog) Append(e string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.entries = append(a.entries, e)
+}
+
+// Entries returns a copy of log entries.
+func (a *AuditLog) Entries() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, len(a.entries))
+	copy(out, a.entries)
+	return out
+}

--- a/internal/governance/audit_log_test.go
+++ b/internal/governance/audit_log_test.go
@@ -1,0 +1,11 @@
+package governance
+
+import "testing"
+
+func TestAuditLog(t *testing.T) {
+	a := NewAuditLog()
+	a.Append("entry")
+	if len(a.Entries()) != 1 {
+		t.Fatalf("expected one entry")
+	}
+}

--- a/internal/governance/replay_protection.go
+++ b/internal/governance/replay_protection.go
@@ -1,0 +1,25 @@
+package governance
+
+import "sync"
+
+// ReplayProtector prevents processing of duplicate IDs.
+type ReplayProtector struct {
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+// NewReplayProtector creates a ReplayProtector.
+func NewReplayProtector() *ReplayProtector {
+	return &ReplayProtector{seen: make(map[string]struct{})}
+}
+
+// Seen checks if the ID has been observed.
+func (r *ReplayProtector) Seen(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.seen[id]; ok {
+		return true
+	}
+	r.seen[id] = struct{}{}
+	return false
+}

--- a/internal/monitoring/alerting.go
+++ b/internal/monitoring/alerting.go
@@ -1,0 +1,21 @@
+package monitoring
+
+// Alerter provides simple alert broadcasting.
+type Alerter struct {
+	listeners []chan string
+}
+
+// NewAlerter creates an Alerter.
+func NewAlerter() *Alerter { return &Alerter{} }
+
+// Subscribe registers a listener channel.
+func (a *Alerter) Subscribe(ch chan string) {
+	a.listeners = append(a.listeners, ch)
+}
+
+// Alert sends a message to all listeners.
+func (a *Alerter) Alert(msg string) {
+	for _, ch := range a.listeners {
+		ch <- msg
+	}
+}

--- a/internal/monitoring/metrics.go
+++ b/internal/monitoring/metrics.go
@@ -1,0 +1,28 @@
+package monitoring
+
+import "sync"
+
+// Metrics provides a simple counter registry.
+type Metrics struct {
+	mu       sync.Mutex
+	counters map[string]int
+}
+
+// NewMetrics creates a Metrics instance.
+func NewMetrics() *Metrics {
+	return &Metrics{counters: make(map[string]int)}
+}
+
+// Inc increments the named counter.
+func (m *Metrics) Inc(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.counters[name]++
+}
+
+// Get retrieves the current value for the named counter.
+func (m *Metrics) Get(name string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.counters[name]
+}

--- a/internal/monitoring/metrics_test.go
+++ b/internal/monitoring/metrics_test.go
@@ -1,0 +1,11 @@
+package monitoring
+
+import "testing"
+
+func TestMetrics(t *testing.T) {
+	m := NewMetrics()
+	m.Inc("a")
+	if m.Get("a") != 1 {
+		t.Fatalf("expected 1")
+	}
+}

--- a/internal/monitoring/tracing.go
+++ b/internal/monitoring/tracing.go
@@ -1,0 +1,12 @@
+package monitoring
+
+// Tracer is a placeholder for distributed tracing.
+type Tracer struct{}
+
+// NewTracer creates a new Tracer.
+func NewTracer() *Tracer { return &Tracer{} }
+
+// StartSpan is a placeholder that would start a trace span.
+func (t *Tracer) StartSpan(name string) func() {
+	return func() {}
+}

--- a/internal/p2p/key_rotation.go
+++ b/internal/p2p/key_rotation.go
@@ -1,0 +1,16 @@
+package p2p
+
+import "time"
+
+// KeyRotator handles periodic key rotation for a channel.
+type KeyRotator struct {
+	Interval time.Duration
+}
+
+// NewKeyRotator creates a KeyRotator with the given interval.
+func NewKeyRotator(d time.Duration) *KeyRotator {
+	return &KeyRotator{Interval: d}
+}
+
+// Rotate is a placeholder rotation implementation.
+func (k *KeyRotator) Rotate() {}

--- a/internal/p2p/pfs.go
+++ b/internal/p2p/pfs.go
@@ -1,0 +1,25 @@
+package p2p
+
+import "errors"
+
+// PFSChannel simulates a peer-to-peer channel with perfect forward secrecy.
+type PFSChannel struct{}
+
+// NewPFSChannel creates a new PFSChannel.
+func NewPFSChannel() *PFSChannel { return &PFSChannel{} }
+
+// Encrypt is a placeholder for message encryption.
+func (c *PFSChannel) Encrypt(msg []byte) ([]byte, error) {
+	if len(msg) == 0 {
+		return nil, errors.New("empty message")
+	}
+	return append([]byte(nil), msg...), nil
+}
+
+// Decrypt is a placeholder for message decryption.
+func (c *PFSChannel) Decrypt(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty data")
+	}
+	return append([]byte(nil), data...), nil
+}

--- a/internal/p2p/pfs_test.go
+++ b/internal/p2p/pfs_test.go
@@ -1,0 +1,18 @@
+package p2p
+
+import "testing"
+
+func TestPFSChannel(t *testing.T) {
+	ch := NewPFSChannel()
+	enc, err := ch.Encrypt([]byte("hello"))
+	if err != nil {
+		t.Fatalf("encrypt error: %v", err)
+	}
+	dec, err := ch.Decrypt(enc)
+	if err != nil {
+		t.Fatalf("decrypt error: %v", err)
+	}
+	if string(dec) != "hello" {
+		t.Fatalf("unexpected value: %s", string(dec))
+	}
+}

--- a/internal/security/ddos_mitigation.go
+++ b/internal/security/ddos_mitigation.go
@@ -1,0 +1,20 @@
+package security
+
+// DDoSMitigator provides simple tracking for IP addresses.
+type DDoSMitigator struct {
+	blocked map[string]struct{}
+}
+
+// NewDDoSMitigator creates an empty DDoSMitigator.
+func NewDDoSMitigator() *DDoSMitigator {
+	return &DDoSMitigator{blocked: make(map[string]struct{})}
+}
+
+// Block records an address as blocked.
+func (d *DDoSMitigator) Block(addr string) { d.blocked[addr] = struct{}{} }
+
+// IsBlocked checks if an address is blocked.
+func (d *DDoSMitigator) IsBlocked(addr string) bool {
+	_, ok := d.blocked[addr]
+	return ok
+}

--- a/internal/security/ddos_mitigation_test.go
+++ b/internal/security/ddos_mitigation_test.go
@@ -1,0 +1,11 @@
+package security
+
+import "testing"
+
+func TestDDoSMitigator(t *testing.T) {
+	d := NewDDoSMitigator()
+	d.Block("1.2.3.4")
+	if !d.IsBlocked("1.2.3.4") {
+		t.Fatalf("address should be blocked")
+	}
+}

--- a/internal/security/encryption.go
+++ b/internal/security/encryption.go
@@ -1,0 +1,23 @@
+package security
+
+// Encryptor provides trivial XOR-based encryption for example purposes.
+type Encryptor struct {
+	key byte
+}
+
+// NewEncryptor creates an Encryptor with the given single-byte key.
+func NewEncryptor(key byte) *Encryptor { return &Encryptor{key: key} }
+
+// Encrypt XORs the data with the key.
+func (e *Encryptor) Encrypt(data []byte) []byte {
+	out := make([]byte, len(data))
+	for i, b := range data {
+		out[i] = b ^ e.key
+	}
+	return out
+}
+
+// Decrypt XORs the data with the key (same as Encrypt for XOR cipher).
+func (e *Encryptor) Decrypt(data []byte) []byte {
+	return e.Encrypt(data)
+}

--- a/internal/security/encryption_test.go
+++ b/internal/security/encryption_test.go
@@ -1,0 +1,12 @@
+package security
+
+import "testing"
+
+func TestEncryptor(t *testing.T) {
+	e := NewEncryptor(0xAA)
+	enc := e.Encrypt([]byte{0x01})
+	dec := e.Decrypt(enc)
+	if dec[0] != 0x01 {
+		t.Fatalf("expected 0x01")
+	}
+}

--- a/internal/security/key_management.go
+++ b/internal/security/key_management.go
@@ -1,0 +1,28 @@
+package security
+
+import "sync"
+
+// KeyManager stores an encryption key with basic rotation capability.
+type KeyManager struct {
+	mu  sync.RWMutex
+	key byte
+}
+
+// NewKeyManager creates a KeyManager.
+func NewKeyManager(k byte) *KeyManager {
+	return &KeyManager{key: k}
+}
+
+// Rotate replaces the current key.
+func (k *KeyManager) Rotate(newKey byte) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.key = newKey
+}
+
+// Key returns the current key.
+func (k *KeyManager) Key() byte {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.key
+}

--- a/internal/security/patch_manager.go
+++ b/internal/security/patch_manager.go
@@ -1,0 +1,19 @@
+package security
+
+// PatchManager tracks applied patches.
+type PatchManager struct {
+	applied []string
+}
+
+// NewPatchManager creates a PatchManager.
+func NewPatchManager() *PatchManager { return &PatchManager{} }
+
+// Apply records a patch ID.
+func (p *PatchManager) Apply(id string) { p.applied = append(p.applied, id) }
+
+// Applied returns all applied patch IDs.
+func (p *PatchManager) Applied() []string {
+	out := make([]string, len(p.applied))
+	copy(out, p.applied)
+	return out
+}

--- a/internal/security/rate_limiter.go
+++ b/internal/security/rate_limiter.go
@@ -1,0 +1,24 @@
+package security
+
+import "time"
+
+// RateLimiter is a minimal token bucket implementation.
+type RateLimiter struct {
+	interval time.Duration
+	last     time.Time
+}
+
+// NewRateLimiter creates a RateLimiter that allows one event per interval.
+func NewRateLimiter(interval time.Duration) *RateLimiter {
+	return &RateLimiter{interval: interval}
+}
+
+// Allow reports whether an event is allowed to proceed.
+func (r *RateLimiter) Allow() bool {
+	now := time.Now()
+	if now.Sub(r.last) >= r.interval {
+		r.last = now
+		return true
+	}
+	return false
+}

--- a/internal/security/secrets_manager.go
+++ b/internal/security/secrets_manager.go
@@ -1,0 +1,22 @@
+package security
+
+// SecretsManager provides a simple in-memory key-value store for secrets.
+type SecretsManager struct {
+	store map[string]string
+}
+
+// NewSecretsManager creates a new SecretsManager.
+func NewSecretsManager() *SecretsManager {
+	return &SecretsManager{store: make(map[string]string)}
+}
+
+// Store saves a secret value for the given key.
+func (s *SecretsManager) Store(key, value string) {
+	s.store[key] = value
+}
+
+// Retrieve gets a secret value by key.
+func (s *SecretsManager) Retrieve(key string) (string, bool) {
+	v, ok := s.store[key]
+	return v, ok
+}

--- a/internal/security/secrets_manager_test.go
+++ b/internal/security/secrets_manager_test.go
@@ -1,0 +1,11 @@
+package security
+
+import "testing"
+
+func TestSecretsManager(t *testing.T) {
+	sm := NewSecretsManager()
+	sm.Store("k", "v")
+	if val, ok := sm.Retrieve("k"); !ok || val != "v" {
+		t.Fatalf("expected v, got %s", val)
+	}
+}

--- a/tests/formal/contracts_verification_test.go
+++ b/tests/formal/contracts_verification_test.go
@@ -1,0 +1,7 @@
+package formal
+
+import "testing"
+
+func TestContractsFormalVerification(t *testing.T) {
+	t.Skip("formal verification not implemented")
+}

--- a/tests/fuzz/crypto_fuzz_test.go
+++ b/tests/fuzz/crypto_fuzz_test.go
@@ -1,0 +1,8 @@
+package fuzz
+
+import "testing"
+
+func FuzzCrypto(f *testing.F) {
+	f.Add([]byte("seed"))
+	f.Fuzz(func(t *testing.T, data []byte) {})
+}

--- a/tests/fuzz/network_fuzz_test.go
+++ b/tests/fuzz/network_fuzz_test.go
@@ -1,0 +1,8 @@
+package fuzz
+
+import "testing"
+
+func FuzzNetwork(f *testing.F) {
+	f.Add([]byte("seed"))
+	f.Fuzz(func(t *testing.T, data []byte) {})
+}

--- a/tests/fuzz/vm_fuzz_test.go
+++ b/tests/fuzz/vm_fuzz_test.go
@@ -1,0 +1,8 @@
+package fuzz
+
+import "testing"
+
+func FuzzVM(f *testing.F) {
+	f.Add([]byte("seed"))
+	f.Fuzz(func(t *testing.T, data []byte) {})
+}


### PR DESCRIPTION
## Summary
- introduce placeholder modules for secrets management, P2P perfect forward secrecy, DDoS mitigation, monitoring/observability, encryption, API gateway, governance logging, and patch management
- add CLI entry points for new services
- add basic fuzz and formal test stubs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8f0f9103c83208c1eaf0746599d9a