### PR TITLE
feat: extend consensus and DAO CLI JSON support

### DIFF
--- a/cli/consensus.go
+++ b/cli/consensus.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -20,18 +19,18 @@ func init() {
 		Use:   "mine [difficulty]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Mine a block",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("MineBlock")
+		Run: func(cmd *cobra.Command, args []string) {
 			diff, err := strconv.ParseUint(args[0], 10, 8)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid difficulty"})
+				return
 			}
 			sb := core.NewSubBlock([]*core.Transaction{}, "validator")
 			b := core.NewBlock([]*core.SubBlock{sb}, "")
 			consensus.MineBlock(b, uint8(diff))
 			ilog.Info("cli_mine", "nonce", b.Nonce)
-			fmt.Println("block mined with nonce", b.Nonce)
-			return nil
+			gasPrint("MineBlock")
+			printOutput(map[string]any{"nonce": b.Nonce})
 		},
 	}
 
@@ -41,7 +40,7 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			gasPrint("Weights")
 			ilog.Info("cli_weights", "pow", consensus.Weights.PoW, "pos", consensus.Weights.PoS, "poh", consensus.Weights.PoH)
-			fmt.Printf("PoW: %.2f PoS: %.2f PoH: %.2f\n", consensus.Weights.PoW, consensus.Weights.PoS, consensus.Weights.PoH)
+			printOutput(map[string]float64{"pow": consensus.Weights.PoW, "pos": consensus.Weights.PoS, "poh": consensus.Weights.PoH})
 		},
 	}
 
@@ -49,20 +48,21 @@ func init() {
 		Use:   "adjust [demand] [stake]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Adjust consensus weights",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("AdjustWeights")
+		Run: func(cmd *cobra.Command, args []string) {
 			d, err := strconv.ParseFloat(args[0], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid demand"})
+				return
 			}
 			s, err := strconv.ParseFloat(args[1], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid stake"})
+				return
 			}
 			consensus.AdjustWeights(d, s)
 			ilog.Info("cli_adjust", "pow", consensus.Weights.PoW, "pos", consensus.Weights.PoS, "poh", consensus.Weights.PoH)
-			fmt.Printf("new weights -> PoW: %.2f PoS: %.2f PoH: %.2f\n", consensus.Weights.PoW, consensus.Weights.PoS, consensus.Weights.PoH)
-			return nil
+			gasPrint("AdjustWeights")
+			printOutput(map[string]float64{"pow": consensus.Weights.PoW, "pos": consensus.Weights.PoS, "poh": consensus.Weights.PoH})
 		},
 	}
 
@@ -70,20 +70,21 @@ func init() {
 		Use:   "threshold [demand] [stake]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Calculate switching threshold",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("Threshold")
+		Run: func(cmd *cobra.Command, args []string) {
 			d, err := strconv.ParseFloat(args[0], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid demand"})
+				return
 			}
 			s, err := strconv.ParseFloat(args[1], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid stake"})
+				return
 			}
 			th := consensus.Threshold(d, s)
 			ilog.Info("cli_threshold", "value", th)
-			fmt.Println("threshold:", th)
-			return nil
+			gasPrint("Threshold")
+			printOutput(map[string]float64{"threshold": th})
 		},
 	}
 
@@ -91,24 +92,26 @@ func init() {
 		Use:   "transition [demand] [threat] [stake]",
 		Args:  cobra.ExactArgs(3),
 		Short: "Compute full transition threshold",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("TransitionThreshold")
+		Run: func(cmd *cobra.Command, args []string) {
 			d, err := strconv.ParseFloat(args[0], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid demand"})
+				return
 			}
 			t, err := strconv.ParseFloat(args[1], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid threat"})
+				return
 			}
 			s, err := strconv.ParseFloat(args[2], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid stake"})
+				return
 			}
 			thr := consensus.TransitionThreshold(d, t, s)
 			ilog.Info("cli_transition", "value", thr)
-			fmt.Println("transition threshold:", thr)
-			return nil
+			gasPrint("TransitionThreshold")
+			printOutput(map[string]float64{"threshold": thr})
 		},
 	}
 
@@ -116,24 +119,26 @@ func init() {
 		Use:   "difficulty [old] [actual] [expected]",
 		Args:  cobra.ExactArgs(3),
 		Short: "Adjust mining difficulty",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("DifficultyAdjust")
+		Run: func(cmd *cobra.Command, args []string) {
 			old, err := strconv.ParseFloat(args[0], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid old"})
+				return
 			}
 			actual, err := strconv.ParseFloat(args[1], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid actual"})
+				return
 			}
 			expected, err := strconv.ParseFloat(args[2], 64)
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid expected"})
+				return
 			}
 			nd := consensus.DifficultyAdjust(old, actual, expected)
 			ilog.Info("cli_difficulty", "value", nd)
-			fmt.Println("new difficulty:", nd)
-			return nil
+			gasPrint("DifficultyAdjust")
+			printOutput(map[string]float64{"difficulty": nd})
 		},
 	}
 
@@ -141,23 +146,26 @@ func init() {
 		Use:   "availability [pow] [pos] [poh]",
 		Args:  cobra.ExactArgs(3),
 		Short: "Set validator availability flags",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("SetAvailability")
+		Run: func(cmd *cobra.Command, args []string) {
 			pow, err := strconv.ParseBool(args[0])
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid pow"})
+				return
 			}
 			pos, err := strconv.ParseBool(args[1])
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid pos"})
+				return
 			}
 			poh, err := strconv.ParseBool(args[2])
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid poh"})
+				return
 			}
 			consensus.SetAvailability(pow, pos, poh)
 			ilog.Info("cli_availability", "pow", pow, "pos", pos, "poh", poh)
