### PR TITLE
Stage25: harden security ops and contract marketplace

### DIFF
--- a/GUI/security-operations-center/tests/e2e/example.e2e.test.ts
+++ b/GUI/security-operations-center/tests/e2e/example.e2e.test.ts
@@ -1,3 +1,10 @@
-test('e2e placeholder', () => {
-  expect(true).toBe(true);
+import { main } from '../../src/main';
+
+describe('security operations center e2e', () => {
+  it('boots with provided API url', () => {
+    process.env.API_URL = 'http://e2e.local';
+    expect(main()).toBe(
+      'Security Operations Center started with API at http://e2e.local'
+    );
+  });
 });

--- a/GUI/security-operations-center/tests/unit/example.test.ts
+++ b/GUI/security-operations-center/tests/unit/example.test.ts
@@ -1,3 +1,10 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { main } from '../../src/main';
+
+describe('main', () => {
+  it('uses default API url when none provided', () => {
+    delete process.env.API_URL;
+    expect(main()).toBe(
+      'Security Operations Center started with API at http://localhost:8080'
+    );
+  });
 });

--- a/GUI/security-operations-center/tsconfig.json
+++ b/GUI/security-operations-center/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "commonjs",
     "outDir": "dist",
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "esModuleInterop": true,
     "skipLibCheck": true
   },

--- a/GUI/smart-contract-marketplace/.env.example
+++ b/GUI/smart-contract-marketplace/.env.example
@@ -1,1 +1,2 @@
 API_URL=http://localhost:3000
+PORT=3000

--- a/GUI/smart-contract-marketplace/.eslintrc.json
+++ b/GUI/smart-contract-marketplace/.eslintrc.json
@@ -2,5 +2,5 @@
   "env": { "es2021": true, "node": true },
   "extends": ["eslint:recommended"],
   "parserOptions": { "ecmaVersion": 12, "sourceType": "module" },
-  "rules": {}
+  "rules": { "no-unused-vars": "error" }
 }

--- a/GUI/smart-contract-marketplace/.gitignore
+++ b/GUI/smart-contract-marketplace/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 coverage
 .env
+npm-debug.log*

--- a/GUI/smart-contract-marketplace/.prettierrc
+++ b/GUI/smart-contract-marketplace/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "semi": true
+  "semi": true,
+  "trailingComma": "es5"
 }

--- a/GUI/smart-contract-marketplace/Dockerfile
+++ b/GUI/smart-contract-marketplace/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm ci --only=production
 COPY . .
 RUN npm run build
 CMD ["node", "dist/main.js"]

--- a/GUI/smart-contract-marketplace/Makefile
+++ b/GUI/smart-contract-marketplace/Makefile
@@ -6,3 +6,9 @@ npm run build
 
 test:
 npm test
+
+lint:
+npm run lint
+
+format:
+npm run format

--- a/GUI/smart-contract-marketplace/README.md
+++ b/GUI/smart-contract-marketplace/README.md
@@ -4,4 +4,9 @@ Enterprise-grade GUI for Smart Contract Marketplace. This scaffold includes Type
 
 ## Scripts
 - `npm run build` - compile TypeScript
-- `npm test` - run tests (placeholder)
+- `npm test` - run unit and e2e tests
+- `npm run lint` - static analysis
+- `npm run format` - format source files
+
+## Environment
+Copy `.env.example` to `.env` and adjust values for deployment.

--- a/GUI/smart-contract-marketplace/ci/pipeline.yml
+++ b/GUI/smart-contract-marketplace/ci/pipeline.yml
@@ -1,1 +1,9 @@
-# Placeholder CI pipeline for smart-contract-marketplace
+stages:
+  - test
+
+test-job:
+  stage: test
+  script:
+    - npm ci
+    - npm test
+    - npm run build

--- a/GUI/smart-contract-marketplace/config/production.ts
+++ b/GUI/smart-contract-marketplace/config/production.ts
@@ -1,3 +1,3 @@
 export default {
-  apiUrl: process.env.API_URL || ''
-};
+  apiUrl: process.env.API_URL || 'http://localhost:3000'
+} as const;

--- a/GUI/smart-contract-marketplace/docker-compose.yml
+++ b/GUI/smart-contract-marketplace/docker-compose.yml
@@ -4,3 +4,5 @@ services:
     build: .
     ports:
       - "3000:3000"
+    environment:
+      - API_URL=http://localhost:3000

--- a/GUI/smart-contract-marketplace/docs/README.md
+++ b/GUI/smart-contract-marketplace/docs/README.md
@@ -1,3 +1,4 @@
 # Smart Contract Marketplace Documentation
 
-Additional documentation for Smart Contract Marketplace.
+This section details architecture and usage for the Smart Contract Marketplace
+module. It covers configuration, deployment and integration steps.

