### PR TITLE
feat(cli): harden audit commands with validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Run `./synnergy --help` for the full command tree. Common modules include:
 | `contracts compile|deploy|invoke|list|info` | WASM smart contract lifecycle through `core.NewContractRegistry` |
 | `system_health snapshot|log` | Emit metrics and structured logs |
 | `data monitor status` | Report network data distribution metrics |
+| `audit log|list` | Record and query audit events via `core.NewAuditManager` |
+| `audit_node start|log|list` | Operate a bootstrap audit node for network-wide logs |
 | `dex liquidity <pair>` | Query on-chain liquidity pool reserves |
 
 Additional modules cover DAO governance, cross-chain bridges, regulatory nodes, watchtowers and more.

--- a/cli/audit.go
+++ b/cli/audit.go
@@ -19,6 +19,10 @@ func init() {
 		Args:  cobra.MinimumNArgs(2),
 		Short: "Record an audit event",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			addr, err := core.StringToAddress(args[0])
+			if err != nil {
+				return err
+			}
 			meta := make(map[string]string)
 			for _, kv := range args[2:] {
 				parts := strings.SplitN(kv, "=", 2)
@@ -26,7 +30,7 @@ func init() {
 					meta[parts[0]] = parts[1]
 				}
 			}
-			return auditManager.Log(args[0], args[1], meta)
+			return auditManager.Log(addr.Hex(), args[1], meta)
 		},
 	}
 
@@ -36,7 +40,11 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Short: "List audit events for an address",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			entries := auditManager.List(args[0])
+			addr, err := core.StringToAddress(args[0])
+			if err != nil {
+				return err
+			}
+			entries := auditManager.List(addr.Hex())
 			if jsonOut {
 				b, err := json.MarshalIndent(entries, "", "  ")
 				if err != nil {

--- a/cli/audit_node.go
+++ b/cli/audit_node.go
@@ -34,6 +34,10 @@ func init() {
 		Args:  cobra.MinimumNArgs(2),
 		Short: "Log event through audit node",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			addr, err := core.StringToAddress(args[0])
+			if err != nil {
+				return err
+			}
 			meta := make(map[string]string)
 			for _, kv := range args[2:] {
 				parts := strings.SplitN(kv, "=", 2)
@@ -41,7 +45,7 @@ func init() {
 					meta[parts[0]] = parts[1]
 				}
 			}
-			return auditNode.LogEvent(args[0], args[1], meta)
+			return auditNode.LogEvent(addr.Hex(), args[1], meta)
 		},
 	}
 
@@ -51,7 +55,11 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Short: "List events via audit node",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			entries := auditNode.ListEvents(args[0])
+			addr, err := core.StringToAddress(args[0])
+			if err != nil {
+				return err
+			}
+			entries := auditNode.ListEvents(addr.Hex())
 			if jsonOut {
 				b, err := json.MarshalIndent(entries, "", "  ")
 				if err != nil {

--- a/cli/audit_node_test.go
+++ b/cli/audit_node_test.go
@@ -1,7 +1,34 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
-func TestAuditnodePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestAuditNodeStart(t *testing.T) {
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audit_node", "start"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("start command failed: %v", err)
+	}
+}
+
+func TestAuditNodeLogAndList(t *testing.T) {
+	addr := "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audit_node", "log", addr, "update"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("log command failed: %v", err)
+	}
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"audit_node", "list", addr})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "update") {
+		t.Fatalf("expected update event, got %s", buf.String())
+	}
 }

--- a/cli/audit_test.go
+++ b/cli/audit_test.go
@@ -1,7 +1,26 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
-func TestAuditPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestAuditLogAndList(t *testing.T) {
+	addr := "0x1234567890abcdef1234567890abcdef12345678"
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audit", "log", addr, "login"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("log command failed: %v", err)
+	}
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"audit", "list", addr})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+	if !strings.Contains(buf.String(), "login") {
+		t.Fatalf("expected login event, got %s", buf.String())
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -42,6 +42,7 @@
 - Stage 36: Completed – wallet GUI configuration, documentation and tests enhanced.
 - Stage 37: Completed – core security and AI modules upgraded with tests and encryption.
 - Stage 38: In Progress – AI storage, training and anomaly detection modules tested; biometric security and CLI components pending.
+- Stage 39: In Progress – audit CLI and audit node validated with address checks and tests; authority and bank CLI modules pending.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -833,10 +834,10 @@
 - [ ] cli/ai_contract_test.go
 
 **Stage 39**
-- [ ] cli/audit.go
-- [ ] cli/audit_node.go
-- [ ] cli/audit_node_test.go
-- [ ] cli/audit_test.go
+- [x] cli/audit.go
+- [x] cli/audit_node.go
+- [x] cli/audit_node_test.go
+- [x] cli/audit_test.go
 - [ ] cli/authority_apply.go
 - [ ] cli/authority_apply_test.go
 - [ ] cli/authority_node_index.go


### PR DESCRIPTION
## Summary
- validate addresses for `audit` and `audit_node` commands
- add CLI tests for audit logging and listing
- document audit commands and mark Stage 39 progress

## Testing
- `go test ./cli/...`


------
https://chatgpt.com/codex/tasks/task_e_68ba3295d708832085f52eba18398f64