### PR TITLE
feat(cli): improve cross-chain bridge CLI

### DIFF
--- a/cli/cross_chain_test.go
+++ b/cli/cross_chain_test.go
@@ -1,7 +1,90 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
 
-func TestCrosschainPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// execCLI executes the root command with the given args and returns output.
+func execCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	out := strings.TrimSpace(buf.String())
+	rootCmd.SetOut(nil)
+	rootCmd.SetErr(nil)
+	rootCmd.SetArgs(nil)
+	return out, err
+}
+
+func TestCrossChainBridgeCommands(t *testing.T) {
+	bridgeRegistry = core.NewBridgeRegistry()
+	if cmd, _, err := rootCmd.Find([]string{"cross_chain", "list"}); err == nil {
+		_ = cmd.Flags().Set("json", "false")
+	}
+	if cmd, _, err := rootCmd.Find([]string{"cross_chain", "get"}); err == nil {
+		_ = cmd.Flags().Set("json", "false")
+	}
+
+	out, err := execCLI(t, "cross_chain", "register", "chainA", "chainB", "relayer1")
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if !strings.Contains(out, "bridge-1") {
+		t.Fatalf("expected bridge ID, got %q", out)
+	}
+
+	out, err = execCLI(t, "cross_chain", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "bridge-1: chainA -> chainB") {
+		t.Fatalf("unexpected list output %q", out)
+	}
+
+	out, err = execCLI(t, "cross_chain", "get", "bridge-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.Contains(out, "relayers=1") {
+		t.Fatalf("expected relayers=1, got %q", out)
+	}
+
+	if _, err = execCLI(t, "cross_chain", "authorize", "bridge-1", "relayer2"); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+
+	out, err = execCLI(t, "cross_chain", "get", "--json", "bridge-1")
+	if err != nil {
+		t.Fatalf("get json: %v", err)
+	}
+	var b core.Bridge
+	if err := json.Unmarshal([]byte(out), &b); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(b.Relayers) != 2 {
+		t.Fatalf("expected 2 relayers, got %d", len(b.Relayers))
+	}
+
+	if _, err = execCLI(t, "cross_chain", "revoke", "bridge-1", "relayer2"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	// reset json flag before calling without --json
+	if cmd, _, errFind := rootCmd.Find([]string{"cross_chain", "get"}); errFind == nil {
+		_ = cmd.Flags().Set("json", "false")
+	}
+	out, err = execCLI(t, "cross_chain", "get", "bridge-1")
+	if err != nil {
+		t.Fatalf("final get: %v", err)
+	}
+	if !strings.Contains(out, "relayers=1") {
+		t.Fatalf("expected relayers=1, got %q", out)
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -45,6 +45,7 @@
 - Stage 39: Completed – authority and bank CLI modules validated with unit tests.
 - Stage 40: Completed – biometric security, compliance and compression CLIs now emit validated JSON responses with unit tests; block, central bank and coin utilities fully validated.
 - Stage 41: Completed – consensus and contract management CLIs now validate inputs with accompanying tests.
+- Stage 42: In Progress – cross-chain bridge CLI upgraded with structured output and integration tests; remaining cross-chain files pending.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -901,7 +902,7 @@
 **Stage 42**
 - [ ] cli/contracts_opcodes_test.go
 - [ ] cli/contracts_test.go
-- [ ] cli/cross_chain.go
+- [x] cli/cross_chain.go – structured outputs and error handling for bridge commands
 - [ ] cli/cross_chain_agnostic_protocols.go
 - [ ] cli/cross_chain_agnostic_protocols_test.go
 - [ ] cli/cross_chain_bridge.go
@@ -911,7 +912,7 @@
 - [ ] cli/cross_chain_connection_test.go
 - [ ] cli/cross_chain_contracts.go
 - [ ] cli/cross_chain_contracts_test.go
-- [ ] cli/cross_chain_test.go
+- [x] cli/cross_chain_test.go – end-to-end tests for register/list/get/authorize/revoke
 - [ ] cli/cross_chain_transactions.go
 - [ ] cli/cross_chain_transactions_test.go
 - [ ] cli/cross_consensus_scaling_networks.go


### PR DESCRIPTION
## Summary
- refine cross-chain bridge CLI to use structured output and JSON flags
- add end-to-end tests for register/list/get/authorize/revoke flows
- mark Stage 42 progress in AGENTS tracker

## Testing
- `go test ./cli -run TestCrossChainBridgeCommands -count=1`
- `go test ./cli -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ba528e47ec832087709170f020660b