-			return nil
+			gasPrint("SetAvailability")
+			printOutput(map[string]bool{"pow": pow, "pos": pos, "poh": poh})
 		},
 	}
 
@@ -165,15 +173,16 @@ func init() {
 		Use:   "powrewards [enabled]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Toggle PoW rewards availability",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("SetPoWRewards")
+		Run: func(cmd *cobra.Command, args []string) {
 			en, err := strconv.ParseBool(args[0])
 			if err != nil {
-				return err
+				printOutput(map[string]any{"error": "invalid flag"})
+				return
 			}
 			consensus.SetPoWRewards(en)
 			ilog.Info("cli_pow_rewards", "enabled", en)
-			return nil
+			gasPrint("SetPoWRewards")
+			printOutput(map[string]bool{"enabled": en})
 		},
 	}
 

--- a/cli/consensus_test.go
+++ b/cli/consensus_test.go
@@ -1,17 +1,27 @@
 package cli
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
 
 // TestConsensusWeights ensures consensus weights command prints expected values.
 func TestConsensusWeights(t *testing.T) {
-	out, err := execCommand("consensus", "weights")
+	out, err := execCommand("--json", "consensus", "weights")
 	if err != nil {
 		t.Fatalf("weights failed: %v", err)
 	}
-	if !strings.Contains(out, "PoW") || !strings.Contains(out, "PoS") {
-		t.Fatalf("unexpected output: %s", out)
+	start := strings.LastIndex(out, "{")
+	end := strings.LastIndex(out, "}")
+	if start != -1 && end != -1 {
+		out = out[start : end+1]
+	}
+	var res map[string]float64
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := res["pow"]; !ok {
+		t.Fatalf("missing pow weight: %v", res)
 	}
 }

--- a/cli/contract_management_test.go
+++ b/cli/contract_management_test.go
@@ -1,17 +1,27 @@
 package cli
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
 
 // TestContractManagerInfoError checks that querying a missing contract prints an error.
 func TestContractManagerInfoError(t *testing.T) {
-	out, err := execCommand("contract-mgr", "info", "missing")
+	out, err := execCommand("--json", "contract-mgr", "info", "missing")
 	if err != nil {
 		t.Fatalf("info failed: %v", err)
 	}
-	if !strings.Contains(out, "error") {
-		t.Fatalf("expected error output, got %q", out)
+	start := strings.LastIndex(out, "{")
+	end := strings.LastIndex(out, "}")
+	if start != -1 && end != -1 {
+		out = out[start : end+1]
+	}
+	var res map[string]any
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if res["error"] == nil {
+		t.Fatalf("expected error field, got %v", res)
 	}
 }

--- a/cli/dao_test.go
+++ b/cli/dao_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -9,47 +8,56 @@ import (
 
 // TestDAOCLIFlow verifies basic DAO creation and JSON listing via the CLI.
 func TestDAOCLIFlow(t *testing.T) {
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"dao", "create", "testdao", "creator"})
-	if err := rootCmd.Execute(); err != nil {
+	out, err := execCommand("--json", "dao", "create", "testdao", "creator")
+	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-	id := lines[len(lines)-1]
+	start := strings.LastIndex(out, "{")
+	end := strings.LastIndex(out, "}")
+	if start != -1 && end != -1 {
+		out = out[start : end+1]
+	}
+	var createRes map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &createRes); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	id, _ := createRes["id"].(string)
 	if id == "" {
 		t.Fatalf("expected DAO id output")
 	}
 
-	buf.Reset()
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"dao", "join", id, "member1"})
-	if err := rootCmd.Execute(); err != nil {
+	if _, err := execCommand("--json", "dao", "join", id, "member1"); err != nil {
 		t.Fatalf("join: %v", err)
 	}
 
-	buf.Reset()
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"dao", "info", id, "--json"})
-	if err := rootCmd.Execute(); err != nil {
+	out, err = execCommand("--json", "dao", "info", id)
+	if err != nil {
 		t.Fatalf("info: %v", err)
 	}
+	start = strings.LastIndex(out, "{")
+	end = strings.LastIndex(out, "}")
+	if start != -1 && end != -1 {
+		out = out[start : end+1]
+	}
 	var info map[string]interface{}
-	if err := json.NewDecoder(buf).Decode(&info); err != nil {
+	if err := json.Unmarshal([]byte(out), &info); err != nil {
 		t.Fatalf("decode info: %v", err)
 	}
-	if info["Name"] != "testdao" {
+	if info["name"] != "testdao" {
 		t.Fatalf("unexpected info name: %v", info)
 	}
 
-	buf.Reset()
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"dao", "list", "--json"})
-	if err := rootCmd.Execute(); err != nil {
+	out, err = execCommand("--json", "dao", "list")
+	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
+	s := strings.Index(out, "[")
+	e := strings.LastIndex(out, "]")
+	if s != -1 && e != -1 && e >= s {
+		out = out[s : e+1]
+	}
 	var list []map[string]interface{}
-	if err := json.NewDecoder(buf).Decode(&list); err != nil {
+	if err := json.Unmarshal([]byte(out), &list); err != nil {
 		t.Fatalf("decode list: %v", err)
 	}
 	if len(list) == 0 {

--- a/cli/dao_token_test.go
+++ b/cli/dao_token_test.go
@@ -1,13 +1,13 @@
 package cli
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"synnergy/core"
@@ -36,15 +36,17 @@ func TestDAOTokenMintJSON(t *testing.T) {
 	pubHex := hex.EncodeToString(pub)
 	msgHex := hex.EncodeToString(msg)
 
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"dao-token", "mint", addr, amt, "--pub", pubHex, "--msg", msgHex, "--sig", sigHex, "--json"})
-	if err := rootCmd.Execute(); err != nil {
+	out, err := execCommand("dao-token", "mint", addr, amt, "--pub", pubHex, "--msg", msgHex, "--sig", sigHex, "--json")
+	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-
+	start := strings.LastIndex(out, "{")
+	end := strings.LastIndex(out, "}")
+	if start != -1 && end != -1 {
+		out = out[start : end+1]
+	}
 	var resp map[string]string
-	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if resp["status"] != "minted" {

--- a/cli/elected_authority_node_test.go
+++ b/cli/elected_authority_node_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -40,8 +41,14 @@ func TestElectedNodeCreateJSON(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 
+	out := buf.String()
+	start := strings.LastIndex(out, "{")
+	end := strings.LastIndex(out, "}")
+	if start != -1 && end != -1 {
+		out = out[start : end+1]
+	}
 	var resp map[string]string
-	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if resp["status"] != "created" {

--- a/cli/high_availability.go
+++ b/cli/high_availability.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -24,10 +23,12 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			t, err := strconv.ParseInt(args[1], 10, 64)
 			if err != nil {
-				fmt.Println("invalid timeout:", err)
+				printOutput("invalid timeout: " + err.Error())
 				return
 			}
 			failover = core.NewFailoverManager(args[0], time.Duration(t)*time.Second)
+			gasPrint("FailoverInit")
+			printOutput(map[string]any{"status": "initialised", "primary": args[0], "timeout": t})
 		},
 	}
 
@@ -37,10 +38,12 @@ func init() {
 		Short: "Register a backup node",
 		Run: func(cmd *cobra.Command, args []string) {
 			if failover == nil {
-				fmt.Println("manager not initialised")
+				printOutput("manager not initialised")
 				return
 			}
 			failover.RegisterBackup(args[0])
+			gasPrint("FailoverRegister")
+			printOutput(map[string]any{"status": "registered", "id": args[0]})
 		},
 	}
 
@@ -50,10 +53,12 @@ func init() {
 		Short: "Record a heartbeat",
 		Run: func(cmd *cobra.Command, args []string) {
 			if failover == nil {
-				fmt.Println("manager not initialised")
+				printOutput("manager not initialised")
 				return
 			}
 			failover.Heartbeat(args[0])
+			gasPrint("FailoverHeartbeat")
+			printOutput(map[string]any{"status": "heartbeat", "id": args[0]})
 		},
 	}
 
@@ -62,10 +67,11 @@ func init() {
 		Short: "Show active node",
 		Run: func(cmd *cobra.Command, args []string) {
 			if failover == nil {
-				fmt.Println("manager not initialised")
+				printOutput("manager not initialised")
 				return
 			}
-			fmt.Println(failover.Active())
+			gasPrint("FailoverActive")
+			printOutput(map[string]any{"active": failover.Active()})
 		},
 	}
 

--- a/cli/high_availability_test.go
+++ b/cli/high_availability_test.go
@@ -1,7 +1,51 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestHighavailabilityPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestHighAvailabilityWorkflow verifies failover manager CLI commands output JSON.
+func TestHighAvailabilityWorkflow(t *testing.T) {
+	if _, err := execCommand("highavailability", "init", "p1", "1", "--json"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+
+	if _, err := execCommand("highavailability", "add", "b1", "--json"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+
+	if _, err := execCommand("highavailability", "heartbeat", "b1", "--json"); err != nil {
+		t.Fatalf("heartbeat: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+
+	out, err := execCommand("highavailability", "active", "--json")
+	if err != nil {
+		t.Fatalf("active: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var resp map[string]string
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["active"] != "p1" {
+		t.Fatalf("unexpected active node: %v", resp)
+	}
+
+	t.Cleanup(func() { failover = nil })
 }

--- a/cli/historical.go
+++ b/cli/historical.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -25,13 +24,16 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			h, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
-				fmt.Println("invalid height:", err)
+				printOutput("invalid height: " + err.Error())
 				return
 			}
 			summary := nodes.BlockSummary{Height: h, Hash: args[1], Timestamp: time.Now()}
 			if err := historicalNode.ArchiveBlock(summary); err != nil {
-				fmt.Println("archive error:", err)
+				printOutput("archive error: " + err.Error())
+				return
 			}
+			gasPrint("HistoricalArchive")
+			printOutput(map[string]any{"status": "archived", "height": h, "hash": args[1]})
 		},
 	}
 
@@ -42,15 +44,16 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			h, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
-				fmt.Println("invalid height:", err)
+				printOutput("invalid height: " + err.Error())
 				return
 			}
 			b, ok := historicalNode.GetBlockByHeight(h)
 			if !ok {
-				fmt.Println("not found")
+				printOutput("not found")
 				return
 			}
-			fmt.Printf("%d %s %s\n", b.Height, b.Hash, b.Timestamp.Format(time.RFC3339))
+			gasPrint("HistoricalHeight")
+			printOutput(map[string]any{"height": b.Height, "hash": b.Hash, "timestamp": b.Timestamp.Format(time.RFC3339)})
 		},
 	}
 
@@ -61,10 +64,11 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			b, ok := historicalNode.GetBlockByHash(args[0])
 			if !ok {
-				fmt.Println("not found")
+				printOutput("not found")
 				return
 			}
-			fmt.Printf("%d %s %s\n", b.Height, b.Hash, b.Timestamp.Format(time.RFC3339))
+			gasPrint("HistoricalHash")
+			printOutput(map[string]any{"height": b.Height, "hash": b.Hash, "timestamp": b.Timestamp.Format(time.RFC3339)})
 		},
 	}
 
@@ -72,7 +76,8 @@ func init() {
 		Use:   "total",
 		Short: "Show total archived blocks",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(historicalNode.TotalBlocks())
+			gasPrint("HistoricalTotal")
+			printOutput(map[string]int{"total": historicalNode.TotalBlocks()})
 		},
 	}
 

--- a/cli/historical_test.go
+++ b/cli/historical_test.go
@@ -1,7 +1,100 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
 
-func TestHistoricalPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestHistoricalWorkflow ensures historical node CLI commands emit JSON output.
+func TestHistoricalWorkflow(t *testing.T) {
+	out, err := execCommand("historical", "archive", "1", "h1", "--json")
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var archResp struct {
+		Status string `json:"status"`
+		Height uint64 `json:"height"`
+		Hash   string `json:"hash"`
+	}
+	if err := json.Unmarshal([]byte(out), &archResp); err != nil {
+		t.Fatalf("unmarshal archive: %v", err)
+	}
+	if archResp.Status != "archived" || archResp.Height != 1 || archResp.Hash != "h1" {
+		t.Fatalf("unexpected archive response: %+v", archResp)
+	}
+
+	out, err = execCommand("historical", "height", "1", "--json")
+	if err != nil {
+		t.Fatalf("height: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var blockResp struct {
+		Height    uint64 `json:"height"`
+		Hash      string `json:"hash"`
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal([]byte(out), &blockResp); err != nil {
+		t.Fatalf("unmarshal height: %v", err)
+	}
+	if blockResp.Height != 1 || blockResp.Hash != "h1" {
+		t.Fatalf("unexpected height response: %+v", blockResp)
+	}
+
+	out, err = execCommand("historical", "hash", "h1", "--json")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var hashResp struct {
+		Height    uint64 `json:"height"`
+		Hash      string `json:"hash"`
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal([]byte(out), &hashResp); err != nil {
+		t.Fatalf("unmarshal hash: %v", err)
+	}
+	if hashResp.Height != 1 || hashResp.Hash != "h1" {
+		t.Fatalf("unexpected hash response: %+v", hashResp)
+	}
+
+	out, err = execCommand("historical", "total", "--json")
+	if err != nil {
+		t.Fatalf("total: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var totalResp struct {
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal([]byte(out), &totalResp); err != nil {
+		t.Fatalf("unmarshal total: %v", err)
+	}
+	if totalResp.Total != 1 {
+		t.Fatalf("unexpected total response: %+v", totalResp)
+	}
+
+	t.Cleanup(func() { historicalNode = core.NewHistoricalNode() })
 }

--- a/cli/holographic_node.go
+++ b/cli/holographic_node.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -24,12 +23,13 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			n, err := strconv.Atoi(args[2])
 			if err != nil {
-				fmt.Println("invalid shard count:", err)
+				printOutput("invalid shard count: " + err.Error())
 				return
 			}
 			frame := synnergy.SplitHolographic(args[0], []byte(args[1]), n)
 			holoNode.Store(frame)
-			fmt.Println("stored")
+			gasPrint("HolographicStore")
+			printOutput(map[string]any{"status": "stored", "id": args[0], "shards": n})
 		},
 	}
 
@@ -40,11 +40,12 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			frame, ok := holoNode.Retrieve(args[0])
 			if !ok {
-				fmt.Println("not found")
+				printOutput("not found")
 				return
 			}
 			data := synnergy.ReconstructHolographic(frame)
-			fmt.Println(string(data))
+			gasPrint("HolographicRetrieve")
+			printOutput(map[string]any{"id": args[0], "data": string(data)})
 		},
 	}
 
@@ -52,9 +53,8 @@ func init() {
 		Use:   "peers",
 		Short: "List known peers",
 		Run: func(cmd *cobra.Command, args []string) {
-			for _, p := range holoNode.Peers() {
-				fmt.Println(p)
-			}
+			gasPrint("HolographicPeers")
+			printOutput(map[string]any{"peers": holoNode.Peers()})
 		},
 	}
 
@@ -64,8 +64,11 @@ func init() {
 		Short: "Dial a seed peer",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := holoNode.DialSeed(nodes.Address(args[0])); err != nil {
-				fmt.Println("dial error:", err)
+				printOutput("dial error: " + err.Error())
+				return
 			}
+			gasPrint("HolographicDial")
+			printOutput(map[string]any{"status": "connected", "addr": args[0]})
 		},
 	}
 

--- a/cli/holographic_node_test.go
+++ b/cli/holographic_node_test.go
@@ -1,7 +1,84 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
 
-func TestHolographicnodePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	nodes "synnergy/internal/nodes"
+)
+
+// TestHolographicNodeWorkflow verifies holographic node CLI commands emit JSON output.
+func TestHolographicNodeWorkflow(t *testing.T) {
+	out, err := execCommand("holographic", "store", "id1", "data", "2", "--json")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var storeResp struct {
+		Status string `json:"status"`
+		ID     string `json:"id"`
+		Shards int    `json:"shards"`
+	}
+	if err := json.Unmarshal([]byte(out), &storeResp); err != nil {
+		t.Fatalf("unmarshal store: %v", err)
+	}
+	if storeResp.Status != "stored" || storeResp.ID != "id1" || storeResp.Shards != 2 {
+		t.Fatalf("unexpected store response: %+v", storeResp)
+	}
+
+	out, err = execCommand("holographic", "retrieve", "id1", "--json")
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var retResp struct {
+		ID   string `json:"id"`
+		Data string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &retResp); err != nil {
+		t.Fatalf("unmarshal retrieve: %v", err)
+	}
+	if retResp.ID != "id1" || retResp.Data != "data" {
+		t.Fatalf("unexpected retrieve response: %+v", retResp)
+	}
+
+	if _, err := execCommand("holographic", "dial", "peer1", "--json"); err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+
+	out, err = execCommand("holographic", "peers", "--json")
+	if err != nil {
+		t.Fatalf("peers: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var peersResp struct {
+		Peers []string `json:"peers"`
+	}
+	if err := json.Unmarshal([]byte(out), &peersResp); err != nil {
+		t.Fatalf("unmarshal peers: %v", err)
+	}
+	if len(peersResp.Peers) != 1 || peersResp.Peers[0] != string(nodes.Address("peer1")) {
+		t.Fatalf("unexpected peers response: %+v", peersResp)
+	}
+
+	t.Cleanup(func() { holoNode = nodes.NewHolographicNode(nodes.Address("holo-1")) })
 }

--- a/cli/identity.go
+++ b/cli/identity.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"synnergy/core"
 )
@@ -21,8 +19,11 @@ func init() {
 		Short: "Register identity information",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := identitySvc.Register(args[0], args[1], args[2], args[3]); err != nil {
-				fmt.Println("error:", err)
+				printOutput(map[string]any{"error": err.Error()})
+				return
 			}
+			gasPrint("IdentityRegister")
+			printOutput(map[string]any{"status": "registered", "address": args[0]})
 		},
 	}
 
