### PR TITLE
Add runnable stubs for benchmarks and security assessments

### DIFF
--- a/Security assessments & Benchmark assessments/Benchmarks/All Token standard Benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/All Token standard Benchmarks.md
@@ -1,0 +1,3 @@
+# All Token standard Benchmarks Benchmark
+
+This document will present comprehensive results for the All Token standard Benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/All Token standard Benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/All Token standard Benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkAllTokenStandardBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement All Token standard Benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Authority node benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Authority node benchmarks.md
@@ -1,0 +1,3 @@
+# Authority node benchmarks Benchmark
+
+This document will present comprehensive results for the Authority node benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Authority node benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Authority node benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkAuthorityNodeBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Authority node benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment.md
@@ -1,0 +1,1 @@
+# Benchmarks_full_report_and_assessment.md

--- a/Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkFullReportAndAssessment(b *testing.B) {
+    b.Skip("TODO: implement full benchmark report and assessment")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Charity benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Charity benchmarks.md
@@ -1,0 +1,3 @@
+# Charity benchmarks Benchmark
+
+This document will present comprehensive results for the Charity benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Charity benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Charity benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkCharityBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Charity benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Coin benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Coin benchmarks.md
@@ -1,0 +1,3 @@
+# Coin benchmarks Benchmark
+
+This document will present comprehensive results for the Coin benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Coin benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Coin benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkCoinBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Coin benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Compliance benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Compliance benchmarks.md
@@ -1,0 +1,3 @@
+# Compliance benchmarks Benchmark
+
+This document will present comprehensive results for the Compliance benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Compliance benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Compliance benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkComplianceBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Compliance benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Consensus_benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Consensus_benchmarks.md
@@ -1,0 +1,3 @@
+# Consensus_benchmarks Benchmark
+
+This document will present comprehensive results for the Consensus_benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Consensus_benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Consensus_benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkConsensusBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Consensus_benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Contract benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Contract benchmarks.md
@@ -1,0 +1,3 @@
+# Contract benchmarks Benchmark
+
+This document will present comprehensive results for the Contract benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Contract benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Contract benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkContractBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Contract benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Governance benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Governance benchmarks.md
@@ -1,0 +1,3 @@
+# Governance benchmarks Benchmark
+
+This document will present comprehensive results for the Governance benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Governance benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Governance benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkGovernanceBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Governance benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/High availability benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/High availability benchmarks.md
@@ -1,0 +1,3 @@
+# High availability benchmarks Benchmark
+
+This document will present comprehensive results for the High availability benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/High availability benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/High availability benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkHighAvailabilityBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement High availability benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Ledger benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Ledger benchmarks.md
@@ -1,0 +1,3 @@
+# Ledger benchmarks Benchmark
+
+This document will present comprehensive results for the Ledger benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Ledger benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Ledger benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkLedgerBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Ledger benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Loanpool benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Loanpool benchmarks.md
@@ -1,0 +1,3 @@
+# Loanpool benchmarks Benchmark
+
+This document will present comprehensive results for the Loanpool benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Loanpool benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Loanpool benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkLoanpoolBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Loanpool benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Network benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Network benchmarks.md
@@ -1,0 +1,3 @@
+# Network benchmarks Benchmark
+
+This document will present comprehensive results for the Network benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Network benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Network benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkNetworkBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Network benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Node benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Node benchmarks.md
@@ -1,0 +1,3 @@
+# Node benchmarks Benchmark
+
+This document will present comprehensive results for the Node benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Node benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Node benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkNodeBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Node benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Opcode benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Opcode benchmarks.md
@@ -1,0 +1,3 @@
+# Opcode benchmarks Benchmark
+
+This document will present comprehensive results for the Opcode benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Opcode benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Opcode benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkOpcodeBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Opcode benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Security benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Security benchmarks.md
@@ -1,0 +1,3 @@
+# Security benchmarks Benchmark
+
+This document will present comprehensive results for the Security benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Security benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Security benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkSecurityBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Security benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Speed Benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Speed Benchmarks.md
@@ -1,0 +1,3 @@
+# Speed Benchmarks Benchmark
+
+This document will present comprehensive results for the Speed Benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Speed Benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Speed Benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkSpeedBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Speed Benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Storage benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Storage benchmarks.md
@@ -1,0 +1,3 @@
+# Storage benchmarks Benchmark
+
+This document will present comprehensive results for the Storage benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Storage benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Storage benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkStorageBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Storage benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/VM benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/VM benchmarks.md
@@ -1,0 +1,3 @@
+# VM benchmarks Benchmark
+
+This document will present comprehensive results for the VM benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/VM benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/VM benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkVmBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement VM benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Validation benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Validation benchmarks.md
@@ -1,0 +1,3 @@
+# Validation benchmarks Benchmark
+
+This document will present comprehensive results for the Validation benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Validation benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Validation benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkValidationBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Validation benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/Wallet benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Wallet benchmarks.md
@@ -1,0 +1,3 @@
+# Wallet benchmarks Benchmark
+
+This document will present comprehensive results for the Wallet benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/Wallet benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/Wallet benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkWalletBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement Wallet benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/ai benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/ai benchmarks.md
@@ -1,0 +1,3 @@
+# ai benchmarks Benchmark
+
+This document will present comprehensive results for the ai benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/ai benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/ai benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkAiBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement ai benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/transactions benchmarks.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/transactions benchmarks.md
@@ -1,0 +1,3 @@
+# transactions benchmarks Benchmark
+
+This document will present comprehensive results for the transactions benchmarks benchmark.

--- a/Security assessments & Benchmark assessments/Benchmarks/transactions benchmarks_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/transactions benchmarks_test.go
@@ -1,0 +1,7 @@
+package benchmarks
+
+import "testing"
+
+func BenchmarkTransactionsBenchmarks(b *testing.B) {
+    b.Skip("TODO: implement transactions benchmarks benchmark")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Ai security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Ai security.md
@@ -1,0 +1,3 @@
+# Ai security Security Assessment
+
+This document will present comprehensive results for the Ai security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Ai security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Ai security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestAiSecurity(t *testing.T) {
+    t.Skip("TODO: implement Ai security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Authority node security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Authority node security.md
@@ -1,0 +1,3 @@
+# Authority node security Security Assessment
+
+This document will present comprehensive results for the Authority node security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Authority node security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Authority node security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestAuthorityNodeSecurity(t *testing.T) {
+    t.Skip("TODO: implement Authority node security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Block security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Block security.md
@@ -1,0 +1,3 @@
+# Block security Security Assessment
+
+This document will present comprehensive results for the Block security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Block security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Block security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestBlockSecurity(t *testing.T) {
+    t.Skip("TODO: implement Block security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Charity security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Charity security.md
@@ -1,0 +1,3 @@
+# Charity security Security Assessment
+
+This document will present comprehensive results for the Charity security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Charity security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Charity security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestCharitySecurity(t *testing.T) {
+    t.Skip("TODO: implement Charity security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Compliance security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Compliance security.md
@@ -1,0 +1,3 @@
+# Compliance security Security Assessment
+
+This document will present comprehensive results for the Compliance security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Compliance security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Compliance security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestComplianceSecurity(t *testing.T) {
+    t.Skip("TODO: implement Compliance security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Consensus security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Consensus security.md
@@ -1,0 +1,3 @@
+# Consensus security Security Assessment
+
+This document will present comprehensive results for the Consensus security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Consensus security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Consensus security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestConsensusSecurity(t *testing.T) {
+    t.Skip("TODO: implement Consensus security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Contract security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Contract security.md
@@ -1,0 +1,3 @@
+# Contract security Security Assessment
+
+This document will present comprehensive results for the Contract security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Contract security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Contract security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestContractSecurity(t *testing.T) {
+    t.Skip("TODO: implement Contract security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Gas security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Gas security.md
@@ -1,0 +1,3 @@
+# Gas security Security Assessment
+
+This document will present comprehensive results for the Gas security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Gas security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Gas security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestGasSecurity(t *testing.T) {
+    t.Skip("TODO: implement Gas security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Governance security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Governance security.md
@@ -1,0 +1,3 @@
+# Governance security Security Assessment
+
+This document will present comprehensive results for the Governance security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Governance security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Governance security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestGovernanceSecurity(t *testing.T) {
+    t.Skip("TODO: implement Governance security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Ledger security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Ledger security.md
@@ -1,0 +1,3 @@
+# Ledger security Security Assessment
+
+This document will present comprehensive results for the Ledger security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Ledger security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Ledger security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestLedgerSecurity(t *testing.T) {
+    t.Skip("TODO: implement Ledger security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Loanpool security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Loanpool security.md
@@ -1,0 +1,3 @@
+# Loanpool security Security Assessment
+
+This document will present comprehensive results for the Loanpool security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Loanpool security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Loanpool security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestLoanpoolSecurity(t *testing.T) {
+    t.Skip("TODO: implement Loanpool security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Network security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Network security.md
@@ -1,0 +1,3 @@
+# Network security Security Assessment
+
+This document will present comprehensive results for the Network security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Network security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Network security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestNetworkSecurity(t *testing.T) {
+    t.Skip("TODO: implement Network security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Node security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Node security.md
@@ -1,0 +1,3 @@
+# Node security Security Assessment
+
+This document will present comprehensive results for the Node security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Node security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Node security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestNodeSecurity(t *testing.T) {
+    t.Skip("TODO: implement Node security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Opcode security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Opcode security.md
@@ -1,0 +1,3 @@
+# Opcode security Security Assessment
+
+This document will present comprehensive results for the Opcode security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Opcode security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Opcode security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestOpcodeSecurity(t *testing.T) {
+    t.Skip("TODO: implement Opcode security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Speed security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Speed security.md
@@ -1,0 +1,3 @@
+# Speed security Security Assessment
+
+This document will present comprehensive results for the Speed security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Speed security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Speed security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestSpeedSecurity(t *testing.T) {
+    t.Skip("TODO: implement Speed security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Storage security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Storage security.md
@@ -1,0 +1,3 @@
+# Storage security Security Assessment
+
+This document will present comprehensive results for the Storage security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Storage security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Storage security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestStorageSecurity(t *testing.T) {
+    t.Skip("TODO: implement Storage security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Sub blocks security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Sub blocks security.md
@@ -1,0 +1,3 @@
+# Sub blocks security Security Assessment
+
+This document will present comprehensive results for the Sub blocks security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Sub blocks security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Sub blocks security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestSubBlocksSecurity(t *testing.T) {
+    t.Skip("TODO: implement Sub blocks security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Token standards security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Token standards security.md
@@ -1,0 +1,3 @@
+# Token standards security Security Assessment
+
+This document will present comprehensive results for the Token standards security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Token standards security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Token standards security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestTokenStandardsSecurity(t *testing.T) {
+    t.Skip("TODO: implement Token standards security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Transaction security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Transaction security.md
@@ -1,0 +1,3 @@
+# Transaction security Security Assessment
+
+This document will present comprehensive results for the Transaction security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Transaction security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Transaction security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestTransactionSecurity(t *testing.T) {
+    t.Skip("TODO: implement Transaction security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Treasury security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Treasury security.md
@@ -1,0 +1,3 @@
+# Treasury security Security Assessment
+
+This document will present comprehensive results for the Treasury security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Treasury security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Treasury security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestTreasurySecurity(t *testing.T) {
+    t.Skip("TODO: implement Treasury security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/Vm security.md
+++ b/Security assessments & Benchmark assessments/Security assessments/Vm security.md
@@ -1,0 +1,3 @@
+# Vm security Security Assessment
+
+This document will present comprehensive results for the Vm security security assessment.

--- a/Security assessments & Benchmark assessments/Security assessments/Vm security_test.go
+++ b/Security assessments & Benchmark assessments/Security assessments/Vm security_test.go
@@ -1,0 +1,7 @@
+package security
+
+import "testing"
+
+func TestVmSecurity(t *testing.T) {
+    t.Skip("TODO: implement Vm security security assessment")
+}

--- a/Security assessments & Benchmark assessments/Security assessments/go.mod
+++ b/Security assessments & Benchmark assessments/Security assessments/go.mod
@@ -1,0 +1,3 @@
+module security_assessments
+
+go 1.21

--- a/Security assessments & Benchmark assessments/go.mod
+++ b/Security assessments & Benchmark assessments/go.mod
@@ -1,0 +1,3 @@
+module security_assessments_benchmarks
+
+go 1.21

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,6 @@
 # Development Stages and File Index
 
-## Stages 1-135 – File Upgrade Checklist
+## Stages 1-136 – File Upgrade Checklist
 
 ### Progress
 - Stage 1: In Progress – issue templates, PR template, README and root `.gitignore` upgraded; remaining files pending.
@@ -59,6 +59,7 @@
 - Stage 51: Completed – syn200, syn20, syn1100, syn12, syn1300, syn131, syn1401, syn1600 and syn1700 token CLIs validated with required flags and tests.
 
 - Stage 53: Complete – bill registry, forex pair, SYN3500 token, futures contract, index token, grant registry, government benefit, charity token, legal token and SYN500 utility token CLIs validated with tests; Stage 54 will address SYN5000+ commands.
+- Stage 136: Pending – security assessment and benchmark scaffolds reserved for final stage.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -7568,3 +7569,93 @@
 | 133 | docs/ux/command_history.md | [ ] |
 | 134 | docs/ux/authentication_roles.md | [ ] |
 | 135 | docs/ux/status_indicators.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/All Token standard Benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/All Token standard Benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Authority node benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Authority node benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Charity benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Charity benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Coin benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Coin benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Compliance benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Compliance benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Consensus_benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Consensus_benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Contract benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Contract benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Governance benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Governance benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/High availability benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/High availability benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Ledger benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Ledger benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Loanpool benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Loanpool benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Network benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Network benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Node benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Node benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Opcode benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Opcode benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Security benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Security benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Speed Benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Speed Benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Storage benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Storage benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/VM benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/VM benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Validation benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Validation benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Wallet benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/Wallet benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/ai benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/ai benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/transactions benchmarks.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Benchmarks/transactions benchmarks_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Ai security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Ai security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Authority node security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Authority node security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Block security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Block security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Charity security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Charity security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Compliance security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Compliance security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Consensus security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Consensus security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Contract security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Contract security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Gas security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Gas security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Governance security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Governance security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Ledger security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Ledger security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Loanpool security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Loanpool security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Network security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Network security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Node security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Node security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Opcode security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Opcode security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Speed security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Speed security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Storage security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Storage security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Sub blocks security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Sub blocks security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Token standards security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Token standards security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Transaction security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Transaction security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Treasury security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Treasury security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Vm security.md | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/Vm security_test.go | [ ] |
+| 136 | Security assessments & Benchmark assessments/Security assessments/go.mod | [ ] |
+| 136 | Security assessments & Benchmark assessments/go.mod | [ ] |


### PR DESCRIPTION
## Summary
- scaffold Go benchmark stubs and matching markdown reports for each benchmarking topic
- add Go test placeholders and documentation for all listed security assessments
- extend AGENTS checklist with stage 136 capturing all benchmark and security assessment files for later completion

## Testing
- `go test ./Security assessments & Benchmark assessments/Benchmarks`
- `go test ./Security assessments & Benchmark assessments/Security assessments`
- `go test -v ./cli -run TestDAOProposalCreateJSON`
- `timeout 60 go test ./...` *(interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbff58380832092e5de6db61dfed9