### PR TITLE
feat(cli): add central bank RunE handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Synnergy is a modular, high-performance blockchain written in Go and built for e
 - **Role-based security** – biometric authentication and security node CLI (`core.NewBiometricService`, `synnergy bioauth`, `synnergy bsn`), zero‑trust data channels and PKI tooling.
 - **Extensible CLI** – built with [Cobra](https://github.com/spf13/cobra) and backed by `cli.Execute()`.
 - **Validated block utilities** – Stage 40 adds sub-block creation and block assembly commands with strict argument checking.
+- **Central bank controls** – `synnergy centralbank` manages monetary policy and CBDC issuance with structured JSON output.
 - **Data distribution monitor** – CLI and GUI for network telemetry.
 - **Node operations dashboard** – TypeScript CLI and GUI for real-time node health monitoring.
 - **Security operations center** – monitors and aggregates security events with a CLI-accessible GUI.

--- a/cli/centralbank.go
+++ b/cli/centralbank.go
@@ -19,17 +19,28 @@ func init() {
 	cbCmd := &cobra.Command{Use: "centralbank", Short: "Central bank node operations"}
 	cbCmd.PersistentFlags().BoolVar(&centralBankJSON, "json", false, "output as JSON")
 
-	infoCmd := &cobra.Command{Use: "info", Short: "Show node info", Run: func(cmd *cobra.Command, args []string) {
-		if centralBankJSON {
-			_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"id": centralBank.ID, "address": centralBank.Addr, "policy": centralBank.MonetaryPolicy})
-		} else {
-			fmt.Printf("id: %s address: %s policy: %s\n", centralBank.ID, centralBank.Addr, centralBank.MonetaryPolicy)
-		}
-	}}
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show node info",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if centralBankJSON {
+				enc := json.NewEncoder(os.Stdout)
+				return enc.Encode(map[string]string{"id": centralBank.ID, "address": centralBank.Addr, "policy": centralBank.MonetaryPolicy})
+			}
+			fmt.Fprintf(os.Stdout, "id: %s address: %s policy: %s\n", centralBank.ID, centralBank.Addr, centralBank.MonetaryPolicy)
+			return nil
+		},
+	}
 
-	policyCmd := &cobra.Command{Use: "policy [description]", Args: cobra.ExactArgs(1), Short: "Update monetary policy", Run: func(cmd *cobra.Command, args []string) {
-		centralBank.UpdatePolicy(args[0])
-	}}
+	policyCmd := &cobra.Command{
+		Use:   "policy [description]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Update monetary policy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			centralBank.UpdatePolicy(args[0])
+			return nil
+		},
+	}
 
 	mintCmd := &cobra.Command{Use: "mint [to] [amount]", Args: cobra.ExactArgs(2), Short: "Mint CBDC tokens", RunE: func(cmd *cobra.Command, args []string) error {
 		amt, _ := strconv.ParseUint(args[1], 10, 64)

--- a/cli/centralbank_test.go
+++ b/cli/centralbank_test.go
@@ -1,7 +1,20 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestCentralbankPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestCentralbankInfo ensures the info subcommand emits basic node details.
+func TestCentralbankInfo(t *testing.T) {
+	out, err := execCommand("centralbank", "info")
+	if err != nil {
+		t.Fatalf("info failed: %v", err)
+	}
+	if out == "" || out == "\n" {
+		t.Fatalf("expected output, got %q", out)
+	}
+	if !strings.Contains(out, "id:") {
+		t.Fatalf("missing id in output: %s", out)
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -43,7 +43,7 @@
 - Stage 37: Completed – core security and AI modules upgraded with tests and encryption.
 - Stage 38: Completed – biometric security node and CLI components finalised with tests.
 - Stage 39: Completed – authority and bank CLI modules validated with unit tests.
-- Stage 40: In Progress – block CLI refactored with validation; remaining modules pending.
+- Stage 40: In Progress – block CLI refactored with validation; central bank command emits structured JSON with RunE handlers; remaining modules pending.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -863,8 +863,8 @@
 - [ ] cli/biometrics_auth_test.go
 - [x] cli/block.go – added argument validation and RunE handlers
 - [x] cli/block_test.go – covered block creation and header hashing
-- [ ] cli/centralbank.go
-- [ ] cli/centralbank_test.go
+ - [x] cli/centralbank.go – RunE handlers and JSON output support
+ - [x] cli/centralbank_test.go – verifies info subcommand
 - [ ] cli/charity.go
 - [ ] cli/charity_test.go
 - [ ] cli/cli_core_test.go
@@ -3446,8 +3446,8 @@
 - [ ] cli/biometrics_auth_test.go
 - [ ] cli/block.go
 - [ ] cli/block_test.go
-- [ ] cli/centralbank.go
-- [ ] cli/centralbank_test.go
+ - [x] cli/centralbank.go
+ - [x] cli/centralbank_test.go
 - [ ] cli/charity.go
 - [ ] cli/charity_test.go
 - [ ] cli/cli_core_test.go
@@ -5897,8 +5897,8 @@
 | 40 | cli/biometrics_auth_test.go | [ ] |
 | 40 | cli/block.go | [x] |
 | 40 | cli/block_test.go | [x] |
-| 40 | cli/centralbank.go | [ ] |
-| 40 | cli/centralbank_test.go | [ ] |
+| 40 | cli/centralbank.go | [x] |
+| 40 | cli/centralbank_test.go | [x] |
 | 40 | cli/charity.go | [ ] |
 | 40 | cli/charity_test.go | [ ] |
 | 40 | cli/cli_core_test.go | [ ] |

--- a/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -56,7 +56,7 @@ Stage 36 adds an NFT marketplace GUI driven by the `nft` CLI module so
 applications can mint and trade unique assets within the function web.
 Stage 38 introduces a token creation tool GUI that generates token contracts through the CLI and finalises biometric security node commands, enabling dashboards to craft new assets and enforce biometric verification within the function web.
 Stage 39 adds a DEX Screener GUI that leverages `liquidity_views` commands so interfaces can stream pool reserves and fees.
-Stage 40 introduces administrative dashboards for authority node indexing and cross-chain management, exposing node and bridge status through CLI-driven views.
+Stage 40 introduces administrative dashboards for authority node indexing and cross-chain management, exposing node and bridge status through CLI-driven views. The central bank module joins the function web at this stage, allowing monetary policy updates and CBDC issuance to be orchestrated alongside other network services via `synnergy centralbank`.
 Stage 44 adds a smart contract test harness exercising the token faucet template through the CLI, ensuring contract modules function reliably across the function web.
 Stage 46 introduces an automated network harness that assembles wallet services
 and in-memory nodes to verify end-to-end transaction propagation and gas


### PR DESCRIPTION
## Summary
- add RunE error handling and JSON output to `centralbank` CLI command
- document central bank CLI in README and function web guide
- track Stage 40 progress in `docs/AGENTS.md`

## Testing
- `go test ./cli -run TestCentralbankInfo -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba3ac11f108320bbbd49194101e696