### PR TITLE
feat: enhance cross-chain CLI with JSON outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Synnergy is a modular, high-performance blockchain written in Go and built for e
 
 ## Key Features
 - **Pluggable node roles** – mining, staking, authority, regulatory, watchtower, warfare and more via constructors such as `core.NewMiningNode` and `core.NewRegulatoryNode`.
-- **Cross-chain interoperability** – bridges, connection managers and transaction relays (`core.NewBridgeRegistry`, `core.NewChainConnectionManager`, `core.NewCrossChainTxManager`). Stage 42 adds a `cross_tx` CLI with lock‑mint and burn‑release commands that emit JSON for seamless automation.
+- **Cross-chain interoperability** – bridges, protocol registries, connection managers and transaction relays (`core.NewBridgeRegistry`, `core.NewProtocolRegistry`, `core.NewChainConnectionManager`, `core.NewCrossChainTxManager`). Stage 42 finalises these modules with JSON emitting CLIs for deposits, claims and contract mappings.
 - **AI modules** – contract management, inference analysis, anomaly detection and secure storage (`core.NewAIEnhancedContract`, `core.NewAIDriftMonitor`).
 - **Gas accounting** – deterministic costs loaded via `synnergy.LoadGasTable()` and registered with `synnergy.RegisterGasCost()`.
 - **Role-based security** – biometric authentication and security node CLI (`core.NewBiometricService`, `synnergy bioauth`, `synnergy bsn`), zero‑trust data channels and PKI tooling.

--- a/cli/contracts_test.go
+++ b/cli/contracts_test.go
@@ -2,6 +2,12 @@ package cli
 
 import "testing"
 
-func TestContractsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestContractsList(t *testing.T) {
+	out, err := execCommand("contracts", "list")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if out != "" {
+		t.Fatalf("expected empty list, got %s", out)
+	}
 }

--- a/cli/cross_chain_agnostic_protocols.go
+++ b/cli/cross_chain_agnostic_protocols.go
@@ -20,16 +20,28 @@ func init() {
 
 	var listJSON bool
 	var getJSON bool
+	var registerJSON bool
 
 	registerCmd := &cobra.Command{
 		Use:   "register <name>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Register a new protocol definition",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if args[0] == "" {
+				return fmt.Errorf("name required")
+			}
 			id := protocolRegistry.Register(args[0])
-			fmt.Printf("%d gas:%d\n", id, synnergy.GasCost("RegisterProtocol"))
+			gas := synnergy.GasCost("RegisterProtocol")
+			if registerJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"id": id, "gas": gas})
+				fmt.Println(string(enc))
+				return nil
+			}
+			fmt.Printf("%d gas:%d\n", id, gas)
+			return nil
 		},
 	}
+	registerCmd.Flags().BoolVar(&registerJSON, "json", false, "output as JSON")
 
 	listCmd := &cobra.Command{
 		Use:   "list",

--- a/cli/cross_chain_agnostic_protocols_test.go
+++ b/cli/cross_chain_agnostic_protocols_test.go
@@ -1,7 +1,28 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestCrosschainagnosticprotocolsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestProtocolRegistryJSON(t *testing.T) {
+	out, err := execCommand("cross_chain_agnostic_protocols", "register", "proto1", "--json")
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if _, ok := resp["id"]; !ok {
+		t.Fatalf("missing id: %v", resp)
+	}
+	out, err = execCommand("cross_chain_agnostic_protocols", "list", "--json")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if !strings.Contains(out, "proto1") {
+		t.Fatalf("expected protocol in list: %s", out)
+	}
 }

--- a/cli/cross_chain_bridge.go
+++ b/cli/cross_chain_bridge.go
@@ -20,6 +20,8 @@ func init() {
 
 	var listJSON bool
 	var getJSON bool
+	var depositJSON bool
+	var claimJSON bool
 
 	depositCmd := &cobra.Command{
 		Use:   "deposit <bridge_id> <from> <to> <amount> [tokenID]",
@@ -38,10 +40,17 @@ func init() {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%s gas:%d\n", t.ID, synnergy.GasCost("BridgeDeposit"))
+			gas := synnergy.GasCost("BridgeDeposit")
+			if depositJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"id": t.ID, "gas": gas})
+				fmt.Println(string(enc))
+				return nil
+			}
+			fmt.Printf("%s gas:%d\n", t.ID, gas)
 			return nil
 		},
 	}
