### PR TITLE
Add security audit results

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1773,6 +1773,8 @@
 - [ ] docs/guides/node_setup.md
 - [ ] docs/index.md
 - [ ] docs/performance_benchmarks.md
+- [x] docs/benchmark_results.md – benchmark test details documented
+- [x] docs/security_audit_results.md – go vet and gosec findings summarised
 - [ ] docs/reference/errors_list.md
 - [ ] docs/reference/functions_list.txt
 - [ ] docs/reference/gas_table_list.md
@@ -6726,6 +6728,8 @@
 | 83 | docs/guides/node_setup.md | [ ] |
 | 83 | docs/index.md | [ ] |
 | 83 | docs/performance_benchmarks.md | [ ] |
+| 83 | docs/benchmark_results.md | [x] |
+| 83 | docs/security_audit_results.md | [x] |
 | 83 | docs/reference/errors_list.md | [ ] |
 | 83 | docs/reference/functions_list.txt | [ ] |
 | 83 | docs/reference/gas_table_list.md | [ ] |

--- a/docs/benchmark_results.md
+++ b/docs/benchmark_results.md
@@ -1,0 +1,40 @@
+# Benchmark Results
+
+The following benchmarks were run with:
+
+```
+go test -bench . ./...
+```
+
+## Test Summary
+
+All unit tests passed when executing:
+
+```
+go test ./...
+```
+
+## synnergy package
+
+| Benchmark | Iterations | ns/op |
+| --- | --- | --- |
+| BenchmarkTransactionManagerLockAndMint | 367810 | 2873 |
+| BenchmarkTransactionManagerBurnAndRelease | 539388 | 2880 |
+| BenchmarkTransactionManagerListTransactions | 10000 | 599597 |
+| BenchmarkTransactionManagerGetTransaction | 3155931 | 380.1 |
+
+## synnergy/core package
+
+| Benchmark | Iterations | ns/op |
+| --- | --- | --- |
+| BenchmarkNFTMarketplaceMint | 1000000 | 1564 |
+
+## synnergy/internal/tokens package
+
+| Benchmark | Iterations | ns/op |
+| --- | --- | --- |
+| BenchmarkBaseTokenTransfer | 30524721 | 39.35 |
+| BenchmarkRegistryInfo | 11217840 | 107.9 |
+
+Benchmarks executed on `Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz`.
+

--- a/docs/security_audit_results.md
+++ b/docs/security_audit_results.md
@@ -1,0 +1,31 @@
+# Security Audit Results
+
+The following security tools were executed:
+
+```bash
+go vet ./...
+gosec ./...
+```
+
+## go vet
+
+`go vet` reported no issues.
+
+## gosec findings
+
+`gosec ./...` flagged 170 issues across the codebase. Key examples include:
+
+- Integer overflow risk when converting lengths in the virtual machine (`virtual_machine.go:147`)
+- Use of a non-cryptographic random generator in the mining node (`mining_node.go:110`)
+- Multiple CLI commands with unhandled errors, such as `base_token.go` and `syn10.go`
+
+These findings should be reviewed and addressed prior to release.
+
+## Test summary
+
+All unit tests pass:
+
+```bash
+go test ./...
+```
+


### PR DESCRIPTION
## Summary
- document go vet and gosec security scan results
- note that all unit tests continue to pass
- track benchmark and security audit docs in AGENTS checklist

## Testing
- `go vet ./...`
- `gosec ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb5bb9c3308320a0f1c7047449e2c0