### PR TITLE
feat(gui): complete stage 3 scaffolding

### DIFF
--- a/GUI/ai-marketplace/jest.config.js
+++ b/GUI/ai-marketplace/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
   collectCoverage: true
 };

--- a/GUI/ai-marketplace/src/state/.gitkeep
+++ b/GUI/ai-marketplace/src/state/.gitkeep
@@ -1,0 +1,1 @@
+# Maintains version control for empty state directory

--- a/GUI/ai-marketplace/src/state/store.ts
+++ b/GUI/ai-marketplace/src/state/store.ts
@@ -1,0 +1,19 @@
+export type State = Record<string, unknown>;
+
+class Store {
+  private state: State = {};
+
+  set(key: string, value: unknown): void {
+    this.state[key] = value;
+  }
+
+  get<T>(key: string): T | undefined {
+    return this.state[key] as T | undefined;
+  }
+
+  reset(): void {
+    this.state = {};
+  }
+}
+
+export const store = new Store();

--- a/GUI/ai-marketplace/src/styles/.gitkeep
+++ b/GUI/ai-marketplace/src/styles/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep styles directory

--- a/GUI/ai-marketplace/src/styles/global.css
+++ b/GUI/ai-marketplace/src/styles/global.css
@@ -1,0 +1,5 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}

--- a/GUI/ai-marketplace/tests/e2e/.gitkeep
+++ b/GUI/ai-marketplace/tests/e2e/.gitkeep
@@ -1,0 +1,1 @@
+# e2e tests placeholder

