### PR TITLE
test: add authority and bank CLI coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Run `./synnergy --help` for the full command tree. Common modules include:
 | `data monitor status` | Report network data distribution metrics |
 | `audit log|list` | Record and query audit events via `core.NewAuditManager` |
 | `audit_node start|log|list` | Operate a bootstrap audit node for network-wide logs |
+| `authority register|vote|list` | Manage the authority node registry (`core.NewAuthorityNodeRegistry`) |
+| `authority_apply submit|vote|finalize|list` | Handle authority node applications (`core.NewAuthorityApplicationManager`) |
+| `bankinst register|list|is` | Manage institutional bank participants (`core.NewBankInstitutionalNode`) |
+| `banknodes types` | Display supported bank node categories |
+| `basenode start|stop|running|peers|dial` | Control a base network node (`core.NewBaseNode`) |
+| `basetoken init|mint|balance` | Interact with a basic token (`tokens.NewBaseToken`) |
 | `dex liquidity <pair>` | Query on-chain liquidity pool reserves |
 
 Additional modules cover DAO governance, cross-chain bridges, regulatory nodes, watchtowers and more.

--- a/cli/authority_apply_test.go
+++ b/cli/authority_apply_test.go
@@ -1,7 +1,37 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+	"time"
 
-func TestAuthorityapplyPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestAuthorityApplySubmit exercises the authority application workflow via the CLI
+// to ensure candidates can be submitted and subsequently listed.
+func TestAuthorityApplySubmit(t *testing.T) {
+	// reset global state used by the CLI commands
+	authorityRegistry = core.NewAuthorityNodeRegistry()
+	applyManager = core.NewAuthorityApplicationManager(authorityRegistry, time.Hour)
+
+	// submit an application
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"authority_apply", "submit", "node1", "validator", "desc"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("submit failed: %v", err)
+	}
+
+	// ensure application stored
+	apps := applyManager.List()
+	if len(apps) != 1 || apps[0].Candidate != "node1" {
+		t.Fatalf("unexpected applications: %+v", apps)
+	}
+
+	// list via CLI to ensure command executes without error
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"authority_apply", "list"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
 }

--- a/cli/authority_node_index_test.go
+++ b/cli/authority_node_index_test.go
@@ -1,7 +1,23 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"testing"
 
-func TestAuthoritynodeindexPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestAuthorityNodeIndexAdd ensures nodes can be added and retrieved via the CLI.
+func TestAuthorityNodeIndexAdd(t *testing.T) {
+	authorityIndex = core.NewAuthorityNodeIndex()
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"authority_index", "add", "addr1", "validator"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	if _, ok := authorityIndex.Get("addr1"); !ok {
+		t.Fatalf("node not indexed")
+	}
 }

--- a/cli/authority_nodes_test.go
+++ b/cli/authority_nodes_test.go
@@ -1,7 +1,23 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"testing"
 
-func TestAuthoritynodesPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestAuthorityRegister verifies authority node registration through the CLI.
+func TestAuthorityRegister(t *testing.T) {
+	authorityReg = core.NewAuthorityNodeRegistry()
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"authority", "register", "addr1", "validator"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	if !authorityReg.IsAuthorityNode("addr1") {
+		t.Fatalf("address not registered")
+	}
 }

--- a/cli/bank_institutional_node_test.go
+++ b/cli/bank_institutional_node_test.go
@@ -1,7 +1,24 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"testing"
 
-func TestBankinstitutionalnodePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestBankInstitutionalRegister ensures institutions can enrol via the CLI.
+func TestBankInstitutionalRegister(t *testing.T) {
+	ledger = core.NewLedger()
+	bankInstNode = core.NewBankInstitutionalNode("bank1", "addr1", ledger)
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"bankinst", "register", "BankA"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	if !bankInstNode.IsRegistered("BankA") {
+		t.Fatalf("bank not registered")
+	}
 }

--- a/cli/bank_nodes_index_test.go
+++ b/cli/bank_nodes_index_test.go
@@ -1,7 +1,35 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
 
-func TestBanknodesindexPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestBankNodeTypes lists available bank node types via the CLI and verifies output.
+func TestBankNodeTypes(t *testing.T) {
+	output := captureOutput(func() {
+		rootCmd.SetArgs([]string{"banknodes", "types"})
+		_ = rootCmd.Execute()
+	})
+
+	if !strings.Contains(output, core.BankInstitutionalNodeType) {
+		t.Fatalf("expected bank node types in output, got %s", output)
+	}
+}
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
 }

--- a/cli/base_node_test.go
+++ b/cli/base_node_test.go
@@ -1,7 +1,32 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"testing"
 
