### PR TITLE
docs: expand AI marketplace guide

### DIFF
--- a/GUI/ai-marketplace/docs/README.md
+++ b/GUI/ai-marketplace/docs/README.md
@@ -1,12 +1,306 @@
-# AI Marketplace Documentation
+# Blackridge Group Ltd. — AI Marketplace Documentation
 
-This section captures architectural decisions and operational guides for the AI Marketplace interface.
+The **AI Marketplace** module provides a foundational interface for exchanging AI services and datasets across the Synnergy Network. Developed and maintained by Blackridge Group Ltd., this component delivers a lightweight HTTP service and flexible scaffolding for building production‑ready marketplace features. The module is intentionally small to act as a reference implementation that teams can clone or extend when building bespoke trading venues for algorithms, models, or analytics data.
 
-## Architecture
+---
 
-The project exposes a lightweight HTTP endpoint that proxies requests to Synnergy network services.  It is designed to be extended with additional pages and API integrations.
+## 1. Architecture Overview
 
-## Deployment Notes
+The service is implemented in TypeScript and transpiled to Node.js. At its core, the [`main.ts`](../src/main.ts) file exposes an HTTP endpoint that returns a simple health message (`ai-marketplace alive`) and is intended to be extended with real marketplace logic. An in‑memory key–value store (`state/store.ts`) demonstrates basic state management used in both unit and end‑to‑end tests.
 