--- a/GUI/smart-contract-marketplace/jest.config.js
+++ b/GUI/smart-contract-marketplace/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src']
+  roots: ['<rootDir>/src', '<rootDir>/tests']
 };

--- a/GUI/smart-contract-marketplace/package.json
+++ b/GUI/smart-contract-marketplace/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/main.js",
-    "test": "echo \"No tests yet\"",
+    "test": "jest",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/GUI/smart-contract-marketplace/tests/e2e/example.e2e.test.ts
+++ b/GUI/smart-contract-marketplace/tests/e2e/example.e2e.test.ts
@@ -1,3 +1,7 @@
-test('e2e placeholder', () => {
-  expect(true).toBe(true);
+import { main } from '../../src/main';
+
+describe('smart contract marketplace e2e', () => {
+  it('greets from main entry', () => {
+    expect(main()).toContain('smart-contract-marketplace');
+  });
 });

--- a/GUI/smart-contract-marketplace/tests/unit/example.test.ts
+++ b/GUI/smart-contract-marketplace/tests/unit/example.test.ts
@@ -1,3 +1,5 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { main } from '../../src/main';
+
+test('main returns greeting', () => {
+  expect(main()).toBe('Hello from smart-contract-marketplace');
 });

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Synnergy is a modular, high-performance blockchain written in Go and built for e
 - **Data distribution monitor** – CLI and GUI for network telemetry.
 - **Node operations dashboard** – TypeScript CLI and GUI for real-time node health monitoring.
 - **Security operations center** – monitors and aggregates security events with a CLI-accessible GUI.
+- **Smart contract marketplace** – publish and trade vetted contracts through CLI or GUI with deterministic gas costs.
 - **Infrastructure-as-code** – Dockerfiles, Helm charts, Terraform and Ansible playbooks for reproducible environments.
 - **Strong encryption and signatures** – all transactions and messages are secured using well‑vetted cryptography with digital signatures.
 - **Permissioned privacy** – fine‑grained access controls enable private channels and selective data disclosure.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -29,6 +29,7 @@
 
 - Stage 23: Completed – node-operations-dashboard status service and security-operations-center configuration hardened.
 - Stage 24: Completed – security-operations-center runtime, documentation and deployment scaffolds finalised.
+- Stage 25: Completed – security tests and smart-contract-marketplace config hardened.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -525,25 +526,25 @@
 - [x] GUI/security-operations-center/tests/e2e/.gitkeep – e2e folder tracked
 
 **Stage 25**
-- [ ] GUI/security-operations-center/tests/e2e/example.e2e.test.ts
-- [ ] GUI/security-operations-center/tests/unit/.gitkeep
-- [ ] GUI/security-operations-center/tests/unit/example.test.ts
-- [ ] GUI/security-operations-center/tsconfig.json
-- [ ] GUI/smart-contract-marketplace/.env.example
-- [ ] GUI/smart-contract-marketplace/.eslintrc.json
-- [ ] GUI/smart-contract-marketplace/.gitignore
-- [ ] GUI/smart-contract-marketplace/.prettierrc
-- [ ] GUI/smart-contract-marketplace/Dockerfile
-- [ ] GUI/smart-contract-marketplace/Makefile
-- [ ] GUI/smart-contract-marketplace/README.md
-- [ ] GUI/smart-contract-marketplace/ci/.gitkeep
-- [ ] GUI/smart-contract-marketplace/ci/pipeline.yml
-- [ ] GUI/smart-contract-marketplace/config/.gitkeep
-- [ ] GUI/smart-contract-marketplace/config/production.ts
-- [ ] GUI/smart-contract-marketplace/docker-compose.yml
-- [ ] GUI/smart-contract-marketplace/docs/.gitkeep
-- [ ] GUI/smart-contract-marketplace/docs/README.md
-- [ ] GUI/smart-contract-marketplace/jest.config.js
+- [x] GUI/security-operations-center/tests/e2e/example.e2e.test.ts – e2e boots with API URL
+- [x] GUI/security-operations-center/tests/unit/.gitkeep – unit folder tracked
+- [x] GUI/security-operations-center/tests/unit/example.test.ts – verifies default API
+- [x] GUI/security-operations-center/tsconfig.json – unused checks enabled
+- [x] GUI/smart-contract-marketplace/.env.example – API and port placeholders
+- [x] GUI/smart-contract-marketplace/.eslintrc.json – lint for unused vars
+- [x] GUI/smart-contract-marketplace/.gitignore – ignore npm debug logs
+- [x] GUI/smart-contract-marketplace/.prettierrc – trailing comma option
+- [x] GUI/smart-contract-marketplace/Dockerfile – reproducible installs
+- [x] GUI/smart-contract-marketplace/Makefile – lint and format targets
+- [x] GUI/smart-contract-marketplace/README.md – document scripts and env
+- [x] GUI/smart-contract-marketplace/ci/.gitkeep – CI folder tracked
+- [x] GUI/smart-contract-marketplace/ci/pipeline.yml – npm ci, test, build
+- [x] GUI/smart-contract-marketplace/config/.gitkeep – config folder tracked
+- [x] GUI/smart-contract-marketplace/config/production.ts – default API URL
+- [x] GUI/smart-contract-marketplace/docker-compose.yml – API env wired
+- [x] GUI/smart-contract-marketplace/docs/.gitkeep – docs folder tracked
+- [x] GUI/smart-contract-marketplace/docs/README.md – expanded documentation
+- [x] GUI/smart-contract-marketplace/jest.config.js – tests include src and tests dirs
 
 **Stage 26**
 - [ ] GUI/smart-contract-marketplace/k8s/.gitkeep

--- a/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -21,7 +21,8 @@ can invoke for inter-network workflows.
 Stage 25 finalises node operations. Full, light, mining, mobile, optimisation,
 staking, watchtower and warfare nodes offer JSON emitting commands allowing the
 function web and external dashboards to orchestrate infrastructure with defined
-gas costs.
+gas costs. A security operations center and smart contract marketplace expose
+these capabilities through hardened GUIs backed by CLI hooks.
 Stage 26 extends operational visibility with gas table controls. Operators can
 adjust opcode pricing on the fly and export the entire schedule as JSON,
 enabling governance portals and monitoring systems to consume pricing data

--- a/docs/reference/gas_table_list.md
+++ b/docs/reference/gas_table_list.md
@@ -734,6 +734,9 @@
 | `IPFS_Add` | `1000` |
 | `IPFS_Get` | `400` |
 | `IPFS_Unpin` | `200` |
+<!-- Stage 25 security operations and marketplace -->
+| `Security_RaiseAlert` | `150` |
+| `Marketplace_ListContract` | `80` |
 <!-- Stage 36 NFT marketplace operations -->
 | `MintNFT` | `1200` |
 | `ListNFT` | `100` |

--- a/gas_table_test.go
+++ b/gas_table_test.go
@@ -2,6 +2,18 @@ package synnergy
 
 import "testing"
 
-func TestGastablePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestGasTableIncludesNewOpcodes(t *testing.T) {
+	ResetGasTable()
+	if !HasOpcode("Security_RaiseAlert") {
+		t.Fatalf("missing Security_RaiseAlert opcode")
+	}
+	if GasCost("Security_RaiseAlert") != 150 {
+		t.Fatalf("unexpected cost for Security_RaiseAlert")
+	}
+	if !HasOpcode("Marketplace_ListContract") {
+		t.Fatalf("missing Marketplace_ListContract opcode")
+	}
+	if GasCost("Marketplace_ListContract") != 80 {
+		t.Fatalf("unexpected cost for Marketplace_ListContract")
+	}
 }

--- a/snvm._opcodes.go
+++ b/snvm._opcodes.go
@@ -1272,6 +1272,8 @@ var SNVMOpcodes = []SNVMOpcode{
 	{"core_nft_marketplace_Buy", 0x0004EC},
 	{"gui_data_distribution_monitor_Status", 0x0004ED},
 	{"gui_dex_screener_Liquidity", 0x0004EE},
+	{"gui_security_operations_RaiseAlert", 0x0004EF},
+	{"gui_smart_contract_marketplace_ListContract", 0x0004F0},
 }
 
 // SNVMOpcodeByName returns the opcode for a given function identifier.

--- a/snvm._opcodes_test.go
+++ b/snvm._opcodes_test.go
@@ -3,8 +3,13 @@ package synnergy
 import "testing"
 
 func TestSNVMOpcodeLookup(t *testing.T) {
-	code := SNVMOpcodeByName("gui_dex_screener_Liquidity")
-	if code != 0x0004EE {
+	if code := SNVMOpcodeByName("gui_dex_screener_Liquidity"); code != 0x0004EE {
+		t.Fatalf("unexpected opcode: %#x", code)
+	}
+	if code := SNVMOpcodeByName("gui_security_operations_RaiseAlert"); code != 0x0004EF {
+		t.Fatalf("unexpected opcode: %#x", code)
+	}
+	if code := SNVMOpcodeByName("gui_smart_contract_marketplace_ListContract"); code != 0x0004F0 {
 		t.Fatalf("unexpected opcode: %#x", code)
 	}
 }


### PR DESCRIPTION
## Summary
- expand security-operations-center test suite and tighten TypeScript compiler checks
- flesh out smart-contract-marketplace scaffold with linting, CI, docs and tests
- introduce SNVM opcodes and gas costs for security alerting and contract listings

## Testing
- `npm test --prefix GUI/security-operations-center`
- `npm test --prefix GUI/smart-contract-marketplace`
- `go test`


------
https://chatgpt.com/codex/tasks/task_e_68ba125428e883209aec54e57fc35793