### PR TITLE
docs: broaden contract authoring guide

### DIFF
--- a/docs/Whitepaper_detailed/How to write a contract.md
+++ b/docs/Whitepaper_detailed/How to write a contract.md
@@ -1,3 +1,143 @@
-# How to write a contract
+# How to Write a Contract
 
-This is a placeholder for How to write a contract.
+Blackridge Group Ltd. provides a powerful framework for authoring, deploying and managing smart contracts on the Synnergy Network. This guide walks developers through the full contract lifecycle—from selecting a language to managing upgrades—so that every contract adheres to our enterprise standards for security, performance and regulatory compliance.
+
+## Prerequisites
+
+- **Development environment** with the Synnergy CLI available in `cmd/synnergy`.
+- Familiarity with WebAssembly (WASM) and smart contract concepts.
+- Access to a test node or sandbox environment for validation.
+
+## Choosing a Contract Language
+
+The Synnergy virtual machine supports multiple high‑level languages that compile to the network’s opcode set. Supported options include WASM, Go, JavaScript, Solidity, Rust, Python and Yul【F:contract_language_compatibility.go†L5-L16】. Use the language best aligned with your team’s expertise and project requirements.
+
+```go
+if !synnergy.IsLanguageSupported(lang) {
+    log.Fatalf("unsupported contract language: %s", lang)
+}
+```
+
+## Structuring the Contract
+
+Each deployed contract is represented by the `Contract` struct, which captures deterministic addressing, ownership and execution constraints【F:contracts.go†L10-L18】. Design your contract with these fields in mind:
+
+- **Address** – derived from the SHA‑256 hash of the compiled WASM.
+- **Owner** – account responsible for upgrades and lifecycle decisions.
+- **Manifest** – optional Ricardian contract describing intent.
+- **GasLimit** – maximum gas per invocation to protect against runaway execution.
+
+## Mapping to Opcodes
+
+Every exported function maps to a stable opcode so the virtual machine can dispatch calls deterministically. The `ContractOpcode` type pairs human‑readable names with numeric codes and the network publishes the full list in `ContractOpcodes`【F:contracts_opcodes.go†L1-L12】. Lookups are performed through helpers such as `opcodeByName`, which translate a function name to its encoded value【F:contracts_opcodes.go†L1403-L1421】. Reserve unique names and corresponding opcodes during design to maintain compatibility across tooling and audits.
+
+## Compiling to WASM
+
+Use the `CompileWASM` helper to convert source code into bytecode and compute its hash for addressing【F:contracts.go†L46-L55】.
+
+```go
+wasm, addrHash, err := synnergy.CompileWASM(src)
+if err != nil {
+    return err
+}
+```
+
+The returned hash becomes the on‑chain address used in subsequent operations.
+
+## Deploying the Contract
+
+Contracts are registered through the `ContractRegistry`. Deployment requires the WASM bytecode, optional manifest, gas limit and owner address【F:contracts.go†L57-L79】.
+
+```go
+registry := synnergy.NewContractRegistry(vm)
+addr, err := registry.Deploy(wasm, manifestJSON, gasLimit, owner)
+```
+
+For command‑line workflows, the provided script wraps this functionality:
+
+```bash
+scripts/deploy_contract.sh path/to/contract.wasm
+```
+
+This script validates the binary path and invokes `synnergy contracts deploy --wasm <file>`【F:scripts/deploy_contract.sh†L1-L28】.
+
+## Invoking Contract Methods
+
+Once deployed, methods are executed via the registry, which routes calls through the configured virtual machine and enforces gas limits and pause status【F:contracts.go†L82-L98】.
+
+```go
+output, gasUsed, err := registry.Invoke(addr, "Execute", args, suppliedGas)
+```
+
+## Enumerating and Auditing Contracts
+
+The registry exposes helpers for discovering and validating deployed artifacts. `List` returns every tracked contract while `Get` fetches metadata for a specific address【F:contracts.go†L100-L116】. These APIs are safe for concurrent use and underpin audit tooling across Blackridge Group Ltd.
+
+```go
+for _, c := range registry.List() {
+    fmt.Printf("%s owned by %s\n", c.Address, c.Owner)
+}
+```
+
+## Testing and Simulation
+
+Unit tests should exercise deployment and invocation flows prior to mainnet release. The `TestContractRegistry` test demonstrates compiling bytecode, deploying it to a local `SimpleVM`, and verifying output【F:contracts_test.go†L5-L24】. Reproduce similar tests for your contract to validate logic and gas consumption deterministically.
+
+## Formal Verification and Fuzzing
+
+Beyond unit tests, the codebase scaffolds advanced validation. Formal verification hooks exist to integrate theorem provers and assert protocol invariants before launch【F:tests/formal/contracts_verification_test.go†L1-L7】. Complementary fuzz tests feed random byte streams into the virtual machine to reveal edge cases and panics early in development【F:tests/fuzz/vm_fuzz_test.go†L1-L8】.
+
+## Managing the Contract Lifecycle
+
+Administrative operations are handled by the `ContractManager`, enabling owners to transfer control, pause execution, resume, upgrade bytecode or query metadata【F:core/contract_management.go†L15-L96】. Each method is instrumented with OpenTelemetry spans so lifecycle events appear in enterprise dashboards.
+
+- `Transfer` – change contract ownership.
+- `Pause`/`Resume` – toggle execution availability.
+- `Upgrade` – replace WASM and optionally adjust gas limits.
+- `Info` – retrieve current metadata.
+
+## Cross‑Chain Mapping
+
+For applications spanning multiple networks, the `XContractRegistry` records relationships between local and remote contract addresses【F:cross_chain_contracts.go†L5-L55】. Register mappings to coordinate cross‑chain calls and asset transfers.
+
+```go
+xreg := synnergy.NewXContractRegistry()
+xreg.RegisterMapping(localAddr, "RemoteChain", remoteAddr)
+```
+
+Mappings can later be enumerated or removed using `ListMappings`, `GetMapping` and `RemoveMapping` to keep cross‑chain relationships current【F:cross_chain_contracts.go†L34-L55】.
+
+## Integrating External Data and Secure Channels
+
+Many contracts rely on off‑chain inputs or confidential messaging. Thread‑safe `DataFeed` structures allow contracts to consume timestamped key/value updates from external systems without race conditions【F:data_operations.go†L8-L28】. When transmitting sensitive payloads, the `ZeroTrustEngine` opens encrypted channels using Ed25519 keys and signed messages to maintain end‑to‑end confidentiality【F:zero_trust_data_channels.go†L9-L33】.
+
+## Security and Best Practices
+
+- Conduct comprehensive testing and formal verification before deployment.
+- Set conservative gas limits to mitigate denial‑of‑service vectors.
+- Maintain version control of manifests and WASM artifacts for auditability.
+- Leverage pause and upgrade controls to respond to vulnerabilities quickly.
+- Enforce role‑based permissions with the `AccessController` to constrain privileged operations【F:access_control.go†L5-L47】.
+
+## Regulatory Compliance and Privacy Controls
+
+Enterprise deployments often operate under multiple jurisdictions. The `RegulatoryManager` stores per‑region rules—such as transaction limits—and evaluates them before execution to ensure adherence to local mandates【F:regulatory_management.go†L8-L35】. For sensitive state transitions, AES‑GCM helpers encrypt and decrypt payloads so that private data remains confidential across the network【F:private_transactions.go†L11-L27】【F:private_transactions.go†L30-L38】.
+
+## CLI Automation
+
+Operational teams can manage contracts through the CLI. The `contract-mgr` command wraps lifecycle operations such as `transfer`, `pause`, `resume`, `upgrade` and `info`【F:cli/contract_management.go†L18-L84】, surfacing coded errors when expectations are not met【F:cli/contract_management.go†L87-L92】.
+
+## Observability, Error Handling and Telemetry
+
+Enterprise deployments require traceability and consistent error semantics. All management functions emit spans via the shared tracer【F:internal/telemetry/telemetry.go†L8-L10】 and return structured errors with codes like `not_found` and `invalid`【F:internal/errors/errors.go†L5-L49】. Instrumentation enables real‑time monitoring, while coded errors simplify automated remediation.
+
+The network’s `SystemHealthLogger` supplements tracing by exporting runtime metrics—including goroutine counts, memory use, peer cardinality and block height—so operators can correlate contract activity with node health in watchtower dashboards【F:system_health_logging.go†L1-L35】.
+
+## Gas Accounting and Resource Profiles
+
+The `SimpleVM` offers configurable execution profiles—heavy, light and super light—controlled by `VMMode` to balance throughput against resource limits【F:virtual_machine.go†L11-L58】. Gas usage per opcode is resolved through the dynamically loaded gas table, allowing dashboards to calculate costs with `GasCost` and related helpers【F:gas_table.go†L18-L106】.
+
+## Conclusion
+
+By adhering to these guidelines, developers can author robust, maintainable smart contracts that leverage the full capabilities of the Synnergy Network while meeting the quality standards of Blackridge Group Ltd. Continued enhancements to tooling and runtime will further streamline contract development across our ecosystem.
+


### PR DESCRIPTION
## Summary
- document opcode mapping and lookup helpers for deterministic VM dispatch
- add formal verification, fuzz testing, and secure data feed guidance
- cover regulatory rules, private payloads, and runtime health metrics

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68baee6844208320a94e2715cb5ed0fa