### PR TITLE
feat(gui): harden node ops and security center

### DIFF
--- a/GUI/node-operations-dashboard/src/main.test.ts
+++ b/GUI/node-operations-dashboard/src/main.test.ts
@@ -1,5 +1,16 @@
 import { main } from './main';
 
+beforeEach(() => {
+  ;(global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: 'OK' }),
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 it('returns node status', async () => {
   await expect(main()).resolves.toContain('Node status: OK');
 });

--- a/GUI/node-operations-dashboard/src/main.ts
+++ b/GUI/node-operations-dashboard/src/main.ts
@@ -1,8 +1,13 @@
 import { fetchNodeStatus } from './services/status';
 
 export async function main(): Promise<string> {
-  const status = await fetchNodeStatus();
-  return `Node status: ${status}`;
+  try {
+    const status = await fetchNodeStatus();
+    return `Node status: ${status}`;
+  } catch {
+    // Ensure callers always receive a string even on unexpected errors
+    return 'Node status: ERROR';
+  }
 }
 
 if (require.main === module) {

--- a/GUI/node-operations-dashboard/src/services/status.ts
+++ b/GUI/node-operations-dashboard/src/services/status.ts
@@ -1,4 +1,24 @@
-export async function fetchNodeStatus(): Promise<string> {
-  // Placeholder for real API call
-  return 'OK';
+export interface NodeStatusResponse {
+  status: string;
+}
+
+/**
+ * Fetches node status from the API defined by STATUS_URL.
+ * Falls back to a local endpoint and returns `ERROR` on network issues.
+ */
+export async function fetchNodeStatus(
+  url: string = process.env.STATUS_URL || 'http://localhost:8080/status'
+): Promise<string> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    const data = (await res.json()) as Partial<NodeStatusResponse>;
+    return data.status ?? 'UNKNOWN';
+  } catch (err) {
+    // Log for observability but do not leak internals to caller
+    console.error('fetchNodeStatus error', err);
+    return 'ERROR';
+  }
 }

--- a/GUI/node-operations-dashboard/tests/e2e/example.e2e.test.ts
+++ b/GUI/node-operations-dashboard/tests/e2e/example.e2e.test.ts
@@ -1,5 +1,16 @@
 import { main } from '../../src/main';
 
+beforeEach(() => {
+  ;(global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: 'OK' }),
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('reports node status end-to-end', async () => {
   const output = await main();
   expect(output).toBe('Node status: OK');

--- a/GUI/node-operations-dashboard/tests/unit/example.test.ts
+++ b/GUI/node-operations-dashboard/tests/unit/example.test.ts
@@ -1,5 +1,17 @@
 import { fetchNodeStatus } from '../../src/services/status';
 
+beforeEach(() => {
+  // Mock global fetch for unit tests
+  ;(global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: 'OK' }),
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('fetchNodeStatus returns OK', async () => {
   await expect(fetchNodeStatus()).resolves.toBe('OK');
 });

--- a/GUI/node-operations-dashboard/tsconfig.json
+++ b/GUI/node-operations-dashboard/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "module": "commonjs",
+    "moduleResolution": "node",
     "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"]
 }

--- a/GUI/security-operations-center/.env.example
+++ b/GUI/security-operations-center/.env.example
@@ -1,1 +1,4 @@
+# Configuration for the security operations center
 API_URL=http://localhost:3000
+JWT_SECRET=change_me
+LOG_LEVEL=info

--- a/GUI/security-operations-center/.eslintrc.json
+++ b/GUI/security-operations-center/.eslintrc.json
@@ -1,6 +1,21 @@
 {
-  "env": { "es2021": true, "node": true },
-  "extends": ["eslint:recommended"],
-  "parserOptions": { "ecmaVersion": 12, "sourceType": "module" },
-  "rules": {}
+  "env": {
+    "es2021": true,
+    "node": true,
+    "jest": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint", "prettier"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
+  ],
+  "rules": {
+    "prettier/prettier": "error"
+  }
 }

--- a/GUI/security-operations-center/.gitignore
+++ b/GUI/security-operations-center/.gitignore
@@ -1,4 +1,7 @@
-node_modules
-dist
-coverage
+node_modules/
+dist/
+coverage/
 .env
+npm-debug.log*
+*.log
+.DS_Store

--- a/GUI/security-operations-center/.prettierrc
+++ b/GUI/security-operations-center/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "semi": true
+  "semi": true,
+  "trailingComma": "es5",
+  "printWidth": 80
 }

--- a/GUI/security-operations-center/Dockerfile
+++ b/GUI/security-operations-center/Dockerfile
@@ -1,7 +1,16 @@
-FROM node:18-alpine
+# Build stage
+FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm ci
 COPY . .
 RUN npm run build
+
+# Runtime stage
+FROM node:18-alpine AS runtime
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY package*.json ./
+RUN npm ci --omit=dev
+USER node
 CMD ["node", "dist/main.js"]

--- a/GUI/security-operations-center/Makefile
+++ b/GUI/security-operations-center/Makefile
@@ -1,8 +1,16 @@
+.PHONY: install build test lint format
+
 install:
-npm install
+	npm ci
 
 build:
-npm run build
+	npm run build
 
 test:
-npm test
+	npm test
+
+lint:
+	npm run lint
+
+format:
+	npm run format

--- a/GUI/security-operations-center/README.md
+++ b/GUI/security-operations-center/README.md
@@ -1,7 +1,21 @@
 # Security Operations Center
 
-Enterprise-grade GUI for Security Operations Center. This scaffold includes TypeScript, linting, formatting, and testing configuration.
+Enterprise-grade GUI for monitoring and responding to network security events. This scaffold ships with TypeScript, linting,
+formatting and containerization to ease production deployments.
 
 ## Scripts
-- `npm run build` - compile TypeScript
-- `npm test` - run tests (placeholder)
+- `npm run build` – compile TypeScript to JavaScript
+- `npm test` – run unit tests (placeholder)
+- `npm run lint` – lint sources with ESLint
+- `npm run format` – format sources with Prettier
+
+## Development
+1. Copy `.env.example` to `.env` and adjust values.
+2. `make install` to install dependencies.
+3. `make build` or `make test` as needed.
+
+## Docker
+A multi-stage `Dockerfile` is provided. Build with:
+```sh
+docker build -t soc .
+```

--- a/GUI/security-operations-center/ci/pipeline.yml
+++ b/GUI/security-operations-center/ci/pipeline.yml
@@ -1,1 +1,14 @@
-# Placeholder CI pipeline for security-operations-center
+name: CI
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -27,6 +27,8 @@
 - Stage 21: Completed – NFT marketplace frontend scaffold expanded with sample components, services, tests and hardened dashboard configuration.
 - Stage 22: Completed – node-operations-dashboard scaffold established with CI, docs and tests.
 
+- Stage 23: Completed – node-operations-dashboard status service and security-operations-center configuration hardened.
+
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
 - [ ] .github/ISSUE_TEMPLATE/config.yml
@@ -480,25 +482,25 @@
 - [x] GUI/node-operations-dashboard/src/main.test.ts
 
 **Stage 23**
-- [ ] GUI/node-operations-dashboard/src/main.ts
-- [ ] GUI/node-operations-dashboard/src/pages/.gitkeep
-- [ ] GUI/node-operations-dashboard/src/services/.gitkeep
-- [ ] GUI/node-operations-dashboard/src/state/.gitkeep
-- [ ] GUI/node-operations-dashboard/src/styles/.gitkeep
-- [ ] GUI/node-operations-dashboard/tests/e2e/.gitkeep
-- [ ] GUI/node-operations-dashboard/tests/e2e/example.e2e.test.ts
-- [ ] GUI/node-operations-dashboard/tests/unit/.gitkeep
-- [ ] GUI/node-operations-dashboard/tests/unit/example.test.ts
-- [ ] GUI/node-operations-dashboard/tsconfig.json
-- [ ] GUI/security-operations-center/.env.example
-- [ ] GUI/security-operations-center/.eslintrc.json
-- [ ] GUI/security-operations-center/.gitignore
-- [ ] GUI/security-operations-center/.prettierrc
-- [ ] GUI/security-operations-center/Dockerfile
-- [ ] GUI/security-operations-center/Makefile
-- [ ] GUI/security-operations-center/README.md
-- [ ] GUI/security-operations-center/ci/.gitkeep
-- [ ] GUI/security-operations-center/ci/pipeline.yml
+- [x] GUI/node-operations-dashboard/src/main.ts – env-driven status fetch with error handling
+- [x] GUI/node-operations-dashboard/src/pages/.gitkeep – placeholder for future pages
+- [x] GUI/node-operations-dashboard/src/services/.gitkeep – directory preserved alongside status service
+- [x] GUI/node-operations-dashboard/src/state/.gitkeep – state management scaffold
+- [x] GUI/node-operations-dashboard/src/styles/.gitkeep – style folder retained
+- [x] GUI/node-operations-dashboard/tests/e2e/.gitkeep – e2e test folder established
+- [x] GUI/node-operations-dashboard/tests/e2e/example.e2e.test.ts – fetch mocked end-to-end test
+- [x] GUI/node-operations-dashboard/tests/unit/.gitkeep – unit test folder established
+- [x] GUI/node-operations-dashboard/tests/unit/example.test.ts – fetch mocked unit test
+- [x] GUI/node-operations-dashboard/tsconfig.json – compiler options hardened
+- [x] GUI/security-operations-center/.env.example – sample environment variables added
+- [x] GUI/security-operations-center/.eslintrc.json – TypeScript and Prettier rules
+- [x] GUI/security-operations-center/.gitignore – broadened ignore patterns
+- [x] GUI/security-operations-center/.prettierrc – formatting rules
+- [x] GUI/security-operations-center/Dockerfile – multi-stage image and non-root user
+- [x] GUI/security-operations-center/Makefile – standard build targets
+- [x] GUI/security-operations-center/README.md – usage and Docker instructions
+- [x] GUI/security-operations-center/ci/.gitkeep – CI folder established
+- [x] GUI/security-operations-center/ci/pipeline.yml – GitHub Actions pipeline
 
 **Stage 24**
 - [ ] GUI/security-operations-center/config/.gitkeep


### PR DESCRIPTION
## Summary
- add environment-aware node status service and error handling for node-operations-dashboard
- scaffold security-operations-center configuration with linting, formatting and CI pipeline
- update AGENTS tracker for stage 23

## Testing
- `cd GUI/node-operations-dashboard && npm test`
- `cd GUI/security-operations-center && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0b77eca88320877ce75fc510a136