### PR TITLE
Restrict government nodes from controlling SYN coin

### DIFF
--- a/cli/centralbank.go
+++ b/cli/centralbank.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"synnergy/core"
+	"synnergy/internal/tokens"
 )
 
-var centralBank = core.NewCentralBankingNode("central", "cbnode", ledger, "neutral")
+var centralBankToken = tokens.NewSYN10Token(1, "CBDC", "cSYN", "central", 1, 2)
+var centralBank = core.NewCentralBankingNode("central", "cbnode", ledger, "neutral", centralBankToken)
 var centralBankJSON bool
 
 func init() {
@@ -29,9 +31,9 @@ func init() {
 		centralBank.UpdatePolicy(args[0])
 	}}
 
-	mintCmd := &cobra.Command{Use: "mint [to] [amount]", Args: cobra.ExactArgs(2), Short: "Mint currency tokens", RunE: func(cmd *cobra.Command, args []string) error {
+	mintCmd := &cobra.Command{Use: "mint [to] [amount]", Args: cobra.ExactArgs(2), Short: "Mint CBDC tokens", RunE: func(cmd *cobra.Command, args []string) error {
 		amt, _ := strconv.ParseUint(args[1], 10, 64)
-		return centralBank.Mint(args[0], amt)
+		return centralBank.MintCBDC(args[0], amt)
 	}}
 
 	cbCmd.AddCommand(infoCmd, policyCmd, mintCmd)

--- a/core/bank_nodes_test.go
+++ b/core/bank_nodes_test.go
@@ -1,6 +1,10 @@
 package core
 
-import "testing"
+import (
+	"testing"
+
+	"synnergy/internal/tokens"
+)
 
 func TestBankNodes(t *testing.T) {
 	ledger := NewLedger()
@@ -8,7 +12,8 @@ func TestBankNodes(t *testing.T) {
 	if b == nil || b.Node == nil {
 		t.Fatal("bank institutional node not created")
 	}
-	c := NewCentralBankingNode("id2", "addr2", ledger, "policy")
+	tok := tokens.NewSYN10Token(1, "CBDC", "cSYN", "central", 1, 2)
+	c := NewCentralBankingNode("id2", "addr2", ledger, "policy", tok)
 	if c.MonetaryPolicy != "policy" {
 		t.Fatal("policy not set")
 	}

--- a/core/central_banking_node.go
+++ b/core/central_banking_node.go
@@ -1,36 +1,42 @@
 package core
 
-import "fmt"
+import (
+	"fmt"
 
-// CentralBankingNode models a node operated by a central bank.
+	"synnergy/internal/tokens"
+)
+
+// CentralBankingNode models a node operated by a central bank. It may manage
+// the supply of a CBDC token but cannot mint the fixed-supply native SYN coin.
 type CentralBankingNode struct {
 	*Node
 	MonetaryPolicy string
+	CBDCToken      *tokens.SYN10Token
 }
 
-// NewCentralBankingNode creates a central banking node with the given policy.
-func NewCentralBankingNode(id, addr string, ledger *Ledger, policy string) *CentralBankingNode {
+// NewCentralBankingNode creates a central banking node with the given policy
+// and associated CBDC token.
+func NewCentralBankingNode(id, addr string, ledger *Ledger, policy string, token *tokens.SYN10Token) *CentralBankingNode {
 	return &CentralBankingNode{
 		Node:           NewNode(id, addr, ledger),
 		MonetaryPolicy: policy,
+		CBDCToken:      token,
 	}
 }
 
 // UpdatePolicy updates the node's monetary policy description.
-func (n *CentralBankingNode) UpdatePolicy(policy string) {
-	n.MonetaryPolicy = policy
-}
+func (n *CentralBankingNode) UpdatePolicy(policy string) { n.MonetaryPolicy = policy }
 
-// Mint increases the treasury within the attached ledger. It rejects mints that
-// would exceed the remaining supply defined in coin.go.
-func (n *CentralBankingNode) Mint(to string, amount uint64) error {
+// MintCBDC mints new units of the CBDC token. It rejects zero amounts. The
+// native SYN coin supply remains unaffected and permanently capped.
+func (n *CentralBankingNode) MintCBDC(to string, amount uint64) error {
 	if amount == 0 {
 		return fmt.Errorf("amount must be greater than zero")
 	}
-	h, _ := n.Ledger.Head()
-	if RemainingSupply(uint64(h)) < amount {
-		return fmt.Errorf("mint exceeds remaining supply")
-	}
-	n.Ledger.Credit(to, amount)
-	return nil
+	return n.CBDCToken.Mint(to, amount)
 }
+
+// Mint is retained for backwards compatibility but now forwards to MintCBDC.
+// This preserves existing opcode mappings while ensuring SYN coin supply is
+// never altered through this method.
+func (n *CentralBankingNode) Mint(to string, amount uint64) error { return n.MintCBDC(to, amount) }

--- a/core/central_banking_node_test.go
+++ b/core/central_banking_node_test.go
@@ -1,19 +1,26 @@
 package core
 
-import "testing"
+import (
+	"testing"
 
-func TestCentralBankingMint(t *testing.T) {
+	"synnergy/internal/tokens"
+)
+
+func TestCentralBankingMintCBDC(t *testing.T) {
 	l := NewLedger()
-	cb := NewCentralBankingNode("id", "addr", l, "neutral")
+	tok := tokens.NewSYN10Token(1, "CBDC", "cSYN", "central", 1, 2)
+	cb := NewCentralBankingNode("id", "addr", l, "neutral", tok)
 
-	if err := cb.Mint("alice", 10); err != nil {
-		t.Fatalf("mint: %v", err)
+	if err := cb.MintCBDC("alice", 10); err != nil {
+		t.Fatalf("mintCBDC: %v", err)
 	}
-	if bal := l.GetBalance("alice"); bal != 10 {
-		t.Fatalf("unexpected balance %d", bal)
+	if bal := tok.BalanceOf("alice"); bal != 10 {
+		t.Fatalf("unexpected token balance %d", bal)
 	}
-	// attempt to mint beyond remaining supply
-	if err := cb.Mint("alice", RemainingSupply(0)+1); err == nil {
-		t.Fatalf("expected supply error")
+	if bal := l.GetBalance("alice"); bal != 0 {
+		t.Fatalf("ledger should remain unchanged, got %d", bal)
+	}
+	if err := cb.MintCBDC("alice", 0); err == nil {
+		t.Fatalf("expected error on zero mint")
 	}
 }

--- a/core/government_authority_node.go
+++ b/core/government_authority_node.go
@@ -1,6 +1,9 @@
 package core
 
+import "errors"
+
 // GovernmentAuthorityNode represents a regulator-operated authority node.
+// It explicitly lacks capabilities to mint SYN coins or modify monetary policy.
 type GovernmentAuthorityNode struct {
 	*AuthorityNode
 	Department string
@@ -10,4 +13,16 @@ type GovernmentAuthorityNode struct {
 func NewGovernmentAuthorityNode(addr, role, department string) *GovernmentAuthorityNode {
 	node := &AuthorityNode{Address: addr, Role: role, Votes: make(map[string]bool)}
 	return &GovernmentAuthorityNode{AuthorityNode: node, Department: department}
+}
+
+// MintSYN always returns an error as government nodes cannot mint the native
+// SYN coin which has a fixed supply.
+func (n *GovernmentAuthorityNode) MintSYN(to string, amount uint64) error {
+	return errors.New("government authority nodes cannot mint SYN coins")
+}
+
+// UpdateMonetaryPolicy always returns an error as government nodes cannot change
+// monetary policy. Only central bank nodes may perform such actions.
+func (n *GovernmentAuthorityNode) UpdateMonetaryPolicy(policy string) error {
+	return errors.New("government authority nodes cannot modify monetary policy")
 }

--- a/core/government_authority_node_test.go
+++ b/core/government_authority_node_test.go
@@ -10,4 +10,10 @@ func TestGovernmentAuthorityNode(t *testing.T) {
 	if gn.Address != "addr" {
 		t.Fatalf("unexpected address")
 	}
+	if err := gn.MintSYN("bob", 1); err == nil {
+		t.Fatalf("expected mint restriction")
+	}
+	if err := gn.UpdateMonetaryPolicy("expansion"); err == nil {
+		t.Fatalf("expected policy restriction")
+	}
 }

--- a/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -117,7 +117,7 @@ graph TD
     end
 
     subgraph CentralBank
-        CBN[NewCentralBankingNode] --> CBM[Mint]
+        CBN[NewCentralBankingNode] --> CBM[MintCBDC]
     end
 
     subgraph Charity

--- a/docs/reference/functions_list.txt
+++ b/docs/reference/functions_list.txt
@@ -531,9 +531,10 @@ core/kademlia.go:18:func NewKademlia() *Kademlia {
 core/kademlia.go:23:func (k *Kademlia) Store(key string, value []byte) {
 core/kademlia.go:30:func (k *Kademlia) FindValue(key string) ([]byte, bool) {
 core/kademlia.go:41:func Distance(a, b string) *big.Int {
-core/central_banking_node.go:10:func NewCentralBankingNode(id, addr string, ledger *Ledger, policy string) *CentralBankingNode {
-core/central_banking_node.go:18:func (n *CentralBankingNode) UpdatePolicy(policy string) {
-core/central_banking_node.go:23:func (n *CentralBankingNode) Mint(to string, amount uint64) {
+core/central_banking_node.go:17:func NewCentralBankingNode(id, addr string, ledger *Ledger, policy string, token *tokens.SYN10Token) *CentralBankingNode {
+core/central_banking_node.go:27:func (n *CentralBankingNode) UpdatePolicy(policy string) {
+core/central_banking_node.go:30:func (n *CentralBankingNode) MintCBDC(to string, amount uint64) error {
+core/central_banking_node.go:39:func (n *CentralBankingNode) Mint(to string, amount uint64) error {
 core/ai_enhanced_contract.go:19:func NewAIContractRegistry(base *ContractRegistry) *AIContractRegistry {
 core/ai_enhanced_contract.go:28:func (r *AIContractRegistry) DeployAIContract(wasm []byte, modelHash, manifest string, gasLimit uint64, owner string) (string, error) {
 core/ai_enhanced_contract.go:41:func (r *AIContractRegistry) InvokeAIContract(addr string, input []byte, gasLimit uint64) ([]byte, uint64, error) {

--- a/internal/nodes/bank_nodes/index.go
+++ b/internal/nodes/bank_nodes/index.go
@@ -17,8 +17,8 @@ type CentralBankingNode interface {
 	nodes.NodeInterface
 	// UpdatePolicy updates the node's monetary policy guidance.
 	UpdatePolicy(policy string)
-	// Mint credits the given amount to the target account within the ledger.
-	Mint(to string, amount uint64)
+	// MintCBDC creates new CBDC tokens for the target account.
+	MintCBDC(to string, amount uint64) error
 }
 
 // CustodialNode models a node that holds assets on behalf of users.

--- a/internal/nodes/bank_nodes/index_test.go
+++ b/internal/nodes/bank_nodes/index_test.go
@@ -5,6 +5,7 @@ import (
 
 	"synnergy/core"
 	"synnergy/internal/nodes"
+	"synnergy/internal/tokens"
 )
 
 type bankNodeAdapter struct{ *core.BankInstitutionalNode }
@@ -24,8 +25,8 @@ func (a *centralBankNodeAdapter) Stop() error                       { return nil
 func (a *centralBankNodeAdapter) IsRunning() bool                   { return true }
 func (a *centralBankNodeAdapter) Peers() []nodes.Address            { return nil }
 func (a *centralBankNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
-func (a *centralBankNodeAdapter) Mint(addr string, amt uint64) {
-	_ = a.CentralBankingNode.Mint(addr, amt)
+func (a *centralBankNodeAdapter) MintCBDC(addr string, amt uint64) error {
+	return a.CentralBankingNode.MintCBDC(addr, amt)
 }
 
 type custodialNodeAdapter struct{ *core.CustodialNode }
@@ -40,8 +41,9 @@ func (a *custodialNodeAdapter) DialSeed(addr nodes.Address) error { return nil }
 // TestInterfaceCompliance ensures core implementations satisfy the banking node interfaces via adapters.
 func TestInterfaceCompliance(t *testing.T) {
 	ledger := core.NewLedger()
+	tok := tokens.NewSYN10Token(1, "CBDC", "cSYN", "central", 1, 2)
 
 	var _ BankInstitutionalNode = &bankNodeAdapter{core.NewBankInstitutionalNode("id1", "addr1", ledger)}
-	var _ CentralBankingNode = &centralBankNodeAdapter{core.NewCentralBankingNode("id2", "addr2", ledger, "policy")}
+	var _ CentralBankingNode = &centralBankNodeAdapter{core.NewCentralBankingNode("id2", "addr2", ledger, "policy", tok)}
 	var _ CustodialNode = &custodialNodeAdapter{core.NewCustodialNode("id3", "addr3", ledger)}
 }


### PR DESCRIPTION
## Summary
- central bank node now mints only CBDC token and leaves SYN coin supply fixed
- government authority nodes explicitly reject minting or policy changes
- updated CLI, interfaces, docs and tests for CBDC minting

## Testing
- `go test ./core`
- `go test ./internal/nodes/bank_nodes`
- `go test ./cli`


------
https://chatgpt.com/codex/tasks/task_e_68b9652998b88320ac8b640ef0e50bb8