### PR TITLE
docs: deepen storage whitepaper

### DIFF
--- a/docs/Whitepaper_detailed/Storage.md
+++ b/docs/Whitepaper_detailed/Storage.md
@@ -1,3 +1,123 @@
 # Storage
 
-This is a placeholder for Storage.
+## Blackridge Group Ltd – Synnergy Network Storage Architecture
+
+The storage layer of the Synnergy Network, engineered by **Blackridge Group Ltd**, delivers a resilient and secure foundation for managing on‑chain and off‑chain data. It combines flexible node roles, encrypted communication channels, and a gas‑priced marketplace for decentralised capacity. This section explains the core components, operational workflows and future direction of the storage ecosystem.
+
+---
+
+## 1. Storage Principles
+
+- **Durability and Flexibility** – Nodes choose between archive and pruned modes to balance historical fidelity with local resource constraints【F:core/full_node.go†L5-L12】.
+- **Interoperable Data Services** – Structured feeds, distribution registries and resource managers expose a unified interface for content indexing and retrieval【F:data_operations.go†L1-L42】【F:data_distribution.go†L1-L32】.
+- **Security by Design** – Encryption, sandboxing and zero‑trust channels protect data at rest and in transit【F:ai_secure_storage.go†L1-L45】【F:vm_sandbox_management.go†L1-L52】【F:zero_trust_data_channels.go†L1-L48】.
+
+---
+
+## 2. Node Storage Modes
+
+Full nodes validate the network while storing the ledger in one of two modes:
+
+| Mode | Description |
+|------|-------------|
+| **Archive** | Retains the entire blockchain history for comprehensive auditing and analytics【F:core/full_node.go†L8-L12】 |
+| **Pruned** | Keeps only recent blocks, enabling lightweight operation without sacrificing consensus integrity【F:core/full_node.go†L8-L12】 |
+
+Historical nodes complement full nodes by archiving block summaries, allowing long‑term retrieval without forcing every participant to store the full chain.
+
+---
+
+## 3. Data Management Modules
+
+Synnergy separates data concerns into modular services:
+
+### Data Feeds and Distribution
+`DataFeed` objects manage concurrent updates to external datasets, while the `DataDistribution` registry records which nodes host specific content sets and automatically prunes stale offerings【F:data_operations.go†L9-L33】【F:data_distribution.go†L23-L45】.
+
+### Resource Management
+`DataResourceManager` supplies lightweight key–value storage with byte‑level accounting, ensuring smart contracts and services can track usage and enforce quotas【F:data_resource_management.go†L5-L28】.
+
+### Secure Storage for Models
+The `SecureStorage` facility encrypts AI model bytes with AES‑GCM, storing only sealed payloads and requiring 32‑byte keys for retrieval【F:ai_secure_storage.go†L12-L45】.
+
+### Sandboxed Execution
+The `SandboxManager` orchestrates isolated contract environments with configurable gas and memory limits. Each sandbox can be started, reset or deleted without impacting neighbouring workloads【F:vm_sandbox_management.go†L9-L52】.
+
+### Content Nodes and Discovery
+`ContentNode` instances encrypt large assets with AES‑GCM before assigning them deterministic SHA‑256 identifiers, while `ContentNetworkNode` registries advertise which peers host particular content for network‑wide discovery【F:content_node_impl.go†L14-L57】【F:content_node.go†L5-L33】.
+
+### Archival and Holographic Extensions
+`HistoricalNode` archives block summaries for retrieval by height or hash, and `HolographicNode` distributes redundant frames to preserve data availability across outages【F:internal/nodes/historical_node.go†L8-L70】【F:internal/nodes/holographic_node.go†L9-L37】.
+
+### Forensic Audit Support
+`ForensicNode` records lightweight transaction snapshots and network traces, enabling post‑incident analysis without exposing the full ledger【F:internal/nodes/forensic_node.go†L8-L88】.
+
+---
+
+## 4. Metadata and Indexing
+
+Synnergy augments raw storage with rich discovery and search capabilities:
+
+### Distributed Hash Table
+The lightweight `Kademlia` implementation stores metadata with XOR‑distance lookups, allowing nodes to locate peers or content based on cryptographic identifiers【F:core/kademlia.go†L1-L48】.
+
+### In‑Memory Indexing
+`IndexingNode` instances maintain thread‑safe key/value maps for rapid queries against ledger snapshots or application datasets【F:indexing_node.go†L1-L39】.
+
+### Domain‑Specific Catalogues
+Specialised nodes, such as the `GeospatialNode`, collect structured records like latitude and longitude histories for tracked subjects【F:geospatial_node.go†L8-L31】.
+
+---
+
+## 5. Zero‑Trust Data Channels
+
+The Zero‑Trust Engine establishes encrypted communication channels backed by per‑channel key pairs. Messages are signed with Ed25519, encrypted, and stored for later verification and decryption, enabling confidential exchanges across untrusted networks【F:zero_trust_data_channels.go†L9-L68】.
+
+---
+
+## 6. Storage Marketplace
+
+### Marketplace Structure
+`StorageMarketplace` offers a concurrency‑safe registry of storage listings and deals. Each operation is telemetry‑instrumented and priced through the network’s gas table to limit abuse and provide predictable fees【F:core/storage_marketplace.go†L28-L69】.
+
+### Listing and Deal Workflow
+1. **Create Listing** – A provider registers a content hash, price and owner address. Insufficient gas rejects the request【F:core/storage_marketplace.go†L53-L69】.
+2. **List Listings** – Consumers query available offers, returned as JSON via CLI or GUI adapters【F:core/storage_marketplace.go†L71-L82】.
+3. **Open Deal** – Buyers initiate a deal against a specific listing, again subject to gas limits【F:core/storage_marketplace.go†L84-L100】.
+4. **Close Deal** – Once fulfilled, deals are removed, releasing associated resources【F:core/storage_marketplace.go†L103-L116】.
+
+### Tooling and Automation
+Command‑line utilities (`storage_marketplace` and helper scripts) streamline listing creation and pinning of assets, enabling rapid integration into deployment pipelines and testing environments.
+
+---
+
+## 7. Operations and Automation
+
+Shell helpers invoke the Synnergy binaries to pin data or advertise marketplace capacity, simplifying continuous‑integration jobs and operator runbooks【F:cmd/scripts/storage_pin.sh†L1-L7】【F:scripts/storage_setup.sh†L1-L18】.
+
+The toolkit also includes backup utilities like `backup_ledger.sh` for timestamped ledger archives, ensuring that critical state can be restored after failures【F:scripts/backup_ledger.sh†L1-L38】.
+
+---
+
+## 8. Security, Audit, and Compliance
+
+- **Encrypted Payloads** – All sensitive data is encrypted before storage, whether model bytes or inter‑node messages.
+- **Access Control** – Sandboxes and marketplace operations require explicit gas budgets, curbing denial‑of‑service vectors.
+- **Auditability** – Archive nodes and historical archives provide immutable records, supporting regulatory audits and forensic analysis.
+- **Event Logging** – The `AuditManager` and lightweight `AuditLog` capture chronological records of node events for later review【F:core/audit_management.go†L9-L45】【F:internal/governance/audit_log.go†L1-L24】.
+- **Receipt Retention** – A thread‑safe `ReceiptStore` preserves transaction outcomes, enabling compliance checks and dispute resolution【F:core/transaction_control.go†L173-L203】.
+
+Planned smart contracts (e.g., GDPR‑compliant storage, versioned archives and SLA enforcement) extend these protections to specialised jurisdictions and enterprise use cases.
+
+---
+
+## 9. Future Outlook
+
+Blackridge Group Ltd is expanding the storage layer with distributed backends (IPFS, Arweave and others), contractual SLAs and cross‑chain replication. Ongoing development will surface these capabilities through the same gas‑priced, contract‑driven interfaces that power today’s marketplace.
+
+---
+
+## 10. Conclusion
+
+The Synnergy Network’s storage architecture delivers a holistic framework for data durability, confidentiality and monetisation. By combining modular services, strict security controls and an extensible marketplace, Blackridge Group Ltd enables organisations to store and exchange digital assets with enterprise‑grade assurance.
+


### PR DESCRIPTION
## Summary
- add metadata and indexing section covering Kademlia, in-memory indices, and geospatial catalogs
- document ledger backup tooling and audit logging for enterprise operations

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb0d4d21b48320ab51b92c9136b0de