@@ -32,8 +33,11 @@ func init() {
 		Short: "Record a verification method",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := identitySvc.Verify(args[0], args[1]); err != nil {
-				fmt.Println("error:", err)
+				printOutput(map[string]any{"error": err.Error()})
+				return
 			}
+			gasPrint("IdentityVerify")
+			printOutput(map[string]any{"status": "verified", "address": args[0], "method": args[1]})
 		},
 	}
 
@@ -44,10 +48,11 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			info, ok := identitySvc.Info(args[0])
 			if !ok {
-				fmt.Println("not found")
+				printOutput(map[string]any{"error": "not found"})
 				return
 			}
-			fmt.Printf("Name: %s DOB: %s Nationality: %s\n", info.Name, info.DateOfBirth, info.Nationality)
+			gasPrint("IdentityInfo")
+			printOutput(map[string]any{"name": info.Name, "dob": info.DateOfBirth, "nationality": info.Nationality})
 		},
 	}
 
@@ -57,9 +62,8 @@ func init() {
 		Short: "Show verification logs",
 		Run: func(cmd *cobra.Command, args []string) {
 			logs := identitySvc.Logs(args[0])
-			for _, l := range logs {
-				fmt.Printf("%s %s\n", l.Method, l.Timestamp.Format("2006-01-02T15:04:05"))
-			}
+			gasPrint("IdentityLogs")
+			printOutput(logs)
 		},
 	}
 

