### PR TITLE
Add placeholders for missing automation scripts

### DIFF
--- a/scripts/biometric_security_node_setup.sh
+++ b/scripts/biometric_security_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/cross_consensus_network.sh
+++ b/scripts/cross_consensus_network.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/custodial_node_setup.sh
+++ b/scripts/custodial_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/dynamic_consensus_hopping.sh
+++ b/scripts/dynamic_consensus_hopping.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/financial_prediction.sh
+++ b/scripts/financial_prediction.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/forensic_node_setup.sh
+++ b/scripts/forensic_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/full_node_setup.sh
+++ b/scripts/full_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/historical_node_setup.sh
+++ b/scripts/historical_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/holographic_node_setup.sh
+++ b/scripts/holographic_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/holographic_storage.sh
+++ b/scripts/holographic_storage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/light_node_setup.sh
+++ b/scripts/light_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/optimization_node_setup.sh
+++ b/scripts/optimization_node_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/stake_penalty.sh
+++ b/scripts/stake_penalty.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/virtual_machine.sh
+++ b/scripts/virtual_machine.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1

--- a/scripts/vm_sandbox_management.sh
+++ b/scripts/vm_sandbox_management.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $(basename "$0") [options]
+Placeholder script. Implementation pending.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+echo "$(basename "$0") is not yet implemented." >&2
+exit 1


### PR DESCRIPTION
## Summary
- add placeholder scripts to orchestrate dynamic consensus hopping and cross-consensus networking
- add automation entries for financial prediction, holographic storage, optimization node setup, VM control, sandbox management, and stake penalties
- provide additional placeholder setup scripts for biometric security, custodial, forensic, full, historical, holographic, and light nodes

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b8f4a8220c83208df2fb93f39c3715