### PR TITLE
docs: remove stage references from whitepaper

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1759,7 +1759,7 @@
 - [x] docs/Whitepaper_detailed/guide/token_guide.md – cross_tx CLI noted
 - [ ] docs/Whitepaper_detailed/guide/transaction_guide.md
 - [ ] docs/Whitepaper_detailed/guide/virtual_machine_guide.md
-- [ ] docs/Whitepaper_detailed/whitepaper.md
+- [x] docs/Whitepaper_detailed/whitepaper.md
 
 **Stage 83**
 - [ ] docs/adr/0001-adopt-mkdocs.md
@@ -4295,7 +4295,7 @@
 - [x] docs/Whitepaper_detailed/guide/token_guide.md – cross_tx CLI noted
 - [ ] docs/Whitepaper_detailed/guide/transaction_guide.md
 - [ ] docs/Whitepaper_detailed/guide/virtual_machine_guide.md
-- [ ] docs/Whitepaper_detailed/whitepaper.md
+- [x] docs/Whitepaper_detailed/whitepaper.md
 - [ ] docs/adr/0001-adopt-mkdocs.md
 - [ ] docs/api/README.md
 - [ ] docs/api/core.md
@@ -6714,7 +6714,7 @@
 | 82 | docs/Whitepaper_detailed/guide/token_guide.md | [x] |
 | 82 | docs/Whitepaper_detailed/guide/transaction_guide.md | [ ] |
 | 82 | docs/Whitepaper_detailed/guide/virtual_machine_guide.md | [ ] |
-| 82 | docs/Whitepaper_detailed/whitepaper.md | [ ] |
+| 82 | docs/Whitepaper_detailed/whitepaper.md | [x] |
 | 83 | docs/adr/0001-adopt-mkdocs.md | [ ] |
 | 83 | docs/api/README.md | [ ] |
 | 83 | docs/api/core.md | [ ] |

--- a/docs/Whitepaper_detailed/whitepaper.md
+++ b/docs/Whitepaper_detailed/whitepaper.md
@@ -13,7 +13,7 @@ Synnergy began as a research effort exploring new consensus strategies and
 virtual machine design. The repository has since grown into an end‑to‑end stack
 that demonstrates how a production network could be assembled. All code is
 released under the Business Source License 1.1 (BUSL‑1.1) and contributions are
-co‑ordinated through the staged workflow described in `AGENTS.md`.
+co‑ordinated through the workflow described in `AGENTS.md`.
 
 ## Architecture
 Synnergy is organised into discrete modules under `core/` and companion packages
@@ -35,59 +35,49 @@ compression allows historic segments of the chain to be archived efficiently.
 A transaction distribution service splits fees between block producers and
 community pools.
 
-Stage 7 formalises error handling and observability for these components. Validator and contract operations emit coded errors and OpenTelemetry traces, allowing operators to audit consensus behaviour across distributed deployments.
-
-Stage 23 further enhances the toolchain by exposing gas costs for consensus and
-governance actions through the CLI, enabling operators to model fees before
-committing transactions.
-Stage 24 introduces enterprise-grade cross-chain tooling. Bridge registration, connection management and Plasma operations now expose deterministic gas fees and optional JSON output so external systems can safely automate transfers.
-Stage 42 finalises this layer: protocol registries, contract mappings and custodial nodes all emit structured JSON through their CLIs, enabling fault-tolerant automation across disparate networks.
-Stage 25 focuses on operational tooling. Node management commands for full,
-light, mining, mobile, optimisation, staking, watchtower and warfare roles now
-emit structured JSON and have explicit gas pricing so that enterprise dashboards
-can monitor and orchestrate infrastructure reliably.
-Stage 26 extends these tools with runtime gas table management. Operators can
-adjust opcode costs without recompiling the network and export the entire
-schedule as JSON, giving auditors and governance systems direct visibility into
-fee policies.
-Stage 27 introduces automation scripts for development and testing networks, including bootstrapping utilities, contract deployment helpers and code quality gates that streamline contributor workflows.
-Stage 28 adds release engineering scripts covering packaging, documentation generation, CI setup and ledger backups, delivering reproducible and auditable deployment processes.
+Error handling and observability for these components are formalised. Validator
+and contract operations emit coded errors and OpenTelemetry traces, allowing
+operators to audit consensus behaviour across distributed deployments. The
+toolchain exposes gas costs for consensus and governance actions through the
+CLI, enabling operators to model fees before committing transactions.
+Enterprise-grade cross-chain tooling offers deterministic gas fees and optional
+JSON output so external systems can safely automate transfers. Protocol
+registries, contract mappings and custodial nodes emit structured JSON through
+their CLIs, enabling fault-tolerant automation across disparate networks.
+Operational tooling covers node management commands for full, light, mining,
+mobile, optimisation, staking, watchtower and warfare roles, all emitting
+structured JSON with explicit gas pricing for reliable orchestration. Runtime
+gas table management lets operators adjust opcode costs without recompiling and
+export the schedule as JSON, giving auditors and governance systems direct
+visibility into fee policies. Automation scripts for development and testing
+networks include bootstrapping utilities, contract deployment helpers and code
+quality gates, while release engineering scripts cover packaging, documentation
+generation, CI setup and ledger backups for reproducible, auditable deployments.
 
 ### Wallets and Network Monitoring
