### PR TITLE
feat(cli): enhance connpool and opcode visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Synnergy is a modular, high-performance blockchain written in Go and built for e
 - **Gas accounting** – deterministic costs loaded via `synnergy.LoadGasTable()` and registered with `synnergy.RegisterGasCost()`.
 - **Role-based security** – biometric authentication and security node CLI (`core.NewBiometricService`, `synnergy bioauth`, `synnergy bsn`), zero‑trust data channels and PKI tooling.
 - **Extensible CLI** – built with [Cobra](https://github.com/spf13/cobra) and backed by `cli.Execute()`.
+- **Resource-managed CLI** – connection pool commands can release individual peers and `contractopcodes` reports gas costs for contract operations.
 - **Validated block utilities** – Stage 40 adds sub-block creation and block assembly commands with strict argument checking.
 - **Central bank controls** – `synnergy centralbank` manages monetary policy and CBDC issuance with structured JSON output.
 - **Monetary policy utilities** – `synnergy coin` provides validated reward and supply queries with optional JSON.

--- a/cli/connpool.go
+++ b/cli/connpool.go
@@ -28,11 +28,16 @@ func init() {
 		return err
 	}}
 
+	releaseCmd := &cobra.Command{Use: "release [addr]", Args: cobra.ExactArgs(1), Short: "Release a connection from the pool", Run: func(cmd *cobra.Command, args []string) {
+		pool.Release(args[0])
+		ilog.Info("cli_pool_release", "id", args[0])
+	}}
+
 	closeCmd := &cobra.Command{Use: "close", Short: "Close the pool", Run: func(cmd *cobra.Command, args []string) {
 		pool.Close()
 		ilog.Info("cli_pool_close")
 	}}
 
-	poolCmd.AddCommand(statsCmd, dialCmd, closeCmd)
+	poolCmd.AddCommand(statsCmd, dialCmd, releaseCmd, closeCmd)
 	rootCmd.AddCommand(poolCmd)
 }

--- a/cli/connpool_test.go
+++ b/cli/connpool_test.go
@@ -5,14 +5,27 @@ import (
 	"testing"
 )
 