-func TestBasenodePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+	"synnergy/internal/nodes"
+)
+
+// TestBaseNodeLifecycle verifies basic start/stop behaviour via the CLI.
+func TestBaseNodeLifecycle(t *testing.T) {
+	baseNode = core.NewBaseNode(nodes.Address("base1"))
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"basenode", "start"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	if !baseNode.IsRunning() {
+		t.Fatalf("node should be running")
+	}
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"basenode", "stop"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
+	if baseNode.IsRunning() {
+		t.Fatalf("node should be stopped")
+	}
 }

--- a/cli/base_token_test.go
+++ b/cli/base_token_test.go
@@ -1,7 +1,30 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"testing"
 
-func TestBasetokenPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/internal/tokens"
+)
+
+// TestBaseTokenMint ensures base token initialisation and minting work via the CLI.
+func TestBaseTokenMint(t *testing.T) {
+	tokenRegistry = tokens.NewRegistry()
+	baseToken = nil
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"basetoken", "init", "--name", "Base", "--symbol", "B", "--decimals", "18"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"basetoken", "mint", "alice", "100"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("mint failed: %v", err)
+	}
+
+	if baseToken.BalanceOf("alice") != 100 {
+		t.Fatalf("expected balance 100, got %d", baseToken.BalanceOf("alice"))
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -42,7 +42,7 @@
 - Stage 36: Completed – wallet GUI configuration, documentation and tests enhanced.
 - Stage 37: Completed – core security and AI modules upgraded with tests and encryption.
 - Stage 38: Completed – biometric security node and CLI components finalised with tests.
-- Stage 39: In Progress – audit CLI and audit node validated with address checks and tests; authority and bank CLI modules pending.
+- Stage 39: Completed – authority and bank CLI modules validated with unit tests.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -838,21 +838,21 @@
 - [x] cli/audit_node.go
 - [x] cli/audit_node_test.go
 - [x] cli/audit_test.go
-- [ ] cli/authority_apply.go
-- [ ] cli/authority_apply_test.go
-- [ ] cli/authority_node_index.go
-- [ ] cli/authority_node_index_test.go
-- [ ] cli/authority_nodes.go
-- [ ] cli/authority_nodes_test.go
-- [ ] cli/bank_institutional_node.go
-- [ ] cli/bank_institutional_node_test.go
-- [ ] cli/bank_nodes_index.go
-- [ ] cli/bank_nodes_index_test.go
-- [ ] cli/base_node.go
-- [ ] cli/base_node_test.go
-- [ ] cli/base_token.go
-- [ ] cli/base_token_test.go
-- [ ] cli/biometric.go
+- [x] cli/authority_apply.go
+- [x] cli/authority_apply_test.go
+- [x] cli/authority_node_index.go
+- [x] cli/authority_node_index_test.go
+- [x] cli/authority_nodes.go
+- [x] cli/authority_nodes_test.go
+- [x] cli/bank_institutional_node.go
+- [x] cli/bank_institutional_node_test.go
+- [x] cli/bank_nodes_index.go
+- [x] cli/bank_nodes_index_test.go
+- [x] cli/base_node.go
+- [x] cli/base_node_test.go
+- [x] cli/base_token.go
+- [x] cli/base_token_test.go
+- [x] cli/biometric.go
 
 **Stage 40**
 - [ ] cli/biometric_security_node.go

--- a/docs/Whitepaper_detailed/How to use the CLI.md
+++ b/docs/Whitepaper_detailed/How to use the CLI.md
@@ -1,9 +1,20 @@
 # How to use the CLI
 
 The `synnergy` binary exposes network and contract functionality.
-Stage 39 extends the toolset with liquidity pool commands used by the DEX screener.
+Stage 39 extends the toolset with authority governance and banking commands alongside liquidity pool utilities used by the DEX screener.
 
 ```bash
+# Manage authority applications and node membership
+synnergy authority_apply submit node1 validator "candidate node"
+synnergy authority_apply list --json
+synnergy authority register node1 validator
+synnergy authority is node1
+
+# Register participating institutions and inspect supported node types
+synnergy bankinst register MyBank
+synnergy bankinst list
+synnergy banknodes types
+
 # Create a new liquidity pool with default fee
 synnergy liquidity_pools create TOKENA TOKENB
 


### PR DESCRIPTION
## Summary
- add unit tests for authority applications, node registry, bank modules, base node, and base token
- document new authority and banking commands in CLI guide and README
- mark Stage 39 complete in AGENTS tracker

## Testing
- `go test ./cli -count=1`
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba367fe18c8320a2294bf1a2340c09