-Stage 12 introduces the data distribution monitor, providing a hardened CLI and GUI for tracking network data flows. The module ships with Docker and Kubernetes deployment assets and feeds telemetry back into the consensus layer for improved operational awareness.
+A data distribution monitor provides a hardened CLI and GUI for tracking network data flows. The module ships with Docker and Kubernetes deployment assets and feeds telemetry back into the consensus layer for improved operational awareness.
 
 ### Governance and DAO
-Stage 9 introduces a lightweight governance layer backed by staking and quadratic
-voting. DAO modules provide proposal management, membership roles, token ledgers
-and custodial nodes, enabling permissioned organisations to coordinate on‑chain.
+A lightweight governance layer backed by staking and quadratic voting provides
+proposal management, membership roles, token ledgers and custodial nodes,
+enabling permissioned organisations to coordinate on‑chain.
 
 ### Token Standards
-Stage 17 expands the token library with standard contracts for central bank
-digital currencies, pausable utility assets and game items. Each implementation
-embeds the concurrency‑safe base token and surfaces dedicated CLI commands for
-minting, transferring and querying balances.
-
-Stage 18 builds on this foundation with advanced financial instruments. New
-registries manage investor share tokens, life and general insurance policies,
-foreign‑exchange pairs, fiat‑pegged currencies, index funds, charity campaigns
-and legal document tokens. All contracts enforce input validation, support
-explicit deactivation and are accessible through dedicated CLI modules.
-
-Stage 19 introduces a reserve‑backed stablecoin (SYN1000) and an accompanying index manager. Both leverage high‑precision arithmetic and thread‑safe data structures to track asset backing and valuations across multiple instances.
-Stage 20 adds a family of token extensions including dividend distribution,
-convertible assets, governance weight ledgers, capped supply utilities,
-time‑locked vesting, loyalty points and multi‑chain balances. These primitives
-share the concurrency guarantees of the base library and expose opcodes and CLI
-wrappers for seamless integration.
-
-Stage 21 introduces a TypeScript-based NFT marketplace and node operations dashboard.
-These web modules expose the same command primitives as the core CLI, delivering
-structured output and hardened error handling while remaining aligned with the
-gas-priced virtual machine and consensus layers.
-
-Stage 22 extends these improvements to AI contract and audit tooling. The
-associated CLI modules expose JSON output and consistent error handling so that
-web dashboards and automated workflows can interact with contract registries and
+The token library includes standard contracts for central bank digital
+currencies, pausable utility assets and game items. Advanced financial
+instruments add registries for investor share tokens, life and general insurance
+policies, foreign‑exchange pairs, fiat‑pegged currencies, index funds, charity
+campaigns and legal document tokens. A reserve‑backed stablecoin (SYN1000) and
+accompanying index manager leverage high‑precision arithmetic and thread‑safe
+data structures to track asset backing and valuations across multiple instances.
+A family of token extensions covers dividend distribution, convertible assets,
+governance weight ledgers, capped supply utilities, time‑locked vesting,
+loyalty points and multi‑chain balances. A TypeScript-based NFT marketplace and
+node operations dashboard expose the same command primitives as the core CLI,
+delivering structured output and hardened error handling while remaining aligned
+with the gas-priced virtual machine and consensus layers. AI contract and audit
+tooling provides JSON output and consistent error handling so that web
+dashboards and automated workflows can interact with contract registries and
 audit logs with minimal coupling.
 
 ### Virtual Machine and Gas Accounting
@@ -95,10 +85,16 @@ Smart contracts execute inside a dedicated virtual machine. Every protocol
 function is assigned a 24‑bit opcode and priced using a deterministic gas table.
 The dispatcher rejects unknown codes and supports pluggable modules for custom
 opcodes. A sandbox manager isolates execution environments so contracts can be
