### PR TITLE
docs: expand executive summary

### DIFF
--- a/docs/Whitepaper_detailed/Executive Summary.md
+++ b/docs/Whitepaper_detailed/Executive Summary.md
@@ -1,3 +1,63 @@
 # Executive Summary
 
-This is a placeholder for Executive Summary.
+*Prepared by Blackridge Group Ltd.*
+
+## Vision
+Blackridge Group Ltd. delivers Synnergy, an enterprise blockchain framework engineered to bridge traditional finance with decentralised innovation. Our mission is to provide a secure, interoperable and intelligent infrastructure that enables organisations to deploy production‑ready distributed networks with confidence and agility.
+
+## Platform Overview
+Synnergy is a modular, high‑performance blockchain written in Go. It offers pluggable node roles, AI‑assisted tooling and cross‑chain interoperability so ecosystems can prototype, pilot and operate on a single unified codebase. Beyond the core ledger, the repository ships dedicated modules for content distribution, environmental and geospatial monitoring, regulatory oversight and zero‑trust communication, allowing enterprises to tailor deployments to domain‑specific requirements.
+
+## Core Capabilities
+- **Hybrid consensus engine** blending proof‑of‑work, proof‑of‑stake and proof‑of‑history with runtime weight adjustment for optimal performance and security.
+- **Cross‑chain transactions** supporting asset lock‑mint and burn‑release operations managed by robust bridge registries and connection managers.
+- **AI‑powered services** including fraud prediction, fee optimisation, volume forecasting and a model marketplace with escrow settlement.
+- **Role‑based security and compliance** featuring biometric authentication, zero‑trust data channels, PKI tooling and rich audit logs.
+- **Governance and token economy** anchored by the capped Synthron (SYN) coin, deterministic reward halving and customisable token classes.
+- **Infrastructure‑as‑code and automation** through Docker, Helm, Terraform and Ansible templates for repeatable deployments.
+- **Dynamic consensus hopping** adjusts PoW/PoS/PoH weighting in response to live throughput, latency and validator counts.
+- **Operational sustainability** via high‑availability failover managers and energy‑efficiency trackers that monitor validator heartbeats and transactions per kilowatt hour.
+- **Identity and regulatory tooling** providing on‑chain KYC registration, transaction evaluation against jurisdictional rules and automated flagging.
+
+## Node Ecosystem
+Synnergy exposes a diverse set of specialised node implementations to satisfy complex enterprise workloads:
+- **Content nodes** maintain catalogues of distributed digital assets for discovery and retrieval.
+- **Environmental monitoring nodes** evaluate real‑time sensor data against programmable thresholds.
+- **Geospatial nodes** record location streams for asset tracking and compliance reporting.
+- **Regulatory nodes** enforce jurisdictional policies and log flagged entities.
+- **Watchtower nodes** observe system health, firewall events and fork conditions.
+- **Warfare and authority nodes** simulate adversarial scenarios and coordinate governance processes.
+- Additional constructors exist for mining, staking, indexing, mobile, energy‑efficient and other operational roles, each exposing CLI modules for fine‑grained control.
+
+## Enterprise Analytics & Data Services
+Synnergy embeds a comprehensive analytics layer to drive informed decision‑making:
+- **AI services** supply fraud‑scoring, base‑fee optimisation, volume forecasting and a model marketplace with escrow‑backed transactions.
+- **Financial prediction tools** implement moving‑average, linear‑regression and autoregressive models for long‑range price forecasting.
+- **Data resource managers** and distribution engines track content usage, orchestrate data replication and enable granular policy enforcement across nodes.
+- **Anomaly detection and drift monitoring** modules flag deviations in on‑chain activity and AI model performance.
+
+## Architecture Highlights
+- **Node versatility:** specialised constructors enable mining, staking, authority, regulatory, watchtower, warfare and other roles, each exposing dedicated CLI modules and monitoring hooks.
+- **Extensible CLI and SDK:** a Cobra‑based command suite and Go libraries cover networking, wallets, contracts, data operations and system health.
+- **Observability and resilience:** OpenTelemetry tracing, structured logging and high‑availability scripts provide real‑time insight and automated failover across clusters.
+
+## Security & Compliance
+Synnergy enforces strong cryptographic guarantees, permissioned privacy and regulatory alignment. Biometric authentication and zero‑trust data channels secure privileged actions, while the Identity Service and Regulatory Manager enable on‑ledger KYC, transaction screening and automated flagging. Operators can apply stake penalties, audit trails and watchtower nodes for continuous threat monitoring.
+
+## Tokenomics & Governance
+The Synthron coin underpins network consensus, fee markets and governance. Its 500 million maximum supply and scheduled halving events balance early participation with long‑term scarcity, while DAO tooling, staking pools and validator registries enable transparent on‑chain decision‑making. Custom token classes and contract templates further allow ecosystems to launch application‑specific assets that inherit the network’s security and compliance guarantees.
+
+## Deployment & Tooling
+Comprehensive tooling accelerates adoption:
+- **CLI modules** for network management, contract lifecycle, mining, staking and authority operations.
+- **GUI front‑ends** for explorers, marketplaces, dashboards and compliance consoles.
+- **Ansible playbooks** and **Terraform templates** for reproducible infrastructure on bare metal and cloud platforms.
+- **Helm charts** and **Docker images** streamline containerised deployments and orchestration.
+- **Testing and CI** suites spanning unit, integration and fuzz tests to assure code integrity and upgrade safety.
+
+## Roadmap
+Synnergy follows a staged development roadmap encompassing over one hundred modules. Completed milestones span GUI dashboards, cross‑chain bridge tooling, data‑distribution services and compliance consoles, while forthcoming stages expand mining and staking managers, AI marketplaces, analytics suites and governance portals. The incremental approach ensures each component is hardened with documentation, tests and deployment scripts before graduation to production.
+
+## Conclusion
+Blackridge Group Ltd.'s Synnergy Network combines adaptive consensus, intelligent services and rigorous security to deliver a next‑generation blockchain ecosystem. Through a cohesive suite of tools, specialised node roles and infrastructure automation, Synnergy empowers enterprises and communities to unlock new digital economies with confidence while maintaining auditability, sustainability and regulatory trust.
+


### PR DESCRIPTION
## Summary
- broaden executive summary with domain-specific modules and specialized node roles
- document dynamic consensus hopping, operational sustainability, and on-chain identity/regulatory services
- add enterprise analytics, security hardening and infrastructure automation details

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb0e2778c083208ef3e85942df5e33