--- a/GUI/ai-marketplace/tests/e2e/example.e2e.test.ts
+++ b/GUI/ai-marketplace/tests/e2e/example.e2e.test.ts
@@ -1,3 +1,7 @@
-test('e2e placeholder', () => {
-  expect(true).toBe(true);
+import { store } from '../../src/state/store';
+
+test('stores and retrieves values', () => {
+  store.set('foo', 'bar');
+  expect(store.get<string>('foo')).toBe('bar');
+  store.reset();
 });

--- a/GUI/ai-marketplace/tests/unit/.gitkeep
+++ b/GUI/ai-marketplace/tests/unit/.gitkeep
@@ -1,0 +1,1 @@
+# unit tests placeholder

--- a/GUI/ai-marketplace/tests/unit/example.test.ts
+++ b/GUI/ai-marketplace/tests/unit/example.test.ts
@@ -1,3 +1,7 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { store } from '../../src/state/store';
+
+test('reset clears state', () => {
+  store.set('count', 1);
+  store.reset();
+  expect(store.get('count')).toBeUndefined();
 });

--- a/GUI/ai-marketplace/tsconfig.json
+++ b/GUI/ai-marketplace/tsconfig.json
@@ -1,11 +1,17 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "module": "commonjs",
     "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/GUI/authority-node-index/.env.example
+++ b/GUI/authority-node-index/.env.example
@@ -1,1 +1,3 @@
 API_URL=http://localhost:3000
+PORT=3000
+LOG_LEVEL=info

--- a/GUI/authority-node-index/.eslintrc.json
+++ b/GUI/authority-node-index/.eslintrc.json
@@ -1,6 +1,8 @@
 {
   "env": { "es2021": true, "node": true },
-  "extends": ["eslint:recommended"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
   "parserOptions": { "ecmaVersion": 12, "sourceType": "module" },
+  "plugins": ["@typescript-eslint"],
   "rules": {}
 }

--- a/GUI/authority-node-index/.gitignore
+++ b/GUI/authority-node-index/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 coverage
 .env
+npm-debug.log*
+yarn-error.log*

--- a/GUI/authority-node-index/.prettierrc
+++ b/GUI/authority-node-index/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "semi": true
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
 }

--- a/GUI/authority-node-index/Dockerfile
+++ b/GUI/authority-node-index/Dockerfile
@@ -1,7 +1,13 @@
-FROM node:18-alpine
+FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm ci
 COPY . .
 RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY package*.json ./
+RUN npm ci --omit=dev
 CMD ["node", "dist/main.js"]

--- a/GUI/authority-node-index/Makefile
+++ b/GUI/authority-node-index/Makefile
@@ -1,8 +1,22 @@
 install:
-npm install
+	npm ci
 
 build:
-npm run build
+	npm run build
 
 test:
-npm test
+	npx jest
+
+lint:
+	npm run lint
+
+format:
+	npm run format
+
+start:
+	npm start
+
+clean:
+	rm -rf dist
+
+.PHONY: install build test lint format start clean

--- a/GUI/authority-node-index/README.md
+++ b/GUI/authority-node-index/README.md
@@ -1,7 +1,21 @@
 # Authority Node Index
 
-Enterprise-grade GUI for Authority Node Index. This scaffold includes TypeScript, linting, formatting, and testing configuration.
+Enterprise-grade GUI for Authority Node Index. Provides TypeScript setup with linting, formatting, tests and Docker deployment.
 
-## Scripts
-- `npm run build` - compile TypeScript
-- `npm test` - run tests (placeholder)
+## Setup
+
+```bash
+make install
+```
+
+## Development
+
+- `make build` - compile TypeScript
+- `make test` - run Jest tests
+- `make lint` - run ESLint
+- `make format` - format with Prettier
+- `make start` - start the built app
+
+## Configuration
+
+Environment variables are defined in `.env.example`.

--- a/GUI/authority-node-index/ci/.gitkeep
+++ b/GUI/authority-node-index/ci/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for CI configurations

--- a/GUI/authority-node-index/ci/pipeline.yml
+++ b/GUI/authority-node-index/ci/pipeline.yml
@@ -1,1 +1,13 @@
-# Placeholder CI pipeline for authority-node-index
+name: authority-node-index CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx jest
+      - run: npm run build

--- a/GUI/authority-node-index/config/.gitkeep
+++ b/GUI/authority-node-index/config/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for environment configs

--- a/GUI/authority-node-index/config/production.ts
+++ b/GUI/authority-node-index/config/production.ts
@@ -1,3 +1,5 @@
 export default {
-  apiUrl: process.env.API_URL || ''
+  apiUrl: process.env.API_URL || '',
+  port: Number(process.env.PORT) || 3000,
+  logLevel: process.env.LOG_LEVEL || 'info'
 };

--- a/GUI/authority-node-index/docker-compose.yml
+++ b/GUI/authority-node-index/docker-compose.yml
@@ -4,3 +4,9 @@ services:
     build: .
     ports:
       - "3000:3000"
+    environment:
+      - API_URL=${API_URL:-http://localhost:3000}
+      - PORT=${PORT:-3000}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    volumes:
+      - .:/app

--- a/GUI/authority-node-index/jest.config.js
+++ b/GUI/authority-node-index/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src']
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  collectCoverage: true
 };

--- a/GUI/authority-node-index/tests/e2e/.gitkeep
+++ b/GUI/authority-node-index/tests/e2e/.gitkeep
@@ -1,0 +1,1 @@
+# e2e tests placeholder

--- a/GUI/authority-node-index/tests/e2e/example.e2e.test.ts
+++ b/GUI/authority-node-index/tests/e2e/example.e2e.test.ts
@@ -1,3 +1,5 @@
-test('e2e placeholder', () => {
-  expect(true).toBe(true);
+import config from '../../config/production';
+
+test('has default api url', () => {
+  expect(config.apiUrl).toBe('');
 });

--- a/GUI/authority-node-index/tests/unit/.gitkeep
+++ b/GUI/authority-node-index/tests/unit/.gitkeep
@@ -1,0 +1,1 @@
+# unit tests placeholder

--- a/GUI/authority-node-index/tests/unit/example.test.ts
+++ b/GUI/authority-node-index/tests/unit/example.test.ts
@@ -1,3 +1,5 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import config from '../../config/production';
+
+test('uses default port', () => {
+  expect(config.port).toBe(3000);
 });

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,6 +5,7 @@
 ### Progress
 - Stage 1: In Progress – issue templates, PR template, README and root `.gitignore` upgraded; remaining files pending.
 - Stage 2: Completed – ai-marketplace scaffold enhanced with CI, config and tests.
+- Stage 3: Completed – GUI state management, styles, tests, and authority-node-index tooling upgraded.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -49,25 +50,25 @@
 - [x] GUI/ai-marketplace/src/services/.gitkeep
 
 **Stage 3**
-- [ ] GUI/ai-marketplace/src/state/.gitkeep
-- [ ] GUI/ai-marketplace/src/styles/.gitkeep
-- [ ] GUI/ai-marketplace/tests/e2e/.gitkeep
-- [ ] GUI/ai-marketplace/tests/e2e/example.e2e.test.ts
-- [ ] GUI/ai-marketplace/tests/unit/.gitkeep
-- [ ] GUI/ai-marketplace/tests/unit/example.test.ts
-- [ ] GUI/ai-marketplace/tsconfig.json
-- [ ] GUI/authority-node-index/.env.example
-- [ ] GUI/authority-node-index/.eslintrc.json
-- [ ] GUI/authority-node-index/.gitignore
-- [ ] GUI/authority-node-index/.prettierrc
-- [ ] GUI/authority-node-index/Dockerfile
-- [ ] GUI/authority-node-index/Makefile
-- [ ] GUI/authority-node-index/README.md
-- [ ] GUI/authority-node-index/ci/.gitkeep
-- [ ] GUI/authority-node-index/ci/pipeline.yml
-- [ ] GUI/authority-node-index/config/.gitkeep
-- [ ] GUI/authority-node-index/config/production.ts
-- [ ] GUI/authority-node-index/docker-compose.yml
+- [x] GUI/ai-marketplace/src/state/.gitkeep
+- [x] GUI/ai-marketplace/src/styles/.gitkeep
+- [x] GUI/ai-marketplace/tests/e2e/.gitkeep
+- [x] GUI/ai-marketplace/tests/e2e/example.e2e.test.ts
+- [x] GUI/ai-marketplace/tests/unit/.gitkeep
+- [x] GUI/ai-marketplace/tests/unit/example.test.ts
+- [x] GUI/ai-marketplace/tsconfig.json
+- [x] GUI/authority-node-index/.env.example
+- [x] GUI/authority-node-index/.eslintrc.json
+- [x] GUI/authority-node-index/.gitignore
+- [x] GUI/authority-node-index/.prettierrc
+- [x] GUI/authority-node-index/Dockerfile
+- [x] GUI/authority-node-index/Makefile
+- [x] GUI/authority-node-index/README.md
+- [x] GUI/authority-node-index/ci/.gitkeep
+- [x] GUI/authority-node-index/ci/pipeline.yml
+- [x] GUI/authority-node-index/config/.gitkeep
+- [x] GUI/authority-node-index/config/production.ts
+- [x] GUI/authority-node-index/docker-compose.yml
 
 **Stage 4**
 - [ ] GUI/authority-node-index/docs/.gitkeep


### PR DESCRIPTION
## Summary
- add simple in-memory state store and global styles for ai-marketplace
- harden authority-node-index tooling with env template, lint/format config, docker & make targets
- mark Stage 3 done in AGENTS tracker

## Testing
- `npm test` (gui/ai-marketplace)
- `npx jest` (gui/authority-node-index)


------
https://chatgpt.com/codex/tasks/task_e_68b95ef747ec8320b2af9c8f7d0507ca