-run with predefined resource limits.
-Stage 11 extends this layer with a context-aware execution engine and lifecycle management for sandboxes, allowing operators to enforce timeouts and remove instances once processing completes. Sandboxes include an inactivity TTL so automated maintenance tasks can purge stale environments and reclaim capacity without manual intervention.
+run with predefined resource limits. A context-aware execution engine and
+lifecycle management for sandboxes allow operators to enforce timeouts and
+remove instances once processing completes. Sandboxes include an inactivity TTL
+so automated maintenance tasks can purge stale environments and reclaim
+capacity without manual intervention.
 
-Stage 29 introduces a library of deployable smart contract templates covering token faucets, storage markets, DAO governance, NFT minting and AI model exchanges. Templates are shipped as precompiled WASM modules and can be instantiated via the CLI with predictable gas costs.
+A library of deployable smart contract templates covers token faucets, storage
+markets, DAO governance, NFT minting and AI model exchanges. Templates are
+shipped as precompiled WASM modules and can be instantiated via the CLI with
+predictable gas costs.
 
 ### Data and Storage Layer
 Synnergy integrates an IPFS‑style storage system for off‑chain assets. The data
@@ -115,15 +111,16 @@ jurisdictional rules. A global access‑control module assigns granular roles to
 validated addresses, and optional biometric authentication modules provide
 additional verification for sensitive workflows. Templates are hashed and
 bound to ECDSA public keys so that enrollment and verification require
-cryptographic proof. Stage 38 finalises these modules by exposing biometric
-enrollment and authentication through hardened CLI commands with gas visibility.
-Stage 13 extends this layer with a zero trust data channel
-engine that signs and encrypts every message, and with regulatory nodes that
-automatically flag non‑compliant transactions into per‑entity logs.
-cryptographic signatures, preventing tampering or replay attacks.
+cryptographic proof. Biometric enrollment and authentication are exposed through
+hardened CLI commands with gas visibility. A zero trust data channel engine
+signs and encrypts every message, and regulatory nodes automatically flag
+non‑compliant transactions into per‑entity logs with cryptographic signatures,
+preventing tampering or replay attacks.
 
 ### Logging and Instrumentation
-Stage 6 introduces a unified logging facade that emits JSON structured events across compliance, consensus and networking modules. Operators can stream these logs to external observability stacks for auditing and real-time monitoring.
+A unified logging facade emits JSON structured events across compliance,
+consensus and networking modules. Operators can stream these logs to external
+observability stacks for auditing and real-time monitoring.
 
 ### AI Services
 AI features are first‑class citizens. Modules such as
@@ -143,12 +140,12 @@ connections to external networks, register contract mappings and relay
 transactions. An agnostic protocol layer enables heterogeneous chains to
 communicate without trusting a central intermediary.
 
-Stage 8 elevates these components with gas‑priced opcodes and accompanying CLI
-commands. Registries for bridges, contracts and transfers are concurrency safe
-and can be backed by persistent stores for fault‑tolerant deployments.
+Gas‑priced opcodes and accompanying CLI commands make registries for bridges,
+contracts and transfers concurrency safe and allow backing by persistent stores
+for fault‑tolerant deployments.
 
 ### Authority and Banking Nodes
-Stage 3 introduces governance‑focused modules. The `AuthorityNodeRegistry` and
+Governance‑focused modules such as the `AuthorityNodeRegistry` and
 `AuthorityApplicationManager` coordinate admission of validator candidates with
 auditable voting. `BankInstitutionalNode` models regulated financial
 participants, allowing institutions to register and interface with the ledger
@@ -163,17 +160,17 @@ regulatory, indexing, watchtower and content nodes. Each type extends the core
 node interface with domain‑specific behaviour, demonstrating how the platform
 can service diverse deployment scenarios.
 
-Stage 14 consolidates these variants under an internal `nodes` package that
-exposes a common lifecycle interface and reusable reference implementations for
-lightweight, watchtower and logistics nodes. This foundation simplifies future
-specialised roles while keeping dependencies minimal.
+An internal `nodes` package exposes a common lifecycle interface and reusable
+reference implementations for lightweight, watchtower and logistics nodes. This
+foundation simplifies future specialised roles while keeping dependencies
+minimal.
 
 ### Central Banking and Charity Modules
-Stage 5 adds economic primitives for public sector deployments. The
-`CentralBankingNode` can mint within the limits enforced by the native coin's
-capped supply and expose monetary policy through the CLI. The `CharityPool`
-coordinates registrations, community voting and fund distribution with gas‑priced
-opcodes so donations and internal transfers can be audited on chain.
+Economic primitives for public sector deployments include a `CentralBankingNode`
+that can mint within the limits enforced by the native coin's capped supply and
+exposes monetary policy through the CLI. The `CharityPool` coordinates
+registrations, community voting and fund distribution with gas‑priced opcodes so
+donations and internal transfers can be audited on chain.
 
 ### Security and Operations
 Runtime security is provided by a firewall module, zero‑trust data channels and
