### PR TITLE
feat(gui): add CLI scaffolding for dao explorer

### DIFF
--- a/GUI/dao-explorer/package-lock.json
+++ b/GUI/dao-explorer/package-lock.json
@@ -7,8 +7,12 @@
     "": {
       "name": "synnergy-dao-explorer",
       "version": "1.0.0",
+      "dependencies": {
+        "yargs": "^17.7.2"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.3",
+        "@types/yargs": "^17.0.24",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
         "prettier": "^3.1.0",
@@ -1413,7 +1417,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1423,7 +1426,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1768,7 +1770,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -1801,7 +1802,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1814,7 +1814,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -1992,7 +1991,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -2009,7 +2007,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2395,7 +2392,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -2664,7 +2660,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4117,7 +4112,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4365,7 +4359,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4380,7 +4373,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4794,7 +4786,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -4833,7 +4824,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -4850,7 +4840,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -4869,7 +4858,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/GUI/dao-explorer/package.json
+++ b/GUI/dao-explorer/package.json
@@ -6,13 +6,16 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/main.js",
-    "test": "echo \"No tests yet\"",
+    "test": "jest",
     "lint": "eslint .",
     "format": "prettier --write ."
   },
-  "dependencies": {},
+  "dependencies": {
+    "yargs": "^17.7.2"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.3",
+    "@types/yargs": "^17.0.24",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "prettier": "^3.1.0",

--- a/GUI/dao-explorer/src/main.test.ts
+++ b/GUI/dao-explorer/src/main.test.ts
@@ -1,5 +1,11 @@
 import { main } from './main';
 
-test('main returns greeting', () => {
-  expect(main()).toContain('dao-explorer');
+describe('main', () => {
+  it('returns default greeting', () => {
+    expect(main()).toBe('Hello from dao-explorer');
+  });
+
+  it('supports custom name', () => {
+    expect(main('tester')).toBe('Hello from tester');
+  });
 });

--- a/GUI/dao-explorer/src/main.ts
+++ b/GUI/dao-explorer/src/main.ts
@@ -1,7 +1,20 @@
-export function main(): string {
-  return 'Hello from dao-explorer';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+export function main(name: string = 'dao-explorer'): string {
+  return `Hello from ${name}`;
 }
 
 if (require.main === module) {
-  console.log(main());
+  const argv = yargs(hideBin(process.argv))
+    .option('name', {
+      type: 'string',
+      description: 'Name to greet',
+      default: 'dao-explorer',
+    })
+    .strict()
+    .help()
+    .parseSync();
+
+  console.log(main(argv.name));
 }

--- a/GUI/dao-explorer/tests/e2e/example.e2e.test.ts
+++ b/GUI/dao-explorer/tests/e2e/example.e2e.test.ts
@@ -1,3 +1,5 @@
-test('e2e placeholder', () => {
-  expect(true).toBe(true);
+import { main } from '../../src/main';
+
+test('CLI main executes with custom name', () => {
+  expect(main('e2e')).toContain('e2e');
 });

--- a/GUI/dao-explorer/tests/unit/example.test.ts
+++ b/GUI/dao-explorer/tests/unit/example.test.ts
@@ -1,3 +1,7 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { main } from '../../src/main';
+
+describe('main unit', () => {
+  it('greets dao-explorer by default', () => {
+    expect(main()).toBe('Hello from dao-explorer');
+  });
 });

--- a/GUI/dao-explorer/tsconfig.json
+++ b/GUI/dao-explorer/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "target": "ES2017",
     "module": "commonjs",
+    "rootDir": "src",
     "outDir": "dist",
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true

--- a/GUI/data-distribution-monitor/.env.example
+++ b/GUI/data-distribution-monitor/.env.example
@@ -1,1 +1,3 @@
-API_URL=http://localhost:3000
+# Example environment configuration
+PORT=3000
+API_URL=https://api.synnergy.local

--- a/GUI/data-distribution-monitor/.eslintrc.json
+++ b/GUI/data-distribution-monitor/.eslintrc.json
@@ -1,6 +1,10 @@
 {
-  "env": { "es2021": true, "node": true },
-  "extends": ["eslint:recommended"],
-  "parserOptions": { "ecmaVersion": 12, "sourceType": "module" },
+  "env": {
+    "node": true,
+    "jest": true
+  },
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
   "rules": {}
 }

--- a/GUI/data-distribution-monitor/.gitignore
+++ b/GUI/data-distribution-monitor/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 dist
-coverage
 .env

--- a/GUI/data-distribution-monitor/.prettierrc
+++ b/GUI/data-distribution-monitor/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "semi": true
+  "semi": true,
+  "printWidth": 80
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -13,6 +13,7 @@
 - Stage 8: Completed – cross-chain-bridge-monitor services and cross-chain-management configuration scaffolds added.
 - Stage 9: Completed – cross-chain-management CLI, deployment and tests strengthened.
 - Stage 10: Completed – cross-chain-management unit tests and DAO explorer tooling enhanced.
+- Stage 11: Completed – DAO explorer CLI and data distribution monitor configs established.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -225,25 +226,25 @@
  - [x] GUI/dao-explorer/k8s/deployment.yaml – resources and environment variables
 
 **Stage 11**
-- [ ] GUI/dao-explorer/package-lock.json
-- [ ] GUI/dao-explorer/package.json
-- [ ] GUI/dao-explorer/src/components/.gitkeep
-- [ ] GUI/dao-explorer/src/hooks/.gitkeep
-- [ ] GUI/dao-explorer/src/main.test.ts
-- [ ] GUI/dao-explorer/src/main.ts
-- [ ] GUI/dao-explorer/src/pages/.gitkeep
-- [ ] GUI/dao-explorer/src/services/.gitkeep
-- [ ] GUI/dao-explorer/src/state/.gitkeep
-- [ ] GUI/dao-explorer/src/styles/.gitkeep
-- [ ] GUI/dao-explorer/tests/e2e/.gitkeep
-- [ ] GUI/dao-explorer/tests/e2e/example.e2e.test.ts
-- [ ] GUI/dao-explorer/tests/unit/.gitkeep
-- [ ] GUI/dao-explorer/tests/unit/example.test.ts
-- [ ] GUI/dao-explorer/tsconfig.json
-- [ ] GUI/data-distribution-monitor/.env.example
-- [ ] GUI/data-distribution-monitor/.eslintrc.json
-- [ ] GUI/data-distribution-monitor/.gitignore
-- [ ] GUI/data-distribution-monitor/.prettierrc
+- [x] GUI/dao-explorer/package-lock.json – include CLI dependencies
+- [x] GUI/dao-explorer/package.json – add yargs and jest script
+- [x] GUI/dao-explorer/src/components/.gitkeep – track empty component dir
+- [x] GUI/dao-explorer/src/hooks/.gitkeep – track hooks scaffold
+- [x] GUI/dao-explorer/src/main.test.ts – test default and custom greeting
+- [x] GUI/dao-explorer/src/main.ts – CLI with argument parsing
+- [x] GUI/dao-explorer/src/pages/.gitkeep – placeholder for pages
+- [x] GUI/dao-explorer/src/services/.gitkeep – placeholder for services
+- [x] GUI/dao-explorer/src/state/.gitkeep – placeholder for state management
+- [x] GUI/dao-explorer/src/styles/.gitkeep – placeholder for styles
+- [x] GUI/dao-explorer/tests/e2e/.gitkeep – preserve e2e test directory
+- [x] GUI/dao-explorer/tests/e2e/example.e2e.test.ts – exercise CLI path
+- [x] GUI/dao-explorer/tests/unit/.gitkeep – preserve unit test directory
+- [x] GUI/dao-explorer/tests/unit/example.test.ts – verify default greeting
+- [x] GUI/dao-explorer/tsconfig.json – enable rootDir and node resolution
+- [x] GUI/data-distribution-monitor/.env.example – document env variables
+- [x] GUI/data-distribution-monitor/.eslintrc.json – lint with TypeScript rules
+- [x] GUI/data-distribution-monitor/.gitignore – ignore builds and secrets
+- [x] GUI/data-distribution-monitor/.prettierrc – formatting preferences
 
 **Stage 12**
 - [ ] GUI/data-distribution-monitor/Dockerfile


### PR DESCRIPTION
## Summary
- add yargs-powered CLI entry point for DAO explorer with tests
- document env/lint/format configs for data-distribution monitor
- update AGENTS tracker for Stage 11 completion

## Testing
- `cd GUI/dao-explorer && npm test`
- `cd GUI/data-distribution-monitor && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96c49f6808320af2184ceb29a876e