+	depositCmd.Flags().BoolVar(&depositJSON, "json", false, "output as JSON")
 
 	claimCmd := &cobra.Command{
 		Use:   "claim <transfer_id> <proof>",
@@ -51,10 +60,17 @@ func init() {
 			if err := transferManager.Claim(args[0], args[1]); err != nil {
 				return err
 			}
-			fmt.Printf("gas:%d\n", synnergy.GasCost("BridgeClaim"))
+			gas := synnergy.GasCost("BridgeClaim")
+			if claimJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"status": "claimed", "gas": gas})
+				fmt.Println(string(enc))
+				return nil
+			}
+			fmt.Printf("gas:%d\n", gas)
 			return nil
 		},
 	}
+	claimCmd.Flags().BoolVar(&claimJSON, "json", false, "output as JSON")
 
 	getCmd := &cobra.Command{
 		Use:   "get <id>",

--- a/cli/cross_chain_bridge_test.go
+++ b/cli/cross_chain_bridge_test.go
@@ -1,7 +1,20 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
-func TestCrosschainbridgePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestCrossChainBridgeDepositJSON(t *testing.T) {
+	out, err := execCommand("cross_chain_bridge", "deposit", "b1", "alice", "bob", "1", "--json")
+	if err != nil {
+		t.Fatalf("deposit failed: %v", err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if resp["id"] == "" {
+		t.Fatalf("expected id in response: %v", resp)
+	}
 }

--- a/cli/cross_chain_cli_test.go
+++ b/cli/cross_chain_cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -39,11 +40,18 @@ func TestPlasmaMgmtCLI(t *testing.T) {
 }
 
 func TestBridgeDepositCLI(t *testing.T) {
-	out, err := execCommand("cross_chain_bridge", "deposit", "bridge1", "alice", "bob", "5")
+	out, err := execCommand("cross_chain_bridge", "deposit", "bridge1", "alice", "bob", "5", "--json")
 	if err != nil {
 		t.Fatalf("deposit failed: %v", err)
 	}
-	if !strings.Contains(out, "gas:") {
-		t.Fatalf("expected gas output, got %s", out)
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if resp["id"] == "" {
+		t.Fatalf("expected id in response: %v", resp)
+	}
+	if _, ok := resp["gas"]; !ok {
+		t.Fatalf("expected gas field: %v", resp)
 	}
 }

--- a/cli/cross_chain_connection_test.go
+++ b/cli/cross_chain_connection_test.go
@@ -1,7 +1,27 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
 
-func TestCrosschainconnectionPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestConnectionManagerJSON(t *testing.T) {
+	out, err := execCommand("cross_chain_connection", "open", "c1", "c2", "--json")
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	id := resp["id"]
+	out, err = execCommand("cross_chain_connection", "get", fmt.Sprintf("%v", id), "--json")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if !strings.Contains(out, "c1") {
+		t.Fatalf("missing connection info: %s", out)
+	}
 }

--- a/cli/cross_chain_contracts.go
+++ b/cli/cross_chain_contracts.go
@@ -19,16 +19,26 @@ func init() {
 
 	var listJSON bool
 	var getJSON bool
+	var registerJSON bool
+	var removeJSON bool
 
 	registerCmd := &cobra.Command{
 		Use:   "register <local_addr> <remote_chain> <remote_addr>",
 		Args:  cobra.ExactArgs(3),
 		Short: "Register a contract mapping",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			crossContractRegistry.RegisterMapping(args[0], args[1], args[2])
-			fmt.Printf("gas:%d\n", synnergy.GasCost("RegisterXContract"))
+			gas := synnergy.GasCost("RegisterXContract")
+			if registerJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"gas": gas})
+				fmt.Println(string(enc))
+				return nil
+			}
+			fmt.Printf("gas:%d\n", gas)
+			return nil
 		},
 	}
+	registerCmd.Flags().BoolVar(&registerJSON, "json", false, "output as JSON")
 
 	listCmd := &cobra.Command{
 		Use:   "list",
@@ -75,10 +85,17 @@ func init() {
 			if err := crossContractRegistry.RemoveMapping(args[0]); err != nil {
 				return err
 			}
-			fmt.Printf("gas:%d\n", synnergy.GasCost("RemoveXContract"))
+			gas := synnergy.GasCost("RemoveXContract")
+			if removeJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"gas": gas})
+				fmt.Println(string(enc))
+				return nil
+			}
+			fmt.Printf("gas:%d\n", gas)
 			return nil
 		},
 	}
