### PR TITLE
Add tests for missing modules

### DIFF
--- a/cmd/api-gateway/main_test.go
+++ b/cmd/api-gateway/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+// captureOutput runs f and returns its stdout output.
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestMainOutput(t *testing.T) {
+	got := captureOutput(main)
+	expected := "api gateway CLI placeholder\n"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/cmd/firewall/main_test.go
+++ b/cmd/firewall/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestMainOutput(t *testing.T) {
+	got := captureOutput(main)
+	expected := "firewall CLI placeholder\n"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/cmd/governance/main_test.go
+++ b/cmd/governance/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestMainOutput(t *testing.T) {
+	got := captureOutput(main)
+	expected := "governance CLI placeholder\n"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/cmd/monitoring/main_test.go
+++ b/cmd/monitoring/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestMainOutput(t *testing.T) {
+	got := captureOutput(main)
+	expected := "monitoring CLI placeholder\n"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/cmd/p2p-node/main_test.go
+++ b/cmd/p2p-node/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestMainOutput(t *testing.T) {
+	got := captureOutput(main)
+	expected := "p2p node CLI placeholder\n"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/cmd/secrets-manager/main_test.go
+++ b/cmd/secrets-manager/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestMainOutput(t *testing.T) {
+	got := captureOutput(main)
+	expected := "secrets manager CLI placeholder\n"
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}

--- a/internal/api/auth_middleware_test.go
+++ b/internal/api/auth_middleware_test.go
@@ -1,0 +1,13 @@
+package api
+
+import "testing"
+
+func TestAuthenticate(t *testing.T) {
+	a := AuthMiddleware{}
+	if !a.Authenticate("token") {
+		t.Error("expected valid token to pass")
+	}
+	if a.Authenticate("") {
+		t.Error("expected empty token to fail")
+	}
+}

--- a/internal/api/gateway_test.go
+++ b/internal/api/gateway_test.go
@@ -1,0 +1,10 @@
+package api
+
+import "testing"
+
+func TestGatewayStart(t *testing.T) {
+	g := NewGateway()
+	if err := g.Start(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/api/rate_limiter_test.go
+++ b/internal/api/rate_limiter_test.go
@@ -1,0 +1,13 @@
+package api
+
+import "testing"
+
+func TestRateLimiterAllow(t *testing.T) {
+	r := NewRateLimiter(1)
+	if !r.Allow() {
+		t.Fatal("expected first request to be allowed")
+	}
+	if r.Allow() {
+		t.Fatal("expected second request to be denied")
+	}
+}

--- a/internal/governance/replay_protection_test.go
+++ b/internal/governance/replay_protection_test.go
@@ -1,0 +1,13 @@
+package governance
+
+import "testing"
+
+func TestReplayProtectorSeen(t *testing.T) {
+	r := NewReplayProtector()
+	if r.Seen("abc") {
+		t.Fatal("ID should not be seen first time")
+	}
+	if !r.Seen("abc") {
+		t.Fatal("ID should be seen second time")
+	}
+}

--- a/internal/monitoring/alerting_test.go
+++ b/internal/monitoring/alerting_test.go
@@ -1,0 +1,18 @@
+package monitoring
+
+import "testing"
+
+func TestAlerterAlert(t *testing.T) {
+	a := NewAlerter()
+	ch := make(chan string, 1)
+	a.Subscribe(ch)
+	a.Alert("hello")
+	select {
+	case msg := <-ch:
+		if msg != "hello" {
+			t.Fatalf("expected 'hello', got %q", msg)
+		}
+	default:
+		t.Fatal("no message received")
+	}
+}

--- a/internal/monitoring/tracing_test.go
+++ b/internal/monitoring/tracing_test.go
@@ -1,0 +1,9 @@
+package monitoring
+
+import "testing"
+
+func TestTracerStartSpan(t *testing.T) {
+	tr := NewTracer()
+	end := tr.StartSpan("op")
+	end() // should not panic
+}

--- a/internal/p2p/key_rotation_test.go
+++ b/internal/p2p/key_rotation_test.go
@@ -1,0 +1,14 @@
+package p2p
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyRotatorRotate(t *testing.T) {
+	kr := NewKeyRotator(time.Second)
+	if kr.Interval != time.Second {
+		t.Fatalf("unexpected interval: %v", kr.Interval)
+	}
+	kr.Rotate() // should not panic
+}

--- a/internal/security/key_management_test.go
+++ b/internal/security/key_management_test.go
@@ -1,0 +1,14 @@
+package security
+
+import "testing"
+
+func TestKeyManager(t *testing.T) {
+	km := NewKeyManager(1)
+	if km.Key() != 1 {
+		t.Fatalf("expected key 1, got %d", km.Key())
+	}
+	km.Rotate(2)
+	if km.Key() != 2 {
+		t.Fatalf("expected key 2, got %d", km.Key())
+	}
+}

--- a/internal/security/patch_manager_test.go
+++ b/internal/security/patch_manager_test.go
@@ -1,0 +1,12 @@
+package security
+
+import "testing"
+
+func TestPatchManager(t *testing.T) {
+	p := NewPatchManager()
+	p.Apply("p1")
+	applied := p.Applied()
+	if len(applied) != 1 || applied[0] != "p1" {
+		t.Fatalf("unexpected applied patches: %v", applied)
+	}
+}

--- a/internal/security/rate_limiter_test.go
+++ b/internal/security/rate_limiter_test.go
@@ -1,0 +1,20 @@
+package security
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiterAllow(t *testing.T) {
+	r := NewRateLimiter(time.Millisecond)
+	if !r.Allow() {
+		t.Fatal("expected first event to be allowed")
+	}
+	if r.Allow() {
+		t.Fatal("expected second event to be blocked")
+	}
+	time.Sleep(time.Millisecond)
+	if !r.Allow() {
+		t.Fatal("expected event after interval to be allowed")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for CLI commands to verify placeholder output
- add coverage for internal packages (authentication, gateways, rate limiting, governance, monitoring, p2p key rotation, and security)

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8f8f144cc8320a427265e4d8e9011