-- **Docker:** `docker-compose up` spins up a development container.
-- **Kubernetes:** manifests under `../k8s/` provide an example deployment.
+The project structure encourages a clear separation of concerns:
+
+```
+src/
+  components/   # Reusable UI elements for marketplace front ends
+  hooks/        # Shared logic for data retrieval and stateful utilities
+  pages/        # Route-level components mapped to URLs
+  services/     # Connectors for external APIs and network protocols
+  state/        # Shared in-memory store implementation
+  styles/       # Global and component CSS resources
+```
+
+This scaffolding allows teams to progressively introduce full marketplace capabilities while maintaining a modular architecture. Directories such as `components/`, `hooks/`, `pages/`, and `services/` are intentionally left empty so development teams can populate them with domain-specific interfaces, state handlers, and integrations.
+
+The HTTP layer relies solely on Node's built-in `http` module and binds to the port supplied via the `PORT` environment variable. When executed directly, [`main.ts`](../src/main.ts) emits a startup message indicating the effective port. The request handler can be expanded to support additional routes by inspecting `req.url`:
+
+```typescript
+import http from 'http';
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok');
+    return;
+  }
+  res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ai-marketplace alive');
+});
+```
+
+State management is provided through [`state/store.ts`](../src/state/store.ts), a minimal in-memory key–value utility exposing `set`, `get`, and `reset` methods. The design keeps behaviour deterministic for unit and end‑to‑end tests and can be swapped for a persistent database in production. Compilation settings in [`tsconfig.json`](../tsconfig.json) enforce strict typing, source maps, and consistent module resolution, yielding robust JavaScript output in `dist/`.
+
+### Core Runtime Modules
+- **`src/main.ts`** – creates the HTTP server and accepts an optional port argument for embedding in larger applications.
+- **`src/state/store.ts`** – provides a singleton in-memory store for simple key–value persistence.
+- **`config/production.ts`** – defines runtime configuration sourced from `API_URL` and `PORT` environment variables.
+- **`jest.config.js`** – configures Jest with TypeScript support and coverage collection.
+
+### Extending the Service
+The request handler can be expanded to expose domain features. The example below demonstrates a route that stores and retrieves a value using the in-memory store:
+
+```typescript
+import { store } from './state/store';
+
+const server = http.createServer((req, res) => {
+  if (req.url?.startsWith('/save/')) {
+    const [, key, value] = req.url.split('/');
+    store.set(key, value);
+    res.writeHead(200, { 'Content-Type': 'text/plain' }).end('saved');
+    return;
+  }
+  if (req.url?.startsWith('/get/')) {
+    const [, key] = req.url.split('/');
+    const data = store.get<string>(key) || 'missing';
+    res.writeHead(200, { 'Content-Type': 'text/plain' }).end(data);
+    return;
+  }
+  res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ai-marketplace alive');
+});
+```
+
+This pattern keeps the codebase framework-agnostic while allowing teams to layer in routing libraries or application frameworks as requirements grow.
+
+---
+
+## 2. Project Layout
+
+Beyond the `src/` directory, the repository includes a concise set of folders that drive the development lifecycle:
+
+| Path | Purpose |
+| ---- | ------- |
+| `config/` | Runtime profiles such as [`production.ts`](../config/production.ts) |
+| `tests/` | Jest unit (`tests/unit/`) and end‑to‑end (`tests/e2e/`) suites |
+| `docs/` | Markdown documentation, including this guide |
+| `ci/` | GitHub Actions workflow definition |
+| `k8s/` | Example Kubernetes manifests |
+| `Dockerfile` & `docker-compose.yml` | Containerisation artefacts for local or cloud deployments |
+| `Makefile` | Convenience targets wrapping common npm commands |
+
+This layout mirrors typical Blackridge Group Ltd. projects, offering a consistent developer experience across the Synnergy ecosystem.
+
+---
+
+## 3. Configuration
+
+Runtime configuration is centralized in `config/` files. The production profile (`config/production.ts`) reads the following environment variables:
+
+- `API_URL` – Base URL for Synnergy network services (default: `https://api.synnergy.example`).
+- `PORT` – HTTP port exposed by the server (default: `3000`).
+
+Environment variables can be supplied directly, via Docker Compose, or through Kubernetes manifests. Additional configuration profiles (for example, `development.ts` or `staging.ts`) can be introduced in the same directory to reflect different deployment targets.
+
+The `main` function in [`src/main.ts`](../src/main.ts) also accepts an explicit port argument, enabling programmatic embedding or override of the `PORT` variable when invoked from other modules.
+
+Example of starting the service on a custom port:
+
+```bash
+npm run build
+PORT=8081 API_URL=https://api.synnergy.example npm start
+```
+
+---
+
+## 4. Development Workflow
+
+### Prerequisites
+- Node.js 18+
+- npm 9+
+
+### Installation & Local Run
+```bash
+npm install      # or: make install
+npm run build    # or: make build
+npm start        # launches the HTTP service
+```
+The default server responds on `http://localhost:3000` and can be tested with any HTTP client.
+
+### Available Scripts
+| Command | Purpose |
+| ------- | ------- |
+| `npm run build` | Compile TypeScript sources to `dist/` |
+| `npm start` | Execute compiled server (`dist/main.js`) |
+| `npm test` | Run unit and end‑to‑end Jest suites |
+| `npm run lint` | Lint source with ESLint |
+| `npm run format` | Format code with Prettier |
+
+A simple `Makefile` wraps the install, build, and test operations for convenience. Prior to opening a pull request, execute `npm run lint` and `npm run format` to ensure code quality and consistent styling across the Blackridge Group Ltd. codebase.
+
+### Code Style Guidelines
+The codebase adheres to a strict TypeScript configuration (`strict: true` in [`tsconfig.json`](../tsconfig.json)) and ESLint rules enforced by [`npm run lint`](../package.json). Prettier maintains consistent formatting across files. Commits should follow the conventional message format (`type: summary`) used across Blackridge Group Ltd. repositories.
+
+---
+
+## 5. Testing Strategy
+
+Jest is configured through [`jest.config.js`](../jest.config.js) to execute tests located in both `src/` and `tests/` directories while collecting coverage metrics. The configuration uses the `ts-jest` preset so TypeScript sources run without a separate compilation step and targets the Node runtime defined in `testEnvironment`.
+
+Example suites illustrate different testing layers:
+
+- **`src/main.test.ts`** – spins up the HTTP server on an ephemeral port and asserts that the response body equals `ai-marketplace alive`.
+- **`tests/unit/example.test.ts`** – validates that calling `reset` on the store clears previously persisted keys.
+- **`tests/e2e/example.e2e.test.ts`** – exercises the store across calls to `set` and `get`, mimicking a lightweight end‑to‑end flow.
+
+To run the full test suite:
+```bash
+npm test    # or: make test
+```
+
+Coverage reports can be generated with:
+```bash
+npm test -- --coverage
+```
+
+To continuously run tests during development, append the `--watch` flag:
+```bash
+npm test -- --watch
+```
+
+---
+
+## 6. Containerization & Deployment
+
+### Docker
+The included [`Dockerfile`](../Dockerfile) builds a minimal production image:
+```Dockerfile
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+RUN npm run build
+CMD ["node", "dist/main.js"]
+```
+
+A companion `docker-compose.yml` file exposes the application on port 3000 and demonstrates how to set `API_URL` and `PORT` environment variables for local development.
+To build and run the image manually:
+
+```bash
+docker build -t ai-marketplace .
+docker run -p 3000:3000 ai-marketplace
+```
+
+Using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+### Kubernetes
+A sample deployment manifest resides in `k8s/deployment.yaml`. It provisions a single replica of the service, mapping container port `3000` and allowing further customization through standard Kubernetes mechanisms. Adjust the `image` field to reference a registry-hosted image and scale `replicas` to match workload requirements. Environment variables can be injected via `env` entries or ConfigMaps and Secrets.
+
+---
+
+## 7. Continuous Integration
+
+Automated builds are defined in `ci/pipeline.yml` using GitHub Actions. The workflow triggers on changes within the `GUI/ai-marketplace` path and performs the following steps:
+1. Check out source code.
+2. Install dependencies with `npm ci`.
+3. Execute unit tests via `npm test`.
+4. Compile the project with `npm run build`.
+
+This pipeline ensures consistency across contributions and provides rapid feedback for pull requests.
+The workflow runs on Ubuntu with Node.js 18 provided by `actions/setup-node` and can be extended with additional jobs for linting, security scanning, or publishing container images.
+
+---
+
+## 8. Security & Compliance
+
+The module currently exposes only a health endpoint and does not persist data, yet future marketplace features should account for:
+
+- **Secret management** – never commit API keys or credentials. Use environment variables or secret stores.
+- **Transport security** – terminate TLS at the ingress layer or front proxy when deployed.
+- **Access controls** – integrate with Synnergy identity services before enabling write operations.
+- **Code quality** – run `npm run lint` and `npm test` locally before submitting changes.
+- **Dependency hygiene** – review `package.json` regularly and apply updates to address upstream vulnerabilities.
+- **Vulnerability scanning** – execute `npm audit` or integrate dependency scanners in CI to catch known issues early.
+
+Review the repository-wide [SECURITY.md](../../../SECURITY.md) and [CODE_OF_CONDUCT.md](../../../CODE_OF_CONDUCT.md) before reporting vulnerabilities or engaging with the community.
+
+---
+
+## 9. Contributing & Support
+
+Contributions are welcome. Please review the repository-wide [CONTRIBUTING.md](../../../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../../../CODE_OF_CONDUCT.md) for guidelines. Issues and feature requests can be submitted through the project tracker under the Blackridge Group Ltd. organization.
+
+For security concerns, consult the global [SECURITY.md](../../../SECURITY.md) policy before reporting vulnerabilities.
+When submitting patches, ensure that tests and linters pass locally and use descriptive commit messages following the conventional `type: summary` format.
+
+---
+
+## 10. Roadmap & Future Enhancements
+
+Planned areas of exploration include:
+
+- Marketplace listings backed by persistent databases and pricing engines.
+- Authentication flows aligned with Synnergy identity wallets.
+- Rich UI components for browsing and purchasing AI services.
+- Observability hooks for metrics and centralized logging.
+- Payment settlement integrations supporting on-chain and off-chain transactions.
+- Governance features for rating vendors and flagging inappropriate content.
+- Dataset lifecycle management with provenance tracking and version history.
+
+Community feedback is welcome—open an issue to propose additional features or integrations.
+
+---
+
+## 11. Monitoring & Observability
+
+While the reference implementation emits basic console logs, production deployments should integrate with centralized logging and metrics platforms. Recommended practices include:
+
+- Forwarding stdout/stderr to a log aggregation service such as ELK, Grafana Loki, or CloudWatch.
+- Exposing Prometheus-compatible metrics for request throughput, latency, and error rates.
+- Configuring health and readiness probes in Kubernetes to surface runtime status.
+
+---
+
+## 12. Performance & Scalability
+
+The baseline service is intentionally lightweight. For production workloads, consider the following to meet performance objectives:
+
+- **Horizontal scaling** – run multiple instances behind a load balancer or Kubernetes deployment and tune `replicas` accordingly.
+- **Clustering** – leverage Node's `cluster` module or process managers like PM2 to utilize multi-core hosts.
+- **Caching** – introduce an external cache (e.g., Redis) when repeated computations or network calls become expensive.
+- **Persistent stores** – replace the in-memory store with a database when durability or query capabilities are required.
+
+Benchmarking early and often helps determine whether the simple HTTP stack suffices or if a full-featured framework is warranted.
+
+---
+
+## 13. Error Handling & Logging
+
+Comprehensive logging accelerates root-cause analysis and post-mortem reviews:
+
+- Wrap asynchronous handlers with try/catch blocks and return meaningful HTTP status codes.
+- Standardize log formats (JSON or key/value) to ease parsing in downstream systems.
+- Redact sensitive data before emitting logs, especially in multi-tenant environments.
+
+For structured logging, consider integrating libraries such as `pino` or `winston`.
+
+---
+
+## 14. Troubleshooting
+
+| Symptom | Resolution |
+| ------- | ---------- |
+| `EADDRINUSE` error on startup | Another service is using the configured `PORT`. Stop the process or supply a different port. |
+| Requests hang without response | Ensure `npm run build` has been executed and that the server is listening on the expected port. |
+| Tests fail with missing TypeScript types | Run `npm install` to restore dependencies and verify that `tsconfig.json` includes all source directories. |
+
+---
+
+## 15. License
+
+This module is released under the [MIT License](../../../LICENSE). Blackridge Group Ltd. and Synnergy contributors provide the software "as is" without warranty of any kind.
+
+---
+
+© 2024 Blackridge Group Ltd. — All rights reserved.


### PR DESCRIPTION
## Summary
- elaborate core runtime modules with extensibility example
- detail testing layers, code style, and operational guidance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae10653c0832088578480de0da185