+	removeCmd.Flags().BoolVar(&removeJSON, "json", false, "output as JSON")
 
 	cmd.AddCommand(registerCmd, listCmd, getCmd, removeCmd)
 	rootCmd.AddCommand(cmd)

--- a/cli/cross_chain_contracts_test.go
+++ b/cli/cross_chain_contracts_test.go
@@ -1,7 +1,31 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestCrosschaincontractsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestXContractJSON(t *testing.T) {
+	if _, err := execCommand("xcontract", "register", "local", "remote", "raddr", "--json"); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	out, err := execCommand("xcontract", "list", "--json")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if !strings.Contains(out, "local") {
+		t.Fatalf("mapping missing: %s", out)
+	}
+	out, err = execCommand("xcontract", "remove", "local", "--json")
+	if err != nil {
+		t.Fatalf("remove failed: %v", err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if _, ok := resp["gas"]; !ok {
+		t.Fatalf("expected gas field: %v", resp)
+	}
 }

--- a/cli/cross_consensus_scaling_networks.go
+++ b/cli/cross_consensus_scaling_networks.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
+	synnergy "synnergy"
 	"synnergy/core"
 )
 
@@ -16,46 +18,69 @@ func init() {
 		Short: "Manage cross-consensus scaling networks",
 	}
 
+	var registerJSON bool
 	registerCmd := &cobra.Command{
 		Use:   "register <source> <target>",
 		Args:  cobra.ExactArgs(2),
 		Short: "Register a new network",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			id := consensusNetMgr.RegisterNetwork(args[0], args[1])
+			gas := synnergy.GasCost("RegisterConsensusNetwork")
+			if registerJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"id": id, "gas": gas})
+				fmt.Println(string(enc))
+				return nil
+			}
 			fmt.Println(id)
+			return nil
 		},
 	}
+	registerCmd.Flags().BoolVar(&registerJSON, "json", false, "output as JSON")
 
+	var listJSON bool
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List networks",
 		Run: func(cmd *cobra.Command, args []string) {
 			nets := consensusNetMgr.ListNetworks()
+			if listJSON {
+				enc, _ := json.Marshal(nets)
+				fmt.Println(string(enc))
+				return
+			}
 			for _, n := range nets {
 				fmt.Printf("%d %s->%s\n", n.ID, n.SourceConsensus, n.TargetConsensus)
 			}
 		},
 	}
+	listCmd.Flags().BoolVar(&listJSON, "json", false, "output as JSON")
 
+	var getJSON bool
 	getCmd := &cobra.Command{
 		Use:   "get <id>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Get network by ID",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.Atoi(args[0])
 			if err != nil {
-				fmt.Println("invalid id")
-				return
+				return fmt.Errorf("invalid id")
 			}
 			n, err := consensusNetMgr.GetNetwork(id)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
+			}
+			if getJSON {
+				enc, _ := json.Marshal(n)
+				fmt.Println(string(enc))
+				return nil
 			}
 			fmt.Printf("%d %s->%s\n", n.ID, n.SourceConsensus, n.TargetConsensus)
+			return nil
 		},
 	}
+	getCmd.Flags().BoolVar(&getJSON, "json", false, "output as JSON")
 
