### PR TITLE
Add geospatial and government CLI tests

### DIFF
--- a/cli/genesis_test.go
+++ b/cli/genesis_test.go
@@ -1,7 +1,31 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestGenesisPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestGenesisShow verifies the show command outputs deterministic wallet addresses.
+func TestGenesisShow(t *testing.T) {
+	out, err := execCommand("genesis", "show")
+	if err != nil {
+		t.Fatalf("show failed: %v", err)
+	}
+	if !strings.Contains(out, genesisWallets.Genesis) {
+		t.Fatalf("genesis address missing from output: %s", out)
+	}
+	if !strings.Contains(out, genesisWallets.AuthorityNodes) {
+		t.Fatalf("authority nodes address missing from output: %s", out)
+	}
+}
+
+// TestGenesisAllocate ensures allocations are displayed for the default wallets.
+func TestGenesisAllocate(t *testing.T) {
+	out, err := execCommand("genesis", "allocate", "1000")
+	if err != nil {
+		t.Fatalf("allocate failed: %v", err)
+	}
+	if !strings.Contains(out, genesisWallets.InternalDevelopment) {
+		t.Fatalf("allocation missing internal development address: %s", out)
+	}
 }

--- a/cli/geospatial.go
+++ b/cli/geospatial.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -24,15 +23,17 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			lat, err := strconv.ParseFloat(args[1], 64)
 			if err != nil {
-				fmt.Println("invalid latitude:", err)
+				printOutput("invalid latitude: " + err.Error())
 				return
 			}
 			lon, err := strconv.ParseFloat(args[2], 64)
 			if err != nil {
-				fmt.Println("invalid longitude:", err)
+				printOutput("invalid longitude: " + err.Error())
 				return
 			}
+			gasPrint("GeospatialRecord")
 			geoNode.Record(args[0], lat, lon)
+			printOutput("recorded")
 		},
 	}
 
@@ -42,9 +43,17 @@ func init() {
 		Short: "Show recorded locations",
 		Run: func(cmd *cobra.Command, args []string) {
 			recs := geoNode.History(args[0])
-			for _, r := range recs {
-				fmt.Printf("%s %f %f %s\n", r.Subject, r.Latitude, r.Longitude, r.Timestamp.Format(time.RFC3339))
+			out := make([]map[string]any, len(recs))
+			for i, r := range recs {
+				out[i] = map[string]any{
+					"subject":   r.Subject,
+					"lat":       r.Latitude,
+					"lon":       r.Longitude,
+					"timestamp": r.Timestamp.Format(time.RFC3339),
+				}
 			}
+			gasPrint("GeospatialHistory")
+			printOutput(out)
 		},
 	}
 

--- a/cli/geospatial_test.go
+++ b/cli/geospatial_test.go
@@ -1,7 +1,35 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestGeospatialPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestGeospatialRecordHistory verifies geospatial records can be stored and retrieved.
+func TestGeospatialRecordHistory(t *testing.T) {
+	if _, err := execCommand("geospatial", "record", "subj", "1.23", "2.34", "--json"); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	out, err := execCommand("geospatial", "history", "subj", "--json")
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var recs []struct {
+		Subject string  `json:"subject"`
+		Lat     float64 `json:"lat"`
+		Lon     float64 `json:"lon"`
+	}
+	if err := json.Unmarshal([]byte(out), &recs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(recs) != 1 || recs[0].Subject != "subj" || recs[0].Lat != 1.23 || recs[0].Lon != 2.34 {
+		t.Fatalf("unexpected record: %v", recs)
+	}
 }

--- a/cli/government.go
+++ b/cli/government.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"synnergy/core"
 )
@@ -18,8 +16,13 @@ func init() {
 		Args:  cobra.ExactArgs(3),
 		Short: "Create a government authority node",
 		Run: func(cmd *cobra.Command, args []string) {
+			gasPrint("GovernmentNew")
 			n := core.NewGovernmentAuthorityNode(args[0], args[1], args[2])
-			fmt.Printf("node address=%s role=%s department=%s\n", n.Address, n.Role, n.Department)
+			printOutput(map[string]string{
+				"address":    n.Address,
+				"role":       n.Role,
+				"department": n.Department,
+			})
 		},
 	}
 

--- a/cli/government_test.go
+++ b/cli/government_test.go
@@ -1,7 +1,28 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestGovernmentPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestGovernmentNew ensures a government authority node can be created.
+func TestGovernmentNew(t *testing.T) {
+	out, err := execCommand("government", "new", "addr1", "role1", "dept1", "--json")
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var resp map[string]string
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["address"] != "addr1" || resp["role"] != "role1" || resp["department"] != "dept1" {
+		t.Fatalf("unexpected response: %v", resp)
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -48,6 +48,7 @@
 - Stage 42: Completed – cross-chain bridge, protocol, connection, contract and custodial CLIs now emit structured JSON with accompanying tests.
 - Stage 43: Completed – DAO CLI now covers proposals, quadratic voting, staking, token and elected-node commands with JSON output and signature verification.
 - Stage 44: Completed – faucet, fees, firewall, forensic, full node and gas CLIs emit JSON with gas tracking and tests.
+- Stage 45: In Progress – genesis, geospatial and government CLI tests implemented; high availability, historical, holographic node and identity CLIs pending.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -965,12 +966,12 @@
 - [ ] cli/genesis.go
 
 **Stage 45**
-- [ ] cli/genesis_cli_test.go
-- [ ] cli/genesis_test.go
-- [ ] cli/geospatial.go
-- [ ] cli/geospatial_test.go
-- [ ] cli/government.go
-- [ ] cli/government_test.go
+- [x] cli/genesis_cli_test.go
+- [x] cli/genesis_test.go
+- [x] cli/geospatial.go
+- [x] cli/geospatial_test.go
+- [x] cli/government.go
+- [x] cli/government_test.go
 - [ ] cli/high_availability.go
 - [ ] cli/high_availability_test.go
 - [ ] cli/historical.go


### PR DESCRIPTION
## Summary
- add gas-tracked, JSON-capable geospatial CLI with history retrieval
- return structured data from government CLI and verify with tests
- record Stage 45 progress for geospatial and government modules

## Testing
- `go test ./cli -run '(GeospatialRecordHistory|GovernmentNew)' -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68bb819f73b883209b111bfc55794c1e