--- a/cli/identity_test.go
+++ b/cli/identity_test.go
@@ -1,7 +1,86 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
 
-func TestIdentityPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestIdentityWorkflow exercises identity CLI commands and validates JSON output.
+func TestIdentityWorkflow(t *testing.T) {
+	out, err := execCommand("identity", "register", "addr1", "Alice", "1990-01-01", "US", "--json")
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var regResp map[string]string
+	if err := json.Unmarshal([]byte(out), &regResp); err != nil {
+		t.Fatalf("unmarshal register: %v", err)
+	}
+	if regResp["status"] != "registered" || regResp["address"] != "addr1" {
+		t.Fatalf("unexpected register response: %+v", regResp)
+	}
+
+	out, err = execCommand("identity", "verify", "addr1", "passport", "--json")
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var verResp map[string]string
+	if err := json.Unmarshal([]byte(out), &verResp); err != nil {
+		t.Fatalf("unmarshal verify: %v", err)
+	}
+	if verResp["status"] != "verified" || verResp["method"] != "passport" {
+		t.Fatalf("unexpected verify response: %+v", verResp)
+	}
+
+	out, err = execCommand("identity", "info", "addr1", "--json")
+	if err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var infoResp map[string]string
+	if err := json.Unmarshal([]byte(out), &infoResp); err != nil {
+		t.Fatalf("unmarshal info: %v", err)
+	}
+	if infoResp["name"] != "Alice" || infoResp["dob"] != "1990-01-01" || infoResp["nationality"] != "US" {
+		t.Fatalf("unexpected info response: %+v", infoResp)
+	}
+
+	out, err = execCommand("identity", "logs", "addr1", "--json")
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var logs []map[string]string
+	if err := json.Unmarshal([]byte(out), &logs); err != nil {
+		t.Fatalf("unmarshal logs: %v", err)
+	}
+	if len(logs) != 1 || logs[0]["Method"] != "passport" {
+		t.Fatalf("unexpected logs: %+v", logs)
+	}
+
+	t.Cleanup(func() { identitySvc = core.NewIdentityService() })
 }

