### PR TITLE
chore: track Stage 20 progress and add mining dashboard test

### DIFF
--- a/GUI/mining-staking-manager/tests/unit/example.test.ts
+++ b/GUI/mining-staking-manager/tests/unit/example.test.ts
@@ -1,3 +1,8 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { renderDashboard } from '../../src/components/MiningDashboard';
+
+describe('MiningDashboard', () => {
+  test('renderDashboard aggregates stake amounts', async () => {
+    const output = await renderDashboard();
+    expect(output).toBe('Total Stake: 150');
+  });
 });

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,6 +23,7 @@
 - Stage 18: In Progress – identity-management-console CLI gains user registration with tests; mining-staking-manager pending.
 
 - Stage 19: Completed – mining-staking-manager scaffold enhanced with config, services, tests and deployment.
+- Stage 20: In Progress – mining-staking-manager unit tests refined; NFT marketplace scaffolding pending.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -416,8 +417,8 @@
 - [x] GUI/mining-staking-manager/tests/e2e/example.e2e.test.ts – CLI e2e test
 
 **Stage 20**
-- [ ] GUI/mining-staking-manager/tests/unit/.gitkeep
-- [ ] GUI/mining-staking-manager/tests/unit/example.test.ts
+- [x] GUI/mining-staking-manager/tests/unit/.gitkeep – ensure test directory tracked
+- [x] GUI/mining-staking-manager/tests/unit/example.test.ts – verify dashboard stake aggregation
 - [ ] GUI/mining-staking-manager/tsconfig.json
 - [ ] GUI/nft_marketplace/.env.example
 - [ ] GUI/nft_marketplace/.eslintrc.json


### PR DESCRIPTION
## Summary
- add unit test verifying mining dashboard stake aggregation
- track Stage 20 progress in AGENTS.md

## Testing
- `cd GUI/mining-staking-manager && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9897358cc8320a4e084b5167dd6f6