-// TestConnPoolStatsAndClose ensures pool stats are printed and the pool closes.
-func TestConnPoolStatsAndClose(t *testing.T) {
+// TestConnPoolLifecycle ensures the pool can dial, release and close connections.
+func TestConnPoolLifecycle(t *testing.T) {
+	if _, err := execCommand("connpool", "dial", "peer1"); err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
 	out, err := execCommand("connpool", "stats")
 	if err != nil {
 		t.Fatalf("stats failed: %v", err)
 	}
-	if !strings.Contains(out, "active:") {
-		t.Fatalf("unexpected output: %s", out)
+	if !strings.Contains(out, "active: 1") {
+		t.Fatalf("expected active 1, got %q", out)
+	}
+	if _, err := execCommand("connpool", "release", "peer1"); err != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+	out, err = execCommand("connpool", "stats")
+	if err != nil {
+		t.Fatalf("stats failed: %v", err)
+	}
+	if !strings.Contains(out, "active: 0") {
+		t.Fatalf("expected active 0, got %q", out)
 	}
 	if _, err := execCommand("connpool", "close"); err != nil {
 		t.Fatalf("close failed: %v", err)

--- a/cli/contracts_opcodes.go
+++ b/cli/contracts_opcodes.go
@@ -4,21 +4,30 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	synn "synnergy"
 	"synnergy/core"
 )
 
 func init() {
 	cmd := &cobra.Command{
 		Use:   "contractopcodes",
-		Short: "List contract-related opcodes",
+		Short: "List contract-related opcodes with gas costs",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "%d: OpInitContracts\n", core.OpInitContracts)
-			fmt.Fprintf(cmd.OutOrStdout(), "%d: OpPauseContract\n", core.OpPauseContract)
-			fmt.Fprintf(cmd.OutOrStdout(), "%d: OpResumeContract\n", core.OpResumeContract)
-			fmt.Fprintf(cmd.OutOrStdout(), "%d: OpUpgradeContract\n", core.OpUpgradeContract)
-			fmt.Fprintf(cmd.OutOrStdout(), "%d: OpContractInfo\n", core.OpContractInfo)
-			fmt.Fprintf(cmd.OutOrStdout(), "%d: OpDeployAIContract\n", core.OpDeployAIContract)
-			fmt.Fprintf(cmd.OutOrStdout(), "%d: OpInvokeAIContract\n", core.OpInvokeAIContract)
+			entries := []struct {
+				name string
+				op   core.Opcode
+			}{
+				{"InitContracts", core.OpInitContracts},
+				{"PauseContract", core.OpPauseContract},
+				{"ResumeContract", core.OpResumeContract},
+				{"UpgradeContract", core.OpUpgradeContract},
+				{"ContractInfo", core.OpContractInfo},
+				{"DeployAIContract", core.OpDeployAIContract},
+				{"InvokeAIContract", core.OpInvokeAIContract},
+			}
+			for _, e := range entries {
+				fmt.Fprintf(cmd.OutOrStdout(), "%d: %s (gas %d)\n", e.op, e.name, synn.GasCost(e.name))
+			}
 			return nil
 		},
 	}

--- a/cli/contracts_opcodes_test.go
+++ b/cli/contracts_opcodes_test.go
@@ -1,7 +1,17 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestContractsopcodesPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestContractOpcodesGas ensures opcode list includes gas costs.
+func TestContractOpcodesGas(t *testing.T) {
+	out, err := execCommand("contractopcodes")
+	if err != nil {
+		t.Fatalf("contractopcodes failed: %v", err)
+	}
+	if !strings.Contains(out, "gas") {
+		t.Fatalf("expected gas annotation, got %q", out)
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -44,7 +44,7 @@
 - Stage 38: Completed – biometric security node and CLI components finalised with tests.
 - Stage 39: Completed – authority and bank CLI modules validated with unit tests.
 - Stage 40: Completed – biometric security, compliance and compression CLIs now emit validated JSON responses with unit tests; block, central bank and coin utilities fully validated.
-- Stage 41: In Progress – initial CLI tests added for compression, connection pooling, consensus and contract management; remaining CLI upgrades pending.
+- Stage 41: In Progress – connection pool release command, gas-aware contract opcode listing and tests added; further consensus CLI upgrades pending.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -5911,8 +5911,8 @@
 | 40 | cli/compliance_test.go | [ ] |
 | 40 | cli/compression.go | [ ] |
 | 41 | cli/compression_test.go | [ ] |
-| 41 | cli/connpool.go | [ ] |
-| 41 | cli/connpool_test.go | [ ] |
+| 41 | cli/connpool.go | [x] | release command |
+| 41 | cli/connpool_test.go | [x] | lifecycle test |
 | 41 | cli/consensus.go | [ ] |
 | 41 | cli/consensus_adaptive_management.go | [ ] |
 | 41 | cli/consensus_adaptive_management_test.go | [ ] |
@@ -5928,7 +5928,7 @@
 | 41 | cli/contract_management.go | [ ] |
 | 41 | cli/contract_management_test.go | [ ] |
 | 41 | cli/contracts.go | [ ] |
-| 41 | cli/contracts_opcodes.go | [ ] |
+| 41 | cli/contracts_opcodes.go | [x] | gas cost listing |
 | 42 | cli/contracts_opcodes_test.go | [ ] |
 | 42 | cli/contracts_test.go | [ ] |
 | 42 | cli/cross_chain.go | [ ] |

--- a/docs/Whitepaper_detailed/architecture/consensus_architecture.md
+++ b/docs/Whitepaper_detailed/architecture/consensus_architecture.md
@@ -25,3 +25,4 @@ This group defines the mechanisms that drive agreement across the network. Core 
 These components coordinate to ensure blocks are validated and added securely while allowing dynamic algorithm changes and validator oversight.
 
 Stage 7 introduces a coded errors package and OpenTelemetry tracing across consensus modules, providing contextual diagnostics and observability for validator operations.
+Stage 41 adds resource-aware CLI tooling: the connection pool can release individual peers and contract opcode listings now include gas prices, enabling interfaces to budget consensus actions.

--- a/docs/Whitepaper_detailed/guide/cli_guide.md
+++ b/docs/Whitepaper_detailed/guide/cli_guide.md
@@ -51,7 +51,7 @@ coverage.
 * [synnergy consensus-node](#synnergy-consensus-node)	 - Consensus specific node operations
 * [synnergy consensus-service](#synnergy-consensus-service)	 - Run consensus mining service
 * [synnergy contract-mgr](#synnergy-contract-mgr)	 - Administrative contract management
-* [synnergy contractopcodes](#synnergy-contractopcodes)	 - List contract-related opcodes
+* [synnergy contractopcodes](#synnergy-contractopcodes)	 - List contract-related opcodes with gas costs
 * [synnergy contracts](#synnergy-contracts)	 - Compile, deploy and invoke smart contracts
 * [synnergy cross-consensus](#synnergy-cross-consensus)	 - Manage cross-consensus scaling networks
 * [synnergy cross_chain](#synnergy-cross-chain)	 - Manage cross-chain bridges
@@ -3222,6 +3222,7 @@ Manage connection pool
 * [synnergy](#synnergy)	 - Synnergy blockchain CLI
 * [synnergy connpool close](#synnergy-connpool-close)	 - Close the pool
 * [synnergy connpool dial](#synnergy-connpool-dial)	 - Dial an address using the pool
+* [synnergy connpool release](#synnergy-connpool-release)        - Release a connection from the pool
 * [synnergy connpool stats](#synnergy-connpool-stats)	 - Show pool statistics
 
 
@@ -3274,6 +3275,30 @@ synnergy connpool dial [addr] [flags]
 
 * [synnergy connpool](#synnergy-connpool)	 - Manage connection pool
 
+
+## synnergy connpool release
+
+Release a connection from the pool
+
+```
+synnergy connpool release [addr] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for release
+```
+
+### Options inherited from parent commands
+
+```
+      --json   output results in JSON
+```
+
+### SEE ALSO
+
+* [synnergy connpool](#synnergy-connpool)        - Manage connection pool
 
 ## synnergy connpool stats
 
@@ -4203,7 +4228,7 @@ synnergy contract-mgr upgrade [addr] [wasmHex] [gasLimit] [flags]
 
 ## synnergy contractopcodes
 
-List contract-related opcodes
+List contract-related opcodes with gas costs
 
 ```
 synnergy contractopcodes [flags]

--- a/docs/Whitepaper_detailed/guide/consensus_guide.md
+++ b/docs/Whitepaper_detailed/guide/consensus_guide.md
@@ -64,6 +64,8 @@ group once the `synnergy` CLI is built. Common operations include starting the
 service, viewing current weights and simulating difficulty adjustments. See the
 CLI help output for a full list of subcommands.
 
+Stage 41 expands these tools with a `connpool release` command for freeing network connections and a `contractopcodes` helper that reports gas costs for contract operations, allowing operators to budget resources during tuning.
+
 ## Extending the Engine
 
 The consensus package is designed for experimentation. Potential extensions

--- a/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -58,6 +58,7 @@ Stage 38 introduces a token creation tool GUI that generates token contracts thr
 Stage 39 adds a DEX Screener GUI that leverages `liquidity_views` commands so interfaces can stream pool reserves and fees.
 Stage 40 introduces administrative dashboards for authority node indexing and cross-chain management, exposing node and bridge status through CLI-driven views. The central bank module joins the function web at this stage, allowing monetary policy updates and CBDC issuance to be orchestrated alongside other network services via `synnergy centralbank`. Biometric security node and compliance management commands now emit JSON, letting interfaces verify identity templates and policy status before invoking token or network operations.
 Coin supply metrics are also exposed through `synnergy coin`, which validates inputs and emits JSON so wallets and dashboards can retrieve rewards and circulating supply.
+Stage 41 refines consensus tooling with a connection pool release command and gas-aware contract opcode listings, allowing dashboards to manage peers and cost insights across the function web.
 Stage 44 adds a smart contract test harness exercising the token faucet template through the CLI, ensuring contract modules function reliably across the function web.
 Stage 46 introduces an automated network harness that assembles wallet services
 and in-memory nodes to verify end-to-end transaction propagation and gas


### PR DESCRIPTION
## Summary
- add connection pool release subcommand
- expose gas costs in contract opcode listings
- document new CLI capabilities and update stage tracker

## Testing
- `go test ./cli -run '(ConnPool|ContractOpcodes)' -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba45f249408320bf6a4da63cc7f270