### PR TITLE
docs: broaden roadmap for edge deployment and standards

### DIFF
--- a/docs/Whitepaper_detailed/Roadmap.md
+++ b/docs/Whitepaper_detailed/Roadmap.md
@@ -1,3 +1,171 @@
-# Roadmap
+# Blackridge Group Ltd. Strategic Roadmap
 
-This is a placeholder for Roadmap.
+## Overview
+The Synnergy Network is the flagship blockchain framework developed by **Blackridge Group Ltd.** to deliver modular, enterprise-grade distributed ledgers. This roadmap synthesizes functionality across the entire codebase—from Go runtime packages and specialized node utilities to TypeScript front-ends and infrastructure scripts—to chart a phased path toward global adoption.
+
+## Phase 1 – Core Platform Maturation
+### Objectives
+- Harden the Go-based runtime, virtual machine and consensus tooling.
+- Finalise essential node roles: mining, staking, authority, regulatory, watchtower, warfare, indexing, content and environmental monitoring nodes.
+- Establish deterministic gas accounting through `synnergy.LoadGasTable()` and `synnergy.RegisterGasCost()`.
+- Expand transaction, wallet and token libraries under `core` and `internal` modules.
+
+### Key Deliverables
+- Stable `cmd/synnergy` entry point and multi-node devnet scripts.
+- Deterministic execution components: `virtual_machine.go`, `vm_sandbox_management.go`, `dynamic_consensus_hopping.go`, `gas_table.go` and `snvm._opcodes.go`.
+- Contract lifecycle libraries: `contracts.go`, `contract_management.go`, `contracts_opcodes.go`.
+- Node utilities: `indexing_node.go`, `content_node.go`, `data_resource_management.go`, `mining_node.go`, `staking_node.go`, `watchtower_node.go`, `warfare_node.go`, `geospatial_node.go`, `mobile_mining_node.go`.
+- Ledger and account foundations: `transaction.go`, `transaction_control.go`, `wallet.go`, `validator_node.go`.
+- Comprehensive unit tests covering networking, transactions, VM execution and consensus switching.
+- Initial documentation for setup, configuration, module boundaries and CLI usage.
+
+## Phase 2 – Interoperability & Network Expansion
+### Objectives
+- Implement cross-chain bridges, protocol registries and connection managers.
+- Support external blockchain integration and cross-chain transaction relays.
+- Introduce dynamic sharding and multi-ledger connectivity.
+
+### Key Deliverables
+- Implementations: `cross_chain.go`, `cross_chain_bridge.go`, `cross_chain_connection.go`, `cross_chain_agnostic_protocols.go`, `cross_chain_contracts.go`, `cross_chain_transactions.go`.
+- JSON-emitting CLIs for deposit, claim, custodial mapping and state proofs.
+- Benchmarks and fuzz tests for cross-chain transaction paths (`cross_chain_transactions_benchmark_test.go`, `tests/fuzz/network_fuzz_test.go`, `cross_chain_stage18_test.go`).
+- Sharding-ready networking, protocol upgrade hooks and pluggable consensus adapters.
+- Sidechain and rollup primitives through `sidechains.go`, `sidechain_ops.go`, `rollups.go`, `cross_consensus_scaling_networks.go`.
+
+## Phase 3 – Security & Compliance Hardening
+### Objectives
+- Enforce role-based security with biometric authentication and zero-trust data channels.
+- Provide regulatory, audit and compliance tooling for institutional deployments.
+- Integrate firewall, identity verification, anomaly detection and system health logging modules.
+
+### Key Deliverables
+- Services: `access_control.go`, `firewall.go`, `identity_verification.go`, `biometric_security_node.go`, `regulatory_node.go`, `zero_trust_data_channels.go`, `compliance.go`, `compliance_management.go`, `forensic_node.go`, `watchtower_node.go`.
+- Identity lifecycle tooling: `idwallet_registration.go`, `biometrics_auth.go`, `wallet.go`, `walletserver/` APIs.
+- `synnergy compliance`, `synnergy audit` and `synnergy security-ops` command suites with structured outputs.
+- Support modules: `anomaly_detection.go`, `system_health_logging.go`, `environmental_monitoring_node.go`, `firewall.go`.
+- Automated security analysis via `make security`, fuzz tests and continuous vulnerability scanning.
+
+## Phase 4 – AI & Data Intelligence Layer
+### Objectives
+- Embed AI modules for contract management, anomaly detection and predictive analytics.
+- Deliver modelling infrastructure and secure storage for AI artefacts.
+- Expand data distribution, resource management and analytics dashboards.
+
+### Key Deliverables
+- AI components: `ai.go`, `ai_model_management.go`, `ai_training.go`, `ai_inference_analysis.go`, `ai_drift_monitor.go`, `ai_enhanced_contract.go`, `ai_secure_storage.go`, `financial_prediction.go`.
+- Data services: `data.go`, `data_distribution.go`, `data_operations.go`, `data_resource_management.go`, `indexing_node.go`.
+- Telemetry and analytics: OpenTelemetry tracing, Prometheus metrics, `system_health_logging.go` and dashboard visualisations.
+- Model validation suites: `ai_modules_test.go`, `ai_inference_analysis_test.go`, `ai_drift_monitor_test.go`.
+- AI-assisted smart contract tooling available through CLI, GUI and `walletserver` APIs.
+
+## Phase 5 – Ecosystem & Developer Experience
+### Objectives
+- Ship production-ready GUIs: NFT marketplace, node operations dashboard, authority node index, wallet admin interface and storage marketplace.
+- Expand documentation to a full MkDocs site with reference guides, tutorials and module indexes.
+- Provide SDKs, templates, sample contracts and comprehensive CLI coverage.
+
+### Key Deliverables
+- TypeScript front-ends under `GUI` with unit and e2e tests, CI pipelines and Docker/Kubernetes manifests.
+- Web and wallet services: `web/`, `walletserver/` and CLI packages under `cmd/` with gRPC/REST APIs.
+- Marketplace engines: `smart_contract_marketplace.go`, `storage_marketplace.go`, `nft_marketplace.go` with corresponding CLI integrations.
+- Smart-contract and storage marketplace modules exposed through `synnergy marketplace` commands and web dashboards.
+- Developer tooling: `tests/fuzz/*`, `tests/formal/contracts_verification_test.go`, templates in `smart-contracts/`, reference indexes under `docs/reference`, `docs/ux/*` and `MODULE_BOUNDARIES.md`.
+- Makefile workflows (`make docs`, `make lint`, `make test`, `make bench`) ensuring consistent quality gates and reproducible builds.
+
+## Phase 6 – Operational Excellence & High Availability
+### Objectives
+- Provide infrastructure-as-code for reproducible deployments across Docker, Helm, Terraform and Ansible.
+- Implement active-active replication, failover scripting and energy-efficient node options.
+- Offer monitoring, alerting, log aggregation and sustainability metrics out-of-the-box.
+
+### Key Deliverables
+- Deployment directories: `deploy/ansible`, `deploy/k8s`, `deploy/helm/synnergy`, `deploy/terraform`, `docker` and accompanying scripts (`scripts/high_availability_setup.sh`, `scripts/ha_failover_test.sh`, `scripts/active_active_sync.sh`).
+- Resilience modules: `high_availability.go`, `high_availability_test.go`, `energy_efficiency.go`, `energy_efficient_node.go`, `environmental_monitoring_node.go`, `light_node.go`, `rpc_webrtc.go`.
+- Observability stack with exporters, dashboards, alert rules and `system_health_logging.go` integrated with Prometheus and Grafana.
+- Sustainability certificates and throttling via `energy_efficiency.go`, `energy_efficient_node.go` and `sustainability_score.wasm`.
+- Distributed performance harnesses and e2e reliability tests: `benchmarks/`, `tests/e2e/network_harness_test.go`.
+
+## Phase 7 – Governance, Economics & Community
+### Objectives
+- Finalise tokenomics, reward distribution and loanpool mechanisms.
+- Enable on-chain governance through DAO modules and voting CLIs.
+- Establish grant, charity and community engagement programs.
+
+### Key Deliverables
+- Governance contracts: `core.NewDAOManager`, `core.NewProposalManager`, `dao.go`, `dao_proposal.go`, `dao_quadratic_voting.go`, `dao_staking.go`, `dao_token.go`, `dao_access_control.go`, `staking_node.go`, `stake_penalty.go`, `loanpool.md`, `Tokenomics.md`.
+- Command suites: `synnergy governance`, `synnergy charity_pool`, `synnergy loanpool`.
+- Policy documentation for staking rewards, halving schedules, authority node incentives and community grants.
+- Community support portals, contributor guides and a public RFC process.
+
+## Phase 8 – Enterprise Integrations & Sector Solutions
+### Objectives
+- Deliver bank and central bank modules for CBDC pilots and sector-specific compliance.
+- Integrate risk engines with `regulatory_management.go` and `financial_prediction.go`.
+- Provide APIs for exchanges, credit management and third-party custodians.
+- Package enterprise support services and SLAs.
+
+### Key Deliverables
+- Institutional modules and docs: `Banks.md`, `Central banks.md`, `Creditors.md`, `faucet.go`, `bank_institutional_node.go`, `centralbank.go`, `bank_nodes_index.go`, `idwallet_registration.go`, `regulatory_management.go`.
+- API gateways and reference connectors for ERP/FinTech systems and exchange integrations.
+- Example sector deployments with Terraform/Helm templates, compliance runbooks and migration scripts.
+- Enterprise onboarding kits, migration guides and 24/7 support playbooks.
+
+## Phase 9 – Advanced Privacy & Formal Verification
+### Objectives
+- Provide end-to-end confidentiality and verifiable execution for regulated industries.
+- Introduce automated formal verification and on-chain audit trails.
+- Strengthen privacy with zero-knowledge proofs and encrypted messaging.
+
+### Key Deliverables
+- Private transaction primitives: `private_transactions.go`, `zk_transaction.wasm`, `threshold_encryption.wasm`.
+- Formal verification harnesses: `tests/formal/contracts_verification_test.go`, model-checking hooks in CI.
+- Confidential data channels via `zero_trust_data_channels.go` and encrypted storage in `ai_secure_storage.go`.
+- Audit-ready logs, state proofs and compliance export utilities.
+
+## Phase 10 – Sustainability & Long‑Term Research
+### Objectives
+- Embed environmental, social and governance (ESG) metrics into network operations.
+- Explore post-quantum cryptography and next-generation consensus algorithms.
+- Foster a research pipeline for emerging technologies and community proposals.
+
+### Key Deliverables
+- Energy and carbon monitors: `energy_efficiency.go`, `energy_efficient_node.go`, `environmental_monitoring_node.go`, `geospatial_node.go`, `sustainability_score.wasm`.
+- Research initiatives for quantum-resistant signatures and hardware acceleration.
+- Community research grants, academic partnerships and periodic whitepaper revisions.
+
+## Phase 11 – Edge, Mobile & Offline Resilience
+### Objectives
+- Extend Synnergy to edge devices, mobile environments and disconnected regions.
+- Provide offline transaction queues and bandwidth-aware synchronisation.
+- Optimise runtimes for lightweight hardware and intermittent connectivity.
+
+### Key Deliverables
+- Edge node implementations: `mobile_mining_node.go`, `geospatial_node.go`, `environmental_monitoring_node.go`, `light_node.go`.
+- Connectivity modules: `rpc_webrtc.go`, `gateway.go`, peer routing via `kademlia.go`.
+- Offline and mobile transaction flows through `cli/mobile_mining_node.go`, `cli/geospatial.go`, `walletserver` mobile APIs.
+- Field deployment guides and power-aware tuning scripts.
+
+## Phase 12 – Standardisation, Certification & Global Adoption
+### Objectives
+- Align network operations with international standards and certification regimes.
+- Offer managed services, SLA-backed support and consortium governance frameworks.
+- Deliver exhaustive documentation, onboarding and training resources for enterprises and regulators.
+
+### Key Deliverables
+- Compliance frameworks and organisational checklists: `regulatory_management.go`, `compliance_management.go`, `PRODUCTION_CHECKLIST.md`, `MODULE_BOUNDARIES.md`, `PRODUCTION_STAGES.md`.
+- End-to-end scenario tests: `tests/e2e/network_harness_test.go`, `tests/gui_wallet_test.go`, `tests/scripts/deploy_contract_test.go`.
+- Certification and SLA packages with monitoring dashboards and incident runbooks.
+- Global rollout playbooks, multilingual documentation under `docs/Whitepaper_detailed` and `docs/ux/*`, and partner enablement programs.
+
+## Future Outlook
+Beyond these phases, Blackridge Group Ltd. will focus on:
+- Advanced privacy features including zk-proofs, confidential transactions and secure multiparty computation.
+- Formal verification of smart contracts and consensus algorithms, with CI hooks for model checking.
+- Quantum-resistant cryptography and post-quantum signature schemes.
+- Partnerships with financial institutions to pilot central bank digital currency modules.
+- Continuous improvement of developer ergonomics, community governance, sustainability tooling and interoperability standards.
+- Expanded edge and mobile deployments with international certification and zero-downtime operations.
+
+## Conclusion
+This roadmap reflects the commitment of **Blackridge Group Ltd.** to deliver a production-ready Synnergy Network. Each phase builds upon the last, ensuring that scalability, security and usability evolve in tandem. Stakeholders are encouraged to follow repository updates and participate in governance discussions as the project progresses.
+


### PR DESCRIPTION
## Summary
- expand core deliverables with additional node roles and ledger libraries
- add sidechain and rollup milestones, forensic security tooling and marketplace engines
- introduce phases for edge/mobile resilience and global standardisation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ad932148320945108872de57246