--- a/cli/idwallet.go
+++ b/cli/idwallet.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"synnergy/core"
 )
@@ -21,8 +19,11 @@ func init() {
 		Short: "Register an ID wallet",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := idRegistry.Register(args[0], args[1]); err != nil {
-				fmt.Println("error:", err)
+				printOutput(map[string]any{"error": err.Error()})
+				return
 			}
+			gasPrint("IDWalletRegister")
+			printOutput(map[string]any{"status": "registered", "address": args[0]})
 		},
 	}
 
@@ -33,10 +34,11 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			info, ok := idRegistry.Info(args[0])
 			if !ok {
-				fmt.Println("not registered")
+				printOutput(map[string]any{"error": "not registered"})
 				return
 			}
-			fmt.Println(info)
+			gasPrint("IDWalletCheck")
+			printOutput(map[string]any{"info": info})
 		},
 	}
 

--- a/cli/idwallet_test.go
+++ b/cli/idwallet_test.go
@@ -1,7 +1,50 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
 
-func TestIdwalletPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestIDWalletWorkflow verifies idwallet CLI commands emit JSON responses.
+func TestIDWalletWorkflow(t *testing.T) {
+	out, err := execCommand("idwallet", "register", "addr1", "info1", "--json")
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var regResp map[string]string
+	if err := json.Unmarshal([]byte(out), &regResp); err != nil {
+		t.Fatalf("unmarshal register: %v", err)
+	}
+	if regResp["status"] != "registered" || regResp["address"] != "addr1" {
+		t.Fatalf("unexpected register response: %+v", regResp)
+	}
+
+	out, err = execCommand("idwallet", "check", "addr1", "--json")
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var chkResp map[string]string
+	if err := json.Unmarshal([]byte(out), &chkResp); err != nil {
+		t.Fatalf("unmarshal check: %v", err)
+	}
+	if chkResp["info"] != "info1" {
+		t.Fatalf("unexpected check response: %+v", chkResp)
+	}
+
+	t.Cleanup(func() { idRegistry = core.NewIDRegistry() })
 }

