### PR TITLE
Add basic CLI tests for consensus and contract management

### DIFF
--- a/cli/compression_test.go
+++ b/cli/compression_test.go
@@ -1,7 +1,32 @@
 package cli
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
-func TestCompressionPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestCompressionSaveLoad verifies snapshot save/load cycle with JSON output.
+func TestCompressionSaveLoad(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "snap-*.bin")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	f.Close()
+
+	out, err := execCommand("compression", "--json", "save", f.Name())
+	if err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+	if !strings.Contains(out, "\"status\":\"saved\"") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	out, err = execCommand("compression", "--json", "load", f.Name())
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if !strings.Contains(out, "\"height\"") {
+		t.Fatalf("unexpected output: %s", out)
+	}
 }

--- a/cli/connpool_test.go
+++ b/cli/connpool_test.go
@@ -1,7 +1,20 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestConnpoolPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestConnPoolStatsAndClose ensures pool stats are printed and the pool closes.
+func TestConnPoolStatsAndClose(t *testing.T) {
+	out, err := execCommand("connpool", "stats")
+	if err != nil {
+		t.Fatalf("stats failed: %v", err)
+	}
+	if !strings.Contains(out, "active:") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	if _, err := execCommand("connpool", "close"); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
 }

--- a/cli/consensus_test.go
+++ b/cli/consensus_test.go
@@ -1,7 +1,17 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestConsensusPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestConsensusWeights ensures consensus weights command prints expected values.
+func TestConsensusWeights(t *testing.T) {
+	out, err := execCommand("consensus", "weights")
+	if err != nil {
+		t.Fatalf("weights failed: %v", err)
+	}
+	if !strings.Contains(out, "PoW") || !strings.Contains(out, "PoS") {
+		t.Fatalf("unexpected output: %s", out)
+	}
 }

--- a/cli/contract_management_test.go
+++ b/cli/contract_management_test.go
@@ -1,7 +1,17 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestContractmanagementPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestContractManagerInfoError checks that querying a missing contract prints an error.
+func TestContractManagerInfoError(t *testing.T) {
+	out, err := execCommand("contract-mgr", "info", "missing")
+	if err != nil {
+		t.Fatalf("info failed: %v", err)
+	}
+	if !strings.Contains(out, "error") {
+		t.Fatalf("expected error output, got %q", out)
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -44,6 +44,7 @@
 - Stage 38: Completed – biometric security node and CLI components finalised with tests.
 - Stage 39: Completed – authority and bank CLI modules validated with unit tests.
 - Stage 40: Completed – biometric security, compliance and compression CLIs now emit validated JSON responses with unit tests; block, central bank and coin utilities fully validated.
+- Stage 41: In Progress – initial CLI tests added for compression, connection pooling, consensus and contract management; remaining CLI upgrades pending.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -877,9 +878,9 @@
  - [x] cli/compression.go – JSON snapshot save/load
 
 **Stage 41**
-- [ ] cli/compression_test.go
+- [x] cli/compression_test.go
 - [ ] cli/connpool.go
-- [ ] cli/connpool_test.go
+- [x] cli/connpool_test.go
 - [ ] cli/consensus.go
 - [ ] cli/consensus_adaptive_management.go
 - [ ] cli/consensus_adaptive_management_test.go
@@ -891,9 +892,9 @@
 - [ ] cli/consensus_service_test.go
 - [ ] cli/consensus_specific_node.go
 - [ ] cli/consensus_specific_node_test.go
-- [ ] cli/consensus_test.go
+- [x] cli/consensus_test.go
 - [ ] cli/contract_management.go
-- [ ] cli/contract_management_test.go
+- [x] cli/contract_management_test.go
 - [ ] cli/contracts.go
 - [ ] cli/contracts_opcodes.go
 


### PR DESCRIPTION
## Summary
- add unit test covering compression snapshot save/load
- add connection pool stats/close test
- add consensus weights CLI test
- add contract manager info error test
- record partial Stage 41 progress in AGENTS tracker

## Testing
- `go test ./cli -run 'TestCompressionSaveLoad|TestConnPoolStatsAndClose|TestConsensusWeights|TestContractManagerInfoError' -v`


------
https://chatgpt.com/codex/tasks/task_e_68ba44bcbf948320ac724fd322fe7c59