+	var removeJSON bool
 	removeCmd := &cobra.Command{
 		Use:   "remove <id>",
 		Args:  cobra.ExactArgs(1),
@@ -68,9 +93,18 @@ func init() {
 			}
 			if err := consensusNetMgr.RemoveNetwork(id); err != nil {
 				fmt.Println(err)
+				return
 			}
+			gas := synnergy.GasCost("RemoveConsensusNetwork")
+			if removeJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"gas": gas})
+				fmt.Println(string(enc))
+				return
+			}
+			fmt.Println("removed")
 		},
 	}
+	removeCmd.Flags().BoolVar(&removeJSON, "json", false, "output as JSON")
 
 	ccsnCmd.AddCommand(registerCmd, listCmd, getCmd, removeCmd)
 	rootCmd.AddCommand(ccsnCmd)

--- a/cli/cross_consensus_scaling_networks_test.go
+++ b/cli/cross_consensus_scaling_networks_test.go
@@ -1,7 +1,25 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestCrossconsensusscalingnetworksPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestConsensusNetworkJSON(t *testing.T) {
+	out, err := execCommand("cross-consensus", "register", "src", "dst", "--json")
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	out, err = execCommand("cross-consensus", "list", "--json")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if !strings.Contains(out, "src") {
+		t.Fatalf("network not listed: %s", out)
+	}
 }

--- a/cli/custodial_node.go
+++ b/cli/custodial_node.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
+	synnergy "synnergy"
 	"synnergy/core"
 )
 
@@ -17,46 +19,77 @@ func init() {
 		Short: "Operate a custodial node",
 	}
 
+	var custodyJSON bool
 	custodyCmd := &cobra.Command{
 		Use:   "custody <user> <amount>",
 		Args:  cobra.ExactArgs(2),
 		Short: "Custody assets for a user",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			amt, err := strconv.ParseUint(args[1], 10, 64)
 			if err != nil {
-				fmt.Println("invalid amount")
-				return
+				return fmt.Errorf("invalid amount")
 			}
 			custodialNode.Custody(args[0], amt)
+			gas := synnergy.GasCost("Custody")
+			if custodyJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"status": "recorded", "gas": gas})
+				fmt.Println(string(enc))
+				return nil
+			}
 			fmt.Println("recorded")
+			return nil
 		},
 	}
+	custodyCmd.Flags().BoolVar(&custodyJSON, "json", false, "output as JSON")
 
+	var releaseJSON bool
 	releaseCmd := &cobra.Command{
 		Use:   "release <user> <amount>",
 		Args:  cobra.ExactArgs(2),
 		Short: "Release assets to a user",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			amt, err := strconv.ParseUint(args[1], 10, 64)
 			if err != nil {
-				fmt.Println("invalid amount")
-				return
+				return fmt.Errorf("invalid amount")
 			}
 			if err := custodialNode.Release(args[0], amt); err != nil {
-				fmt.Println(err)
-				return
+				return err
+			}
+			gas := synnergy.GasCost("Release")
+			if releaseJSON {
+				enc, _ := json.Marshal(map[string]interface{}{"status": "released", "gas": gas})
+				fmt.Println(string(enc))
+				return nil
 			}
 			fmt.Println("released")
+			return nil
 		},
 	}
+	releaseCmd.Flags().BoolVar(&releaseJSON, "json", false, "output as JSON")
 
+	var holdingsJSON bool
 	holdingsCmd := &cobra.Command{
 		Use:   "holdings [user]",
 		Args:  cobra.RangeArgs(0, 1),
 		Short: "Show holdings",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 1 {
-				fmt.Println(custodialNode.Balance(args[0]))
+				bal := custodialNode.Balance(args[0])
+				if holdingsJSON {
+					enc, _ := json.Marshal(map[string]interface{}{"user": args[0], "balance": bal})
+					fmt.Println(string(enc))
+					return
+				}
+				fmt.Println(bal)
+				return
+			}
+			if holdingsJSON {
+				out := make(map[string]uint64)
+				for u := range custodialNode.Holdings {
+					out[u] = custodialNode.Balance(u)
+				}
+				enc, _ := json.Marshal(out)
+				fmt.Println(string(enc))
 				return
 			}
 			for u := range custodialNode.Holdings {
@@ -64,6 +97,7 @@ func init() {
 			}
 		},
 	}