--- a/cli/immutability.go
+++ b/cli/immutability.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"synnergy/core"
 )
@@ -23,7 +21,8 @@ func init() {
 			gen.Hash = gen.HeaderHash(0)
 			ledger.AddBlock(gen)
 			enforcer = core.NewImmutabilityEnforcer(gen)
-			fmt.Println("genesis hash", gen.Hash)
+			gasPrint("ImmutabilityInit")
+			printOutput(map[string]any{"genesis": gen.Hash})
 		},
 	}
 
@@ -32,14 +31,15 @@ func init() {
 		Short: "Verify ledger against genesis hash",
 		Run: func(cmd *cobra.Command, args []string) {
 			if enforcer == nil {
-				fmt.Println("enforcer not initialised")
+				printOutput("enforcer not initialised")
 				return
 			}
 			if err := enforcer.CheckLedger(ledger); err != nil {
-				fmt.Println("check failed:", err)
+				printOutput(map[string]any{"error": err.Error()})
 				return
 			}
-			fmt.Println("ledger matches genesis hash")
+			gasPrint("ImmutabilityCheck")
+			printOutput(map[string]any{"status": "ok"})
 		},
 	}
 

--- a/cli/immutability_test.go
+++ b/cli/immutability_test.go
@@ -1,7 +1,52 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
 
-func TestImmutabilityPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+// TestImmutabilityWorkflow ensures immutability CLI emits JSON.
+func TestImmutabilityWorkflow(t *testing.T) {
+	origLedger := ledger
+	ledger = core.NewLedger()
+	t.Cleanup(func() { ledger = origLedger; enforcer = nil })
+
+	out, err := execCommand("immutability", "init", "--json")
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.LastIndex(out, "{"); idx != -1 {
+		out = out[idx:]
+	}
+	var initResp map[string]string
+	if err := json.Unmarshal([]byte(out), &initResp); err != nil {
+		t.Fatalf("unmarshal init: %v", err)
+	}
+	if initResp["genesis"] == "" {
+		t.Fatalf("expected genesis hash, got %+v", initResp)
+	}
+
+	out, err = execCommand("immutability", "check", "--json")
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.LastIndex(out, "{"); idx != -1 {
+		out = out[idx:]
+	}
+	var chkResp map[string]string
+	if err := json.Unmarshal([]byte(out), &chkResp); err != nil {
+		t.Fatalf("unmarshal check: %v", err)
+	}
+	if chkResp["status"] != "ok" {
+		t.Fatalf("unexpected check response: %+v", chkResp)
+	}
 }

--- a/cli/initrep.go
+++ b/cli/initrep.go
@@ -21,6 +21,8 @@ func init() {
 		Short: "Bootstrap ledger and start replication",
 		Run: func(cmd *cobra.Command, args []string) {
 			initSvc.Start()
+			gasPrint("InitrepStart")
+			printOutput(map[string]any{"status": "started"})
 		},
 	}
 
@@ -29,6 +31,8 @@ func init() {
 		Short: "Stop initialization service",
 		Run: func(cmd *cobra.Command, args []string) {
 			initSvc.Stop()
+			gasPrint("InitrepStop")
+			printOutput(map[string]any{"status": "stopped"})
 		},
 	}
 

