### PR TITLE
chore: scaffold system analytics dashboard

### DIFF
--- a/GUI/system-analytics-dashboard/ci/pipeline.yml
+++ b/GUI/system-analytics-dashboard/ci/pipeline.yml
@@ -1,1 +1,24 @@
-# Placeholder CI pipeline for system-analytics-dashboard
+name: system-analytics-dashboard CI
+
+on:
+  push:
+    paths:
+      - 'GUI/system-analytics-dashboard/**'
+  pull_request:
+    paths:
+      - 'GUI/system-analytics-dashboard/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+        working-directory: GUI/system-analytics-dashboard
+      - run: npm test
+        working-directory: GUI/system-analytics-dashboard
+      - run: npm run build
+        working-directory: GUI/system-analytics-dashboard

--- a/GUI/system-analytics-dashboard/config/production.ts
+++ b/GUI/system-analytics-dashboard/config/production.ts
@@ -1,3 +1,11 @@
-export default {
-  apiUrl: process.env.API_URL || ''
+interface ProdConfig {
+  apiUrl: string;
+  port: number;
+}
+
+const config: ProdConfig = {
+  apiUrl: process.env.API_URL || 'https://api.synnergy.local',
+  port: Number(process.env.PORT) || 3000,
 };
+
+export default config;

--- a/GUI/system-analytics-dashboard/docker-compose.yml
+++ b/GUI/system-analytics-dashboard/docker-compose.yml
@@ -2,5 +2,8 @@ version: '3'
 services:
   app:
     build: .
+    environment:
+      - API_URL=${API_URL:-https://api.synnergy.local}
     ports:
       - "3000:3000"
+    restart: unless-stopped

--- a/GUI/system-analytics-dashboard/docs/README.md
+++ b/GUI/system-analytics-dashboard/docs/README.md
@@ -1,3 +1,7 @@
 # System Analytics Dashboard Documentation
 
-Additional documentation for System Analytics Dashboard.
+This directory contains design and operational notes for the System Analytics Dashboard.
+
+## Overview
+
+The dashboard visualizes real-time network metrics and exposes a simple CLI entry point for automation.

--- a/GUI/system-analytics-dashboard/jest.config.js
+++ b/GUI/system-analytics-dashboard/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src']
+  roots: ['<rootDir>/src'],
+  collectCoverage: true,
 };

--- a/GUI/system-analytics-dashboard/k8s/deployment.yaml
+++ b/GUI/system-analytics-dashboard/k8s/deployment.yaml
@@ -16,4 +16,7 @@ spec:
         - name: system-analytics-dashboard
           image: system-analytics-dashboard:latest
           ports:
-            - containerPort: 80
+            - containerPort: 3000
+          env:
+            - name: API_URL
+              value: https://api.synnergy.local

--- a/GUI/system-analytics-dashboard/package.json
+++ b/GUI/system-analytics-dashboard/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/main.js",
-    "test": "echo \"No tests yet\"",
+    "test": "jest",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/GUI/system-analytics-dashboard/src/main.test.ts
+++ b/GUI/system-analytics-dashboard/src/main.test.ts
@@ -1,5 +1,16 @@
 import { main } from './main';
 
-test('main returns greeting', () => {
-  expect(main()).toContain('system-analytics-dashboard');
+beforeEach(() => {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status: 'OK' }),
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('main returns analytics status', async () => {
+  await expect(main()).resolves.toContain('System analytics: OK');
 });

--- a/GUI/system-analytics-dashboard/src/main.ts
+++ b/GUI/system-analytics-dashboard/src/main.ts
@@ -1,7 +1,21 @@
-export function main(): string {
-  return 'Hello from system-analytics-dashboard';
+import config from '../config/production';
+
+export async function main(): Promise<string> {
+  try {
+    const res = await fetch(`${config.apiUrl}/metrics`);
+    if (!res.ok) throw new Error('request failed');
+    const data = await res.json();
+    return `System analytics: ${data.status}`;
+  } catch {
+    return 'System analytics: ERROR';
+  }
 }
 
 if (require.main === module) {
-  console.log(main());
+  main()
+    .then((output) => console.log(output))
+    .catch((err) => {
+      console.error('Failed to start system-analytics-dashboard', err);
+      process.exit(1);
+    });
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -32,6 +32,8 @@
 - Stage 25: Completed – security tests and smart-contract-marketplace config hardened.
 - Stage 26: Completed – smart-contract-marketplace API server, docs and tests added.
 - Stage 27: Completed – storage-marketplace GUI scaffold with configs, Docker and CI.
+- Stage 28: Completed – storage marketplace module finalized and system analytics dashboard scaffold created.
+- Stage 29: Completed – system analytics dashboard CI pipeline, configuration and tests established.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -611,7 +613,7 @@
 - [x] GUI/system-analytics-dashboard/README.md
 - [x] GUI/system-analytics-dashboard/ci/.gitkeep
 
-**Stage 29**
+**Stage 29** ✅ Completed – system analytics dashboard CI, config and tests established
 - [ ] GUI/system-analytics-dashboard/ci/pipeline.yml
 - [ ] GUI/system-analytics-dashboard/config/.gitkeep
 - [ ] GUI/system-analytics-dashboard/config/production.ts
@@ -5666,27 +5668,27 @@
 | 28 | GUI/system-analytics-dashboard/.prettierrc | [ ] |
 | 28 | GUI/system-analytics-dashboard/Dockerfile | [ ] |
 | 28 | GUI/system-analytics-dashboard/Makefile | [ ] |
-| 28 | GUI/system-analytics-dashboard/README.md | [ ] |
-| 28 | GUI/system-analytics-dashboard/ci/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/ci/pipeline.yml | [ ] |
-| 29 | GUI/system-analytics-dashboard/config/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/config/production.ts | [ ] |
-| 29 | GUI/system-analytics-dashboard/docker-compose.yml | [ ] |
-| 29 | GUI/system-analytics-dashboard/docs/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/docs/README.md | [ ] |
-| 29 | GUI/system-analytics-dashboard/jest.config.js | [ ] |
-| 29 | GUI/system-analytics-dashboard/k8s/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/k8s/deployment.yaml | [ ] |
-| 29 | GUI/system-analytics-dashboard/package-lock.json | [ ] |
-| 29 | GUI/system-analytics-dashboard/package.json | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/components/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/hooks/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/main.test.ts | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/main.ts | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/pages/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/services/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/state/.gitkeep | [ ] |
-| 29 | GUI/system-analytics-dashboard/src/styles/.gitkeep | [ ] |
+| 28 | GUI/system-analytics-dashboard/README.md | [x] |
+| 28 | GUI/system-analytics-dashboard/ci/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/ci/pipeline.yml | [x] |
+| 29 | GUI/system-analytics-dashboard/config/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/config/production.ts | [x] |
+| 29 | GUI/system-analytics-dashboard/docker-compose.yml | [x] |
+| 29 | GUI/system-analytics-dashboard/docs/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/docs/README.md | [x] |
+| 29 | GUI/system-analytics-dashboard/jest.config.js | [x] |
+| 29 | GUI/system-analytics-dashboard/k8s/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/k8s/deployment.yaml | [x] |
+| 29 | GUI/system-analytics-dashboard/package-lock.json | [x] |
+| 29 | GUI/system-analytics-dashboard/package.json | [x] |
+| 29 | GUI/system-analytics-dashboard/src/components/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/src/hooks/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/src/main.test.ts | [x] |
+| 29 | GUI/system-analytics-dashboard/src/main.ts | [x] |
+| 29 | GUI/system-analytics-dashboard/src/pages/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/src/services/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/src/state/.gitkeep | [x] |
+| 29 | GUI/system-analytics-dashboard/src/styles/.gitkeep | [x] |
 | 30 | GUI/system-analytics-dashboard/tests/e2e/.gitkeep | [ ] |
 | 30 | GUI/system-analytics-dashboard/tests/e2e/example.e2e.test.ts | [ ] |
 | 30 | GUI/system-analytics-dashboard/tests/unit/.gitkeep | [ ] |


### PR DESCRIPTION
## Summary
- set up CI pipeline and deployment config for system analytics dashboard
- wire dashboard entry point to fetch metrics with tests
- mark stage 29 as complete in agent tracker

## Testing
- `cd GUI/system-analytics-dashboard && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1b5b8a4c8320954e71bc5d4b6021