@@ -209,31 +206,24 @@ wallet creation, mnemonic import and transaction signing. Several GUI projects
 under `GUI/` showcase wallet management, explorers, marketplaces, DAO tooling and
 cross‑chain dashboards. Example smart contracts and extensive unit tests provide
 reference implementations for builders.
-Stage 31 delivers a reference GUI wallet that executes CLI commands under the
-hood. Keys are encrypted with scrypt‑derived AES‑GCM and never leave the host,
-providing a model for secure integrations with existing browsers or desktop
-front‑ends.
-Stage 32 adds a CLI-backed Explorer GUI for inspecting chain height and blocks without requiring direct node access.
-Stage 33 introduces an AI Marketplace GUI that deploys AI-enhanced contracts through the CLI, illustrating how complex workflows can be packaged for users.
-Stage 34 debuts a Smart-Contract Marketplace GUI enabling contract deployment and ownership transfers via the CLI.
-Stage 35 launches a Storage Marketplace GUI allowing decentralized storage listings and deals to be managed through the CLI.
+A reference GUI wallet executes CLI commands under the hood. Keys are encrypted
+with scrypt‑derived AES‑GCM and never leave the host, providing a model for
+secure integrations with existing browsers or desktop front‑ends. A CLI-backed
+Explorer GUI inspects chain height and blocks without requiring direct node
+access. An AI Marketplace GUI deploys AI-enhanced contracts through the CLI,
+illustrating how complex workflows can be packaged for users. A Smart-Contract
+Marketplace GUI enables contract deployment and ownership transfers via the CLI,
+and a Storage Marketplace GUI allows decentralized storage listings and deals to
+be managed through the CLI.
 
 Scripts such as `devnet_start.sh` and `testnet_start.sh` help launch local or
-multi‑node networks, while the `docker/` directory provides multi-stage
+multi‑node networks, while the `docker/` directory provides multi-step
 Dockerfiles and a compose setup for running the node and wallet server
-in isolated containers for rapid deployment.
-Stage 48 supplies Kubernetes manifests in `deploy/k8s/` so clusters can
-orchestrate replicated nodes and the wallet server with health probes and
-resource quotas for enterprise deployments.
-Stage 50 adds Terraform and Ansible automation under `deploy/` to provision cloud infrastructure and configure nodes with Infrastructure as Code, enabling repeatable fault-tolerant deployments.
-
-## Roadmap
-Development is guided by a staged plan documented in `AGENTS.md`. Early stages
-focus on core consensus and contract functionality. Later stages introduce GUIs,
-integration tests, containerisation, orchestration manifests and production
-automation. The roadmap extends to 100 stages covering security audits,
-fuzz testing, formal verification and governance infrastructure.
-Stage 16 adds a concurrency-safe token registry with performance benchmarks to validate token throughput under load.
+in isolated containers for rapid deployment. Kubernetes manifests in
+`deploy/k8s/` orchestrate replicated nodes and the wallet server with health
+probes and resource quotas for enterprise deployments. Terraform and Ansible
+automation under `deploy/` provision cloud infrastructure and configure nodes
+with Infrastructure as Code, enabling repeatable fault-tolerant deployments.
 
 ## Conclusion
 Synnergy Network demonstrates how a feature‑rich blockchain can be composed from
@@ -242,9 +232,10 @@ a modular VM, cross‑chain bridges, AI services and numerous specialised nodes
 while providing extensive tooling for developers. Community contributions are
 welcome as the project advances toward a production‑grade platform.
 
-
-Stage 39 debuts a DEX Screener GUI that reads liquidity pool metrics via CLI commands, enabling real-time market monitoring.
-Stage 40 finalises monetary policy tooling: the `coin` CLI validates inputs and emits JSON so wallets and dashboards can query rewards and supply with deterministic gas costs.
+A DEX Screener GUI reads liquidity pool metrics via CLI commands, enabling
+real-time market monitoring. Monetary policy tooling includes a `coin` CLI that
+validates inputs and emits JSON so wallets and dashboards can query rewards and
+supply with deterministic gas costs.
 
 ### Node Operations Dashboard
 A dedicated dashboard module now provides operators with a TypeScript-based CLI and web interface for monitoring node health and status across the network. It consumes opcode and gas metrics exposed by the core system.


### PR DESCRIPTION
## Summary
- strip roadmap section and milestone terminology from whitepaper
- reword Docker description to avoid "stage" references

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb39e337388320872baeb2634f4b86