--- a/cli/initrep_test.go
+++ b/cli/initrep_test.go
@@ -1,7 +1,46 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
-func TestInitrepPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+// TestInitrepWorkflow validates JSON output for initialization replication.
+func TestInitrepWorkflow(t *testing.T) {
+	out, err := execCommand("initrep", "start", "--json")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var startResp map[string]string
+	if err := json.Unmarshal([]byte(out), &startResp); err != nil {
+		t.Fatalf("unmarshal start: %v", err)
+	}
+	if startResp["status"] != "started" {
+		t.Fatalf("unexpected start response: %+v", startResp)
+	}
+
+	out, err = execCommand("initrep", "stop", "--json")
+	if err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if err := rootCmd.PersistentFlags().Set("json", "false"); err != nil {
+		t.Fatalf("reset json flag: %v", err)
+	}
+	if idx := strings.Index(out, "\n"); idx != -1 {
+		out = out[idx+1:]
+	}
+	var stopResp map[string]string
+	if err := json.Unmarshal([]byte(out), &stopResp); err != nil {
+		t.Fatalf("unmarshal stop: %v", err)
+	}
+	if stopResp["status"] != "stopped" {
+		t.Fatalf("unexpected stop response: %+v", stopResp)
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -44,11 +44,11 @@
 - Stage 38: Completed – biometric security node and CLI components finalised with tests.
 - Stage 39: Completed – authority and bank CLI modules validated with unit tests.
 - Stage 40: Completed – biometric security, compliance and compression CLIs now emit validated JSON responses with unit tests; block, central bank and coin utilities fully validated.
-- Stage 41: Completed – consensus and contract management CLIs now validate inputs with accompanying tests.
-- Stage 42: Completed – cross-chain bridge, protocol, connection, contract and custodial CLIs now emit structured JSON with accompanying tests.
-- Stage 43: Completed – DAO CLI now covers proposals, quadratic voting, staking, token and elected-node commands with JSON output and signature verification.
-- Stage 44: Completed – faucet, fees, firewall, forensic, full node and gas CLIs emit JSON with gas tracking and tests.
-- Stage 45: In Progress – genesis, geospatial and government CLI tests implemented; high availability, historical, holographic node and identity CLIs pending.
+- Stage 41: ✅ consensus and contract management CLIs emit JSON responses with gas tracking and validation tests.
+- Stage 42: ✅ cross-chain bridge, protocol, connection, contract and custodial CLIs now emit structured JSON with accompanying tests.
+- Stage 43: ✅ DAO CLI covers proposals, quadratic voting, staking, token and elected-node commands with JSON output and signature verification.
+- Stage 44: ✅ faucet, fees, firewall, forensic, full node and gas CLIs emit JSON with gas tracking and tests.
+- Stage 45: ✅ genesis, geospatial, government, high availability, historical, holographic node, identity, idwallet, immutability and initrep CLIs emit JSON output with gas tracking.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -966,28 +966,29 @@
 - [ ] cli/genesis.go
 
 **Stage 45**
+- Completed: all Stage 45 CLIs emit structured JSON with gas tracking and are covered by tests.
 - [x] cli/genesis_cli_test.go
 - [x] cli/genesis_test.go
 - [x] cli/geospatial.go
 - [x] cli/geospatial_test.go
 - [x] cli/government.go
 - [x] cli/government_test.go
-- [ ] cli/high_availability.go
-- [ ] cli/high_availability_test.go
-- [ ] cli/historical.go
-- [ ] cli/historical_test.go
-- [ ] cli/holographic_node.go
-- [ ] cli/holographic_node_test.go
-- [ ] cli/identity.go
-- [ ] cli/identity_test.go
-- [ ] cli/idwallet.go
-- [ ] cli/idwallet_test.go
-- [ ] cli/immutability.go
-- [ ] cli/immutability_test.go
-- [ ] cli/initrep.go
+- [x] cli/high_availability.go
+- [x] cli/high_availability_test.go
+- [x] cli/historical.go
+- [x] cli/historical_test.go
+- [x] cli/holographic_node.go
+- [x] cli/holographic_node_test.go
+- [x] cli/identity.go
+- [x] cli/identity_test.go
+- [x] cli/idwallet.go
+- [x] cli/idwallet_test.go
+- [x] cli/immutability.go
+- [x] cli/immutability_test.go
+- [x] cli/initrep.go
+- [x] cli/initrep_test.go
 
 **Stage 46**
-- [ ] cli/initrep_test.go
 - [ ] cli/instruction.go
 - [ ] cli/instruction_test.go
 - [ ] cli/kademlia.go
@@ -2640,7 +2641,7 @@
 - [ ] system_health_logging_test.go
 - [ ] tests/cli_integration_test.go
 - [ ] tests/contracts/faucet_test.go
-- [ ] tests/e2e/network_harness_test.go
+- [x] tests/e2e/network_harness_test.go
 - [ ] tests/formal/contracts_verification_test.go
 - [ ] tests/fuzz/crypto_fuzz_test.go
 - [ ] tests/fuzz/network_fuzz_test.go
@@ -5125,7 +5126,7 @@
 - [ ] system_health_logging_test.go
 - [ ] tests/cli_integration_test.go
 - [ ] tests/contracts/faucet_test.go
-- [ ] tests/e2e/network_harness_test.go
+- [x] tests/e2e/network_harness_test.go
 - [ ] tests/formal/contracts_verification_test.go
 
 **Stage 175 – Publish `opcodes_list.md`, `errors_list.md`, `functions_list.txt`, and related reference `.md` files for developers.**
@@ -5937,9 +5938,10 @@
 | 41 | cli/consensus_service_test.go | [x] | lifecycle test |
 | 41 | cli/consensus_specific_node.go | [x] | parse validation |
 | 41 | cli/consensus_specific_node_test.go | [x] | create/info test |
+| 41 | cli/consensus.go | [x] | JSON output |
 | 41 | cli/consensus_test.go | [x] | weights command test |
-| 41 | cli/contract_management.go | [x] | gas limit parse |
-| 41 | cli/contract_management_test.go | [x] | info error test |
+| 41 | cli/contract_management.go | [x] | JSON output |
+| 41 | cli/contract_management_test.go | [x] | JSON error test |
 | 41 | cli/contracts.go | [x] | deploy validation |
 | 41 | cli/contracts_opcodes.go | [x] | gas cost listing |
 | 42 | cli/contracts_opcodes_test.go | [ ] |
@@ -5961,7 +5963,7 @@
 | 42 | cli/cross_consensus_scaling_networks_test.go | [ ] |
 | 42 | cli/custodial_node.go | [ ] |
 | 42 | cli/custodial_node_test.go | [ ] |
-| 43 | cli/dao.go | [ ] |
+| 43 | cli/dao.go | [x] | JSON output |
 | 43 | cli/dao_access_control.go | [ ] |
 | 43 | cli/dao_access_control_test.go | [ ] |
 | 43 | cli/dao_proposal.go | [ ] |
@@ -5970,7 +5972,7 @@
 | 43 | cli/dao_quadratic_voting_test.go | [ ] |
 | 43 | cli/dao_staking.go | [ ] |
 | 43 | cli/dao_staking_test.go | [ ] |
-| 43 | cli/dao_test.go | [ ] |
+| 43 | cli/dao_test.go | [x] | workflow test |
 | 43 | cli/dao_token.go | [ ] |
 | 43 | cli/dao_token_test.go | [ ] |
 | 43 | cli/ecdsa_util.go | [ ] |
@@ -7513,7 +7515,7 @@
 | 124 | system_health_logging_test.go | [ ] |
 | 124 | tests/cli_integration_test.go | [ ] |
 | 124 | tests/contracts/faucet_test.go | [ ] |
-| 124 | tests/e2e/network_harness_test.go | [ ] |
+| 124 | tests/e2e/network_harness_test.go | [x] | JSON parsing fix |
 | 124 | tests/formal/contracts_verification_test.go | [ ] |
 | 124 | tests/fuzz/crypto_fuzz_test.go | [ ] |
 | 124 | tests/fuzz/network_fuzz_test.go | [ ] |

--- a/docs/reference/gas_table_list.md
+++ b/docs/reference/gas_table_list.md
@@ -213,7 +213,21 @@
 | `HexDump` | `1` |
 | `Hex` | `1` |
 | `History` | `1` |
+| `HolographicDial` | `1` |
+| `HolographicPeers` | `1` |
+| `HolographicRetrieve` | `1` |
+| `HolographicStore` | `1` |
 | `ID` | `1` |
+| `IDWalletCheck` | `1` |
+| `IDWalletRegister` | `1` |
+| `IdentityInfo` | `1` |
+| `IdentityLogs` | `1` |
+| `IdentityRegister` | `1` |
+| `IdentityVerify` | `1` |
+| `ImmutabilityCheck` | `1` |
+| `ImmutabilityInit` | `1` |
+| `InitrepStart` | `1` |
+| `InitrepStop` | `1` |
 | `IPFS_Add` | `1000` |
 | `IPFS_Get` | `400` |
 | `IPFS_Unpin` | `200` |
@@ -735,3 +749,4 @@
 | `zero_trust_data_channels_NewZeroTrustEngine` | `5` |
 | `zero_trust_data_channels_OpenChannel` | `5` |
 | `zero_trust_data_channels_Send` | `10` |
+| `TransferContract` | `250` |

--- a/tests/e2e/network_harness_test.go
+++ b/tests/e2e/network_harness_test.go
@@ -37,7 +37,17 @@ func execCLI(t *testing.T, args ...string) (string, error) {
 	os.Stdout = old
 	out, _ := io.ReadAll(r)
 	r.Close()
-	return strings.TrimSpace(buf.String() + string(out)), err
+	outStr := strings.TrimSpace(buf.String() + string(out))
+	if start := strings.IndexAny(outStr, "{"); start != -1 {
+		if end := strings.LastIndex(outStr, "}"); end != -1 && end >= start {
+			outStr = outStr[start : end+1]
+		}
+	} else if start := strings.Index(outStr, "["); start != -1 {
+		if end := strings.LastIndex(outStr, "]"); end != -1 && end >= start {
+			outStr = outStr[start : end+1]
+		}
+	}
+	return outStr, err
 }
 
 // TestNetworkHarness spins up core components and exercises a full flow


### PR DESCRIPTION
## Summary
- align DAO, consensus, and contract management CLIs with unified JSON output and gas tracking
- document Stage 41–45 completion and add TransferContract gas entry
- harden CLI and e2e tests with robust JSON parsing helpers

## Testing
- `go test ./cli/... -count=1`
- `go test ./tests/e2e -run TestNetwork -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68bb8b783e688320905200fbc98e1a55