### PR TITLE
docs: add missing token standards

### DIFF
--- a/docs/Whitepaper_detailed/Tokens.md
+++ b/docs/Whitepaper_detailed/Tokens.md
@@ -1,3 +1,302 @@
 # Tokens
 
-This is a placeholder for Tokens.
+## Introduction
+Blackridge Group Ltd. designs the Synnergy Network token framework to support a diverse ecosystem of digital assets. Each token type encapsulates specific business logic, enabling regulated financial operations, real‑world asset representation and community governance. The architecture combines secure ledgers, structured registries and extensible smart‑contract interfaces to allow token classes to operate independently while remaining interoperable across the network.
+
+## Token Framework Overview
+Tokens on Synnergy Network are implemented as Go modules that maintain their own state and persistence model. Ledgers and registries are used to manage balances, metadata and transactional history. This modular approach allows Blackridge Group Ltd. to:
+
+- Tailor functionality to the asset class or utility.
+- Enforce compliance through whitelists, blacklists and certification metadata.
+- Provide deterministic APIs for minting, transferring, burning and querying tokens.
+
+## Monetary and Financial Instruments
+### SYN10 – Central Bank Digital Currency
+`syn10.go` embeds a base ledger and protects issuer metadata and exchange
+rates with a dedicated mutex. The `SetExchangeRate` function atomically
+updates the fiat peg while `Info` exposes the current issuer details and
+total supply for audit trails.
+
+### SYN11 – Central Bank Digital Gilts
+`syn11_token.go` models government bond instruments issued by central banks.
+Fixed‑rate metadata tracks coupon schedules and redemption amounts, letting
+treasuries settle gilt obligations on chain.
+
+### SYN12 – Tokenised Treasury Bill
+`syn12.go` structures a treasury bill with issue and maturity dates,
+discount and face value. Instances are created via `NewSYN12Token`, which
+captures the immutable `SYN12Metadata` used for settlement calculations.
+
+### SYN20 – Pausable and Freezable Ledger
+`syn20.go` extends the base token with emergency controls. Mutex‑guarded
+flags allow administrators to pause all transfers or freeze specific
+addresses, and overrides ensure `Transfer`, `Mint` and `Burn` respect these
+restrictions.
+
+### SYN1000 – Reserve‑Backed Stablecoin
+`syn1000.go` tracks backing assets as high‑precision rational numbers and
+guards the reserve map with a read/write mutex. Functions such as
+`AddReserve`, `SetReservePrice` and `TotalReserveValue` let operators manage
+collateral transparently.
+
+### SYN1000 Index – Stablecoin Manager
+`syn1000_index.go` orchestrates multiple stablecoin instances. A central
+registry creates tokens, retrieves them by `TokenID` and proxies reserve
+updates so enterprises can administer distinct fiat pegs under one service.
+
+### SYN2100 – Trade Finance Ledger
+`syn2100.go` maintains structured invoices and liquidity pools for trade
+finance. Registries register documents, mark financing status and track pool
+contributions, enabling on‑chain factoring and invoice discounting.
+
+## Governance and Membership Tokens
+### DAO Membership Ledger
+`dao_token.go` implements a simple ledger that mints, transfers and burns tokens representing voting rights within a decentralised autonomous organisation. The ledger locks access with a `sync.RWMutex` to prevent race conditions and exposes `Mint`, `Transfer`, `Balance` and `Burn` methods for membership management.
+
+### SYN300 – Governance Token
+`syn300_token.go` provides advanced on‑chain governance. Holders may delegate voting power, propose network changes and vote on proposals. Quorum checks ensure proposals only execute when approval power meets predefined thresholds. Proposal and vote data are timestamped for auditability.
+
+### SYN1500 – Reputation Token
+`syn1500.go` tracks reputation adjustments through `ReputationEvent` entries, allowing communities to weight governance influence or service access based on historical behaviour.
+
+### SYN2500 – DAO Registry
+`syn2500_token.go` maintains structured membership records including join time, voting power and arbitrary metadata. The registry enables Blackridge Group Ltd. to build rich DAO applications that track member evolution without affecting underlying token balances.
+
+## Asset‑Backed Tokens
+### SYN130 – Tangible Assets
+`token_syn130.go` models real‑world assets with valuation, ownership and lease tracking. Sale history and lease agreements are recorded to support secondary markets or rental models.
+
+### SYN131 – Intangible Assets
+`syn131_token.go` represents non‑physical assets such as patents or trademarks. Tokens carry a valuation field and can be updated through controlled registries.
+
+### SYN800 – Certified Asset Registry
+`syn800_token.go` stores metadata for physical items, including location, asset type and certification identifiers. Valuation updates are timestamped to maintain an immutable audit trail.
+
+### SYN4900 – Agricultural Commodities
+`token_syn4900.go` tokenises agricultural goods with origin, quantity, harvest/expiry dates and a chronological event history. Ownership transfers append events, ensuring full provenance for supply‑chain compliance.
+
+### SYN1300 – Supply Chain Tracking
+`syn1300.go` captures status changes for assets as they move through logistics networks. Events such as location updates or condition reports are appended to asset history for comprehensive traceability.
+
+### SYN3000 – Rental Tokens
+`SYN3000.go` records rental agreements with metadata for lease terms,
+payments and return conditions, enabling on‑chain management of equipment
+or property rentals.
+
+## Investment and Market Tokens
+### SYN1401 – Investment Records
+`syn1401.go` issues time‑bound investments with principal, rate and maturity data. `Accrue` compounds interest since the last check, while `Redeem` validates ownership and maturity before returning principal plus earnings.
+
+### SYN2600 – Investor Tokens
+`syn2600.go` registers share allocations for funded projects. The `Issue` constructor validates expiry dates, `Transfer` reassigns ownership and `RecordReturn` appends distribution events so investors can audit payouts.
+
+### SYN2700 – Dividend Distributor
+`syn2700.go` maintains holder balances and computes proportional payouts. `AddHolder` updates the supply and `Distribute` returns a map of address‑to‑dividend amounts without mutating internal state.
+
+### SYN3100 – Employment Contracts
+`syn3100.go` stores employment terms, compensation and tenure data,
+providing a verifiable record of labour agreements across enterprises.
+
+### SYN3200 – Conversion Token
+`syn3200.go` applies a configurable ratio to model wrapped or convertible assets. `Convert` multiplies an amount by the current ratio and `SetRatio` safely updates the conversion factor at runtime.
+
+### SYN3400 – Forex Pair Registry
+`syn3400.go` tracks currency pairs with update timestamps. `Register` assigns a pair ID, `UpdateRate` revises the exchange rate and `List` exposes all pairs for market dashboards.
+
+### SYN3800 – Capped Supply Token
+`syn3800.go` enforces a hard supply limit. `Mint` and `Burn` guard against cap violations, and `Supply` reports current circulation for audit trails.
+
+### SYN3900 – Vesting Registry
+`syn3900.go` locks grants until a release time. `Grant` schedules an amount for an address and `Release` returns funds once the timestamp elapses, preventing double spends.
+
+## Utility and Functional Tokens
+### SYN600 – Reward Token
+`token_syn600.go` implements staking mechanics and reward balances to
+incentivise participation across Blackridge Group Ltd. services.
+
+### SYN721 – Non‑Fungible Token
+`syn721_token.go` stores unique asset metadata and owner addresses,
+providing provenance for one‑of‑a‑kind digital items.
+
+### SYN1155 – Multi‑Asset Token
+`syn1155.go` manages batches of fungible or non‑fungible assets within a
+single contract, streamlining large‑scale mint and transfer operations.
+
+### SYN1700 – Event Tickets
+`syn1700_token.go` issues and manages unique ticket IDs for events. Supply limits, class types and ownership transfers are enforced, allowing venues to verify tickets on chain.
+
+### SYN223 – Secure Transfer Token
+`syn223_token.go` introduces whitelist and blacklist enforcement, preventing transfers to unauthorised addresses. It is suited for regulated environments where recipient eligibility must be validated.
+
+### SYN3500 – Stable Currency
+`syn3500_token.go` models a centrally issued currency or stablecoin. Balances are maintained per address, while the issuer can update the exchange rate to track fiat value. Minting and redemption functions support monetary policy control.
+
+### SYN3700 – Index Token
+`syn3700_token.go` aggregates multiple asset tokens into a weighted index. Components can be added or removed, and index value is calculated from external price feeds.
+
+### SYN4200 – Charity Token
+`syn4200_token.go` facilitates charitable campaigns. Donations accumulate per symbol, and campaign snapshots expose progress and donor contributions, enabling transparent fundraising.
+
+## Gaming and Loyalty Tokens
+### SYN70 – In‑Game Assets
+`syn70.go` registers game items with owners, titles and achievements. `TransferAsset` moves ownership, while `SetAttribute` and `AddAchievement` enrich metadata for player progression.
+
+### SYN2369 – Virtual World Items
+`syn2369.go` manages metaverse objects through an `ItemRegistry`. `CreateItem` assigns IDs and timestamps, `TransferItem` updates custodians and `UpdateAttributes` modifies trait maps for evolving assets.
+
+### SYN500 – Loyalty Points
+`syn500.go` grants promotional balances with explicit expiries. `Mint` seeds an account, and `Redeem` returns points only if they remain valid at redemption time.
+
+## Insurance and Risk Management Tokens
+### SYN845 – Debt Instruments
+`syn845.go` issues debt records with principal, interest and penalty fields.
+The registry enforces unique debt IDs, tracks repayments and exposes
+`RecordPayment` and `GetDebt` for precise liability management.
+
+### SYN2800 – Life Insurance Policies
+`syn2800.go` manages life policies with premium schedules and claim logs.
+Mutex‑protected registries validate coverage periods and allow premium
+payments, claim filings and policy deactivation when terms expire.
+
+### SYN2900 – General Insurance Policies
+`syn2900.go` records property or casualty coverage. Policies capture payout
+limits, deductibles and chronological claim histories, supporting full audit
+trails for adjusters and regulators.
+
+## Derivative and Cross‑Chain Tokens
+### SYN3600 – Governance Weight Ledger
+`syn3600.go` maintains voting weights for addresses via a thread‑safe map. `SetWeight` assigns governance power and `Weight` returns the current allocation for on‑chain decisions.
+
+### SYN5000 – Multi‑Chain Gambling Ledger
+`syn5000.go` records bets with odds and outcomes. Concurrency‑safe storage
+assigns incremental IDs, resolves bets and returns calculated payouts, while
+`GetBet` exposes immutable bet history for compliance review.
+
+### SYN5000 Index – Exposure Tracker
+`syn5000_index.go` specifies an interface for aggregating multiple SYN5000
+instances. Implementations can evaluate network‑wide exposure or route bets
+across chains.
+
+## Data and Intellectual Property Tokens
+### SYN700 – IP Licensing Registry
+`syn700.go` captures intellectual property assets and associated licences. `Register` stores metadata and owner details, `CreateLicense` issues royalty‑bearing agreements and `RecordRoyalty` logs payments for transparent revenue sharing.
+
+### SYN900 – Identity Tokens
+`tokens_syn900.go` records personal identifiers and exposes an
+`IdentityTokenAPI` so services can verify users against a
+privacy‑preserving registry.
+
+### SYN1100 – Healthcare Records
+`syn1100.go` stores encrypted medical records keyed by token ID. Access
+control lists grant or revoke reading rights so only authorised clinicians
+can decrypt patient data.
+
+### SYN1600 – Music Rights Management
+`syn1600.go` models song metadata and royalty splits. Rights holders set
+percentage shares and `Distribute` computes payouts across recipients for a
+given revenue amount.
+
+### SYN2400 – Data Marketplace Token
+`syn2400.go` registers datasets with pricing metadata and consumption
+policies, enabling secure exchange of information assets.
+
+## Environmental and Legal Compliance Tokens
+### SYN200 – Carbon Credit Registry
+`syn200.go` registers carbon‑offset projects, issues credits and records
+verification events. Credits can be retired to prove emissions reduction,
+ensuring transparent sustainability accounting.
+
+### SYN4700 – Legal Process Ledger
+`syn4700.go` represents legal agreements with status tracking, signature
+management and dispute logging. Registries append dispute events with
+timestamps, while mutex‑protected maps maintain party signatures and
+status transitions for evidentiary integrity.
+
+## Comprehensive Token Catalogue
+The Synnergy Network includes a broad library of token standards maintained by Blackridge Group Ltd.  Each token listed below is implemented in the Go codebase and exposes deterministic APIs for enterprise integration.
+
+| Token | Purpose |
+|-------|---------|
+| **DAO Token** | Membership ledger granting voting rights within decentralised organisations. |
+| **SYN10** | Central bank digital currency with issuer metadata and adjustable exchange rate. |
+| **SYN11** | Central bank digital gilts representing government bond obligations. |
+| **SYN12** | Tokenised treasury bill capturing issue and maturity dates, discount and face value. |
+| **SYN20** | Pausable and freezable ledger token for emergency controls. |
+| **SYN70** | In‑game asset tracker storing attributes and achievements for each digital item. |
+| **SYN130** | Tangible asset registry with valuation, sale history and leasing records. |
+| **SYN131** | Intangible asset token representing IP such as patents or trademarks. |
+| **SYN200** | Carbon credit registry issuing, retiring and verifying offset projects. |
+| **SYN223** | Secure transfer token enforcing whitelist and blacklist rules. |
+| **SYN300** | Governance token enabling delegation, proposal creation and on‑chain voting. |
+| **SYN500** | Expiring loyalty‑point registry for promotional programs. |
+| **SYN600** | Reward token with staking mechanics for network incentives. |
+| **SYN700** | Intellectual‑property licensing token with royalty payment logging. |
+| **SYN721** | Non‑fungible token standard tracking unique digital assets. |
+| **SYN800** | Certified asset registry capturing location, asset type and certification identifiers. |
+| **SYN845** | Debt instrument token recording principal, rates, penalties and payments. |
+| **SYN900** | Identity token storing personal details behind an API‑driven registry. |
+| **SYN1000** | Reserve‑backed stablecoin using high‑precision rational numbers for reserves. |
+| **SYN1000 Index** | Management layer for creating and tracking multiple SYN1000 stablecoins. |
+| **SYN1100** | Healthcare record token controlling access to patient data. |
+| **SYN1155** | Multi‑asset token managing batches of fungible and non‑fungible items. |
+| **SYN1300** | Supply‑chain tracking token appending location and condition events. |
+| **SYN1401** | Investment record token storing principal, rate, maturity and accrued interest. |
+| **SYN1500** | Reputation token adjusting influence based on historical behaviour. |
+| **SYN1600** | Music rights token managing royalty splits for artists and collaborators. |
+| **SYN1700** | Event ticket token issuing unique ticket IDs and transfer rules. |
+| **SYN2100** | Trade finance document ledger managing invoices, financiers and liquidity pools. |
+| **SYN2369** | Virtual world item registry supporting custom attributes and ownership history. |
+| **SYN2400** | Data marketplace token registering datasets with pricing metadata. |
+| **SYN2500** | DAO membership registry storing join time, voting power and metadata. |
+| **SYN2600** | Investor token capturing share allocations and periodic returns. |
+| **SYN2700** | Dividend token distributing payouts proportionally to holders. |
+| **SYN2800** | Life insurance policy ledger with premium tracking and claims management. |
+| **SYN2900** | General insurance policy registry covering coverage limits and claim status. |
+| **SYN3000** | Rental token recording lease terms, payments and return conditions. |
+| **SYN3100** | Employment contract token storing compensation and tenure data. |
+| **SYN3200** | Conversion token applying a configurable ratio for wrapped assets. |
+| **SYN3400** | Foreign‑exchange pair registry maintaining exchange rates and update timestamps. |
+| **SYN3500** | Centrally issued currency or stablecoin with adjustable exchange rate. |
+| **SYN3600** | Governance weight ledger assigning voting power. |
+| **SYN3700** | Index token aggregating multiple assets with configurable weights. |
+| **SYN3800** | Capped supply token enforcing maximum circulation. |
+| **SYN3900** | Vesting registry releasing funds once maturity is reached. |
+| **SYN4200** | Charity campaign token recording donations and progress toward goals. |
+| **SYN4700** | Legal process token logging case status, disputes and resolutions. |
+| **SYN4900** | Agricultural commodity token with provenance and event history. |
+| **SYN5000** | Multi‑chain gambling ledger recording cross‑chain bets and payouts. |
+| **SYN5000 Index** | Interface for aggregating SYN5000 ledgers and evaluating exposure. |
+ 
+## Token Lifecycle
+1. **Creation and Minting** – New tokens or assets are registered through constructors such as `NewTangibleAssetRegistry`, `NewSYN3500Token` or `NewAgriculturalRegistry`.
+2. **Transfer and Ownership Management** – Ledgers expose safe `Transfer` functions that validate balances and authorisation. Asset tokens like SYN1700 or SYN130 update ownership directly within their registries.
+3. **Burning and Redemption** – Tokens such as the DAO ledger and SYN3500 support deflationary operations through `Burn` or `Redeem` methods.
+4. **Valuation and Status Updates** – Asset classes include methods like `UpdateValuation`, `UpdateStatus` or `SetRate` to reflect market or lifecycle changes.
+5. **Audit and History** – Many token structures append events to historical arrays, creating immutable audit logs vital for regulatory review.
+6. **Cross‑Chain Settlement** – Tokens such as SYN5000 surface hooks for bridge services so balances and bets can move between chains without breaking accounting.
+7. **CLI and API Automation** – Each module ships with matching CLI commands under `cli/` enabling enterprises to script minting, transfers and registry queries.
+
+## Security and Compliance
+Blackridge Group Ltd. embeds security controls across token modules:
+
+- **Whitelisting & Blacklisting** – SYN223 prevents illicit transfers by validating recipient addresses.
+- **Certification Metadata** – SYN800 and SYN4900 tokens record certification details to meet industry standards.
+- **Mutex‑Protected State** – Concurrency locks across ledgers and registries protect against race conditions during transactions.
+- **Provenance Tracking** – Event histories in SYN1300, SYN4900 and lease/sale records in SYN130 provide full traceability for asset provenance.
+- **Access‑Controlled Records** – SYN1100 gates healthcare data behind granular access lists to maintain patient confidentiality.
+- **Dispute Logging** – SYN4700 records legal disputes and status transitions to support evidentiary workflows.
+
+## Interoperability
+Although each token manages its own state, consistent Go interfaces enable integration with other modules such as the virtual machine, cross‑chain bridge and governance services. Registries can be exposed via APIs or smart contracts, allowing tokens to participate in broader DeFi, supply‑chain or charity ecosystems managed by Blackridge Group Ltd.
+
+## Use Cases
+- **Real‑estate and equipment tokenisation** using SYN130 and SYN800.
+- **IP rights trading** with SYN131.
+- **Event ticketing platforms** leveraging SYN1700 for verifiable tickets.
+- **Compliant digital currencies** backed by SYN3500.
+- **Agricultural commodity marketplaces** powered by SYN4900 and SYN1300 registries.
+- **Transparent philanthropic drives** facilitated through SYN4200.
+
+## Conclusion
+The Synnergy Network token suite developed by Blackridge Group Ltd. demonstrates a modular, secure and extensible approach to digital asset management. By aligning token logic with real‑world processes—governance, asset custody, supply‑chain tracking and charitable giving—the platform equips partners to build sophisticated decentralised applications while maintaining regulatory rigour and operational transparency.
+


### PR DESCRIPTION
## Summary
- document SYN11 gilts and SYN1500 reputation scoring in token reference
- expand utility, identity, and data-marketplace sections with SYN600, SYN721, SYN1155, SYN900, and SYN2400
- cover rental and employment tokens and refresh catalogue with new standards

## Testing
- `go test ./...` *(command produced no output and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68baef3181c48320bbab28a9e7bf9482