+	holdingsCmd.Flags().BoolVar(&holdingsJSON, "json", false, "output as JSON")
 
 	custCmd.AddCommand(custodyCmd, releaseCmd, holdingsCmd)
 	rootCmd.AddCommand(custCmd)

--- a/cli/custodial_node_test.go
+++ b/cli/custodial_node_test.go
@@ -1,7 +1,25 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestCustodialnodePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestCustodialNodeJSON(t *testing.T) {
+	out, err := execCommand("custodial", "custody", "user1", "5", "--json")
+	if err != nil {
+		t.Fatalf("custody failed: %v", err)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	out, err = execCommand("custodial", "holdings", "user1", "--json")
+	if err != nil {
+		t.Fatalf("holdings failed: %v", err)
+	}
+	if !strings.Contains(out, "user1") {
+		t.Fatalf("expected user in holdings: %s", out)
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -45,7 +45,7 @@
 - Stage 39: Completed – authority and bank CLI modules validated with unit tests.
 - Stage 40: Completed – biometric security, compliance and compression CLIs now emit validated JSON responses with unit tests; block, central bank and coin utilities fully validated.
 - Stage 41: Completed – consensus and contract management CLIs now validate inputs with accompanying tests.
-- Stage 42: In Progress – cross-chain bridge and transaction CLIs upgraded with structured output and integration tests; remaining cross-chain files pending.
+- Stage 42: Completed – cross-chain bridge, protocol, connection, contract and custodial CLIs now emit structured JSON with accompanying tests.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -900,26 +900,25 @@
 - [ ] cli/contracts_opcodes.go
 
 **Stage 42**
-- [ ] cli/contracts_opcodes_test.go
-- [ ] cli/contracts_test.go
+- [x] cli/contracts_opcodes_test.go – gas annotations verified
+- [x] cli/contracts_test.go – lists contracts with error checking
 - [x] cli/cross_chain.go – structured outputs and error handling for bridge commands
-- [ ] cli/cross_chain_agnostic_protocols.go
-- [ ] cli/cross_chain_agnostic_protocols_test.go
-- [ ] cli/cross_chain_bridge.go
-- [ ] cli/cross_chain_bridge_test.go
-- [ ] cli/cross_chain_cli_test.go
-- [ ] cli/cross_chain_connection.go
-- [ ] cli/cross_chain_connection_test.go
-- [ ] cli/cross_chain_contracts.go
-- [ ] cli/cross_chain_contracts_test.go
+- [x] cli/cross_chain_agnostic_protocols.go – registration emits JSON with gas
+- [x] cli/cross_chain_agnostic_protocols_test.go – protocol registry JSON test
+- [x] cli/cross_chain_bridge.go – deposit/claim commands output JSON and gas
+- [x] cli/cross_chain_bridge_test.go – deposit JSON response validated
+- [x] cli/cross_chain_cli_test.go – bridge deposit uses JSON response
+- [x] cli/cross_chain_connection.go – open/close provide structured JSON
+- [x] cli/cross_chain_connection_test.go – connection JSON workflow covered
+- [x] cli/cross_chain_contracts.go – mapping commands emit JSON
+- [x] cli/cross_chain_contracts_test.go – mapping lifecycle validated
 - [x] cli/cross_chain_test.go – end-to-end tests for register/list/get/authorize/revoke
-- [ ] cli/cross_chain_transactions.go
 - [x] cli/cross_chain_transactions.go – root json flag and structured outputs for lock‑mint/burn‑release
 - [x] cli/cross_chain_transactions_test.go – CLI coverage for lock‑mint, burn‑release, list and get
-- [ ] cli/cross_consensus_scaling_networks.go
-- [ ] cli/cross_consensus_scaling_networks_test.go
-- [ ] cli/custodial_node.go
-- [ ] cli/custodial_node_test.go
+- [x] cli/cross_consensus_scaling_networks.go – register/list/get/remove support JSON
+- [x] cli/cross_consensus_scaling_networks_test.go – consensus network JSON test
+- [x] cli/custodial_node.go – custody, release and holdings emit JSON
+- [x] cli/custodial_node_test.go – custodial operations verified
 
 **Stage 43**
 - [ ] cli/dao.go

--- a/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
+++ b/docs/Whitepaper_detailed/guide/synnergy_network_function_web.md
@@ -20,7 +20,9 @@ registration, connection tracking and gas-priced transfer operations that UIs
 can invoke for inter-network workflows.
 Stage 42 builds on this by adding the `cross_tx` module so the function web can
 initiate lock‑mint and burn‑release flows with JSON responses and audited gas
-charges.
+charges. Bridge, protocol, connection, contract mapping and custodial node
+CLIs now emit structured JSON, letting web interfaces coordinate cross-chain
+transfers end‑to‑end.
 Stage 35 delivers a production-ready wallet interface with rigorous testing and
 CI integration, allowing web dashboards to securely sign and submit
 transactions through the same function web.

--- a/docs/Whitepaper_detailed/whitepaper.md
+++ b/docs/Whitepaper_detailed/whitepaper.md
@@ -41,6 +41,7 @@ Stage 23 further enhances the toolchain by exposing gas costs for consensus and
 governance actions through the CLI, enabling operators to model fees before
 committing transactions.
 Stage 24 introduces enterprise-grade cross-chain tooling. Bridge registration, connection management and Plasma operations now expose deterministic gas fees and optional JSON output so external systems can safely automate transfers.
+Stage 42 finalises this layer: protocol registries, contract mappings and custodial nodes all emit structured JSON through their CLIs, enabling fault-tolerant automation across disparate networks.
 Stage 25 focuses on operational tooling. Node management commands for full,
 light, mining, mobile, optimisation, staking, watchtower and warfare roles now
 emit structured JSON and have explicit gas pricing so that enterprise dashboards

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -5,6 +5,12 @@ The core package implements consensus, transaction processing, and network primi
 ## Key Types
 - `Block` – representation of a blockchain block
 - `Transaction` – basic transaction structure
+- `BridgeTransferManager` – coordinates cross-chain deposits and claims
+- `ProtocolRegistry` – tracks cross-chain protocol definitions
+- `ChainConnectionManager` – opens and monitors inter-chain connections
+- `CrossChainRegistry` – stores contract address mappings across networks
+- `ConsensusNetworkManager` – registers cross-consensus scaling networks
+- `CustodialNode` – maintains off-chain asset custody records
 
 ## Functions
 - `ValidateBlock` – verifies block integrity

--- a/docs/guides/cli_quickstart.md
+++ b/docs/guides/cli_quickstart.md
@@ -15,6 +15,7 @@ make build
 - `synnergy charity_pool --json registration <addr>` – view charity registration info as JSON
 - `synnergy charity_mgmt donate <from> <amount>` – donate tokens to the charity pool
 - `synnergy coin --json info` – inspect monetary parameters
+- `synnergy cross_chain_bridge deposit <bridge> <from> <to> <amount> --json` – lock assets for bridging with structured output
 
 ## Help
 Run `synnergy --help` or `synnergy <command> --help` for more details.


### PR DESCRIPTION
## Summary
- add structured JSON output and gas reporting to cross-chain bridge, protocol, connection, contract, consensus-network and custodial CLIs
- document cross-chain CLI usage and finalize Stage 42 checklist
- expand core docs and whitepaper for new cross-chain managers

## Testing
- `go test ./cli -run 'CrossChainBridgeDepositJSON|ProtocolRegistryJSON|ConnectionManagerJSON|XContractJSON|ConsensusNetworkJSON|CustodialNodeJSON|BridgeDepositCLI|CrossChainCLI|PlasmaMgmtCLI|ContractsList' -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68badd39ec988320b2e3386d92d96845