### PR TITLE
docs: add opcode reference overview

### DIFF
--- a/docs/reference/opcodes_list.md
+++ b/docs/reference/opcodes_list.md
@@ -1,4 +1,11 @@
 <!-- Stage 25 ensures full node, light node, mining, staking, watchtower and warfare opcodes are documented for UI integration -->
+
+# Opcode Reference
+
+This document lists Synnergy's opcode assignments. Each function maps to a
+unique hexadecimal value used across full, light, mining, staking, watchtower
+and warfare nodes as well as UI integrations.
+
 | Function | Opcode |
 |---|---|
 | `Accrue` | `0x100001` |


### PR DESCRIPTION
## Summary
- document purpose of opcode reference and usage across node types

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb390eeb74832097306c2ef4b9ff63