### PR TITLE
Optimize coin supply calculations and gas table snapshots for Stage 62

### DIFF
--- a/cli/gas_table.go
+++ b/cli/gas_table.go
@@ -31,11 +31,20 @@ func init() {
 	}
 
 	var jsonOut bool
+	var outPath string
 	snapCmd := &cobra.Command{
 		Use:   "snapshot",
-		Short: "Print current gas table snapshot",
+		Short: "Print or persist current gas table snapshot",
 		Run: func(cmd *cobra.Command, args []string) {
 			gasPrint("GasSnapshot")
+			if outPath != "" {
+				if err := core.WriteGasTableSnapshot(outPath); err != nil {
+					printOutput(err.Error())
+					return
+				}
+				printOutput("snapshot written")
+				return
+			}
 			if jsonOut {
 				data, err := core.GasTableSnapshotJSON()
 				if err != nil {
@@ -50,6 +59,7 @@ func init() {
 		},
 	}
 	snapCmd.Flags().BoolVar(&jsonOut, "json", false, "output JSON")
+	snapCmd.Flags().StringVar(&outPath, "out", "", "write snapshot to file")
 
 	gasCmd.AddCommand(setCmd)
 	gasCmd.AddCommand(snapCmd)

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -1,36 +1,92 @@
 package core
 
 import (
-    "crypto/sha256"
-    "encoding/hex"
-    "fmt"
-    "testing"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
 )
 
 func TestSubBlockCreationAndVerification(t *testing.T) {
-    tx := NewTransaction("a", "b", 1, 0, 0)
-    sb := NewSubBlock([]*Transaction{tx}, "val")
-    if sb.PohHash != sb.Hash() {
-        t.Fatalf("poh hash not set correctly")
-    }
-    if !sb.VerifySignature() {
-        t.Fatalf("signature verification failed")
-    }
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "val")
+	if err := sb.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
 }
 
 func TestBlockHeaderHash(t *testing.T) {
-    tx := NewTransaction("a", "b", 1, 0, 0)
-    sb := NewSubBlock([]*Transaction{tx}, "v1")
-    b := NewBlock([]*SubBlock{sb}, "prevhash")
-    nonce := uint64(7)
-    got := b.HeaderHash(nonce)
-    h := sha256.New()
-    h.Write([]byte("prevhash"))
-    h.Write([]byte(sb.PohHash))
-    h.Write([]byte(fmt.Sprintf("%d%d", b.Timestamp, nonce)))
-    expected := hex.EncodeToString(h.Sum(nil))
-    if got != expected {
-        t.Fatalf("header hash mismatch")
-    }
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	b := NewBlock([]*SubBlock{sb}, "prevhash")
+	nonce := uint64(7)
+	got := b.HeaderHash(nonce)
+	h := sha256.New()
+	h.Write([]byte("prevhash"))
+	h.Write([]byte(sb.PohHash))
+	h.Write([]byte(fmt.Sprintf("%d%d", b.Timestamp, nonce)))
+	expected := hex.EncodeToString(h.Sum(nil))
+	if got != expected {
+		t.Fatalf("header hash mismatch")
+	}
+	b.Nonce = nonce
+	b.Hash = got
+	if err := b.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
 }
 
+func TestSubBlockValidateRejectsDuplicateTransactions(t *testing.T) {
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx, tx}, "val")
+	if err := sb.Validate(); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected duplicate transaction error, got %v", err)
+	}
+}
+
+func TestBlockValidateRejectsFutureTimestamp(t *testing.T) {
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	b := NewBlock([]*SubBlock{sb}, "prevhash")
+	b.Timestamp = time.Now().Add(6 * time.Minute).Unix()
+	b.Nonce = 1
+	b.Hash = b.HeaderHash(b.Nonce)
+	if err := b.Validate(); err == nil || !strings.Contains(err.Error(), "timestamp in future") {
+		t.Fatalf("expected future timestamp error, got %v", err)
+	}
+}
+
+func TestBlockValidateRejectsSubBlockAfterBlockTimestamp(t *testing.T) {
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	b := NewBlock([]*SubBlock{sb}, "prevhash")
+	b.Timestamp = sb.Timestamp - 10
+	b.Nonce = 1
+	b.Hash = b.HeaderHash(b.Nonce)
+	if err := b.Validate(); err == nil || !strings.Contains(err.Error(), "sub-block timestamp") {
+		t.Fatalf("expected sub-block timestamp error, got %v", err)
+	}
+}
+
+func TestBlockValidateRequiresHash(t *testing.T) {
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	b := NewBlock([]*SubBlock{sb}, "prevhash")
+	b.Nonce = 1
+	if err := b.Validate(); err == nil || !strings.Contains(err.Error(), "hash required") {
+		t.Fatalf("expected hash required error, got %v", err)
+	}
+}
+
+func TestBlockValidateDetectsHashMismatch(t *testing.T) {
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	b := NewBlock([]*SubBlock{sb}, "prevhash")
+	b.Nonce = 1
+	b.Hash = "bad"
+	if err := b.Validate(); err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("expected hash mismatch error, got %v", err)
+	}
+}

--- a/core/coin.go
+++ b/core/coin.go
@@ -2,7 +2,6 @@ package core
 
 import "math"
 
-
 const (
 	// CoinName represents the name of the native coin.
 	CoinName = "Synthron"
@@ -21,6 +20,9 @@ const (
 // is returned once all halvings have completed.
 func BlockReward(height uint64) uint64 {
 	halvings := height / HalvingInterval
+	if halvings >= 63 {
+		return 0
+	}
 	reward := InitialBlockReward >> halvings
 	return reward
 }
@@ -29,11 +31,28 @@ func BlockReward(height uint64) uint64 {
 // the given block height, taking the halving schedule into account.
 func CirculatingSupply(height uint64) uint64 {
 	supply := GenesisAllocation
-	for i := uint64(0); i < height; i++ {
-		supply += BlockReward(i)
-		if supply >= MaxSupply {
-			return MaxSupply
+	reward := InitialBlockReward
+	blocks := height
+
+	for blocks > 0 && reward > 0 {
+		interval := HalvingInterval
+		if blocks < interval {
+			interval = blocks
 		}
+
+		if reward > 0 {
+			if reward >= (MaxSupply-supply)/interval {
+				return MaxSupply
+			}
+			supply += reward * interval
+		}
+
+		blocks -= interval
+		reward >>= 1
+	}
+
+	if supply > MaxSupply {
+		return MaxSupply
 	}
 	return supply
 }
@@ -84,4 +103,3 @@ func LockupDuration(base, V, threshold, sigma float64) float64 {
 func PriceToSupplyRatio(price float64, height uint64) float64 {
 	return price / math.Max(float64(CirculatingSupply(height)), 1)
 }
-

--- a/core/coin_test.go
+++ b/core/coin_test.go
@@ -1,52 +1,60 @@
 package core
 
 import (
-    "math"
-    "testing"
+	"math"
+	"testing"
 )
 
 func TestBlockRewardHalving(t *testing.T) {
-    if BlockReward(0) != InitialBlockReward {
-        t.Fatalf("unexpected reward at height 0")
-    }
-    if BlockReward(HalvingInterval) != InitialBlockReward/2 {
-        t.Fatalf("reward not halved at interval")
-    }
+	if BlockReward(0) != InitialBlockReward {
+		t.Fatalf("unexpected reward at height 0")
+	}
+	if BlockReward(HalvingInterval) != InitialBlockReward/2 {
+		t.Fatalf("reward not halved at interval")
+	}
+	if BlockReward(HalvingInterval*63) != 0 {
+		t.Fatalf("reward should be zero after 63 halvings")
+	}
 }
 
 func TestCirculatingAndRemainingSupply(t *testing.T) {
-    height := uint64(2)
-    expected := GenesisAllocation + BlockReward(0) + BlockReward(1)
-    if got := CirculatingSupply(height); got != expected {
-        t.Fatalf("circulating supply %d != %d", got, expected)
-    }
-    if rem := RemainingSupply(height); rem != MaxSupply-expected {
-        t.Fatalf("remaining supply %d != %d", rem, MaxSupply-expected)
-    }
+	height := uint64(2)
+	expected := GenesisAllocation + BlockReward(0) + BlockReward(1)
+	if got := CirculatingSupply(height); got != expected {
+		t.Fatalf("circulating supply %d != %d", got, expected)
+	}
+	if rem := RemainingSupply(height); rem != MaxSupply-expected {
+		t.Fatalf("remaining supply %d != %d", rem, MaxSupply-expected)
+	}
+}
+
+func TestCirculatingSupplyCapped(t *testing.T) {
+	if supply := CirculatingSupply(^uint64(0)); supply != MaxSupply {
+		t.Fatalf("circulating supply should cap at max, got %d", supply)
+	}
 }
 
 func TestEconomicHelpers(t *testing.T) {
-    if v := InitialPrice(1, 2, 3, 4, 5, 6); math.Abs(v-(1.0+2.0+(3.0*4.0)/5.0)*6.0) > 1e-9 {
-        t.Fatalf("initial price mismatch")
-    }
-    if v := AlphaFactor(1, 2, 3, 4); math.Abs(v-(3.0*1.0+2.0+3.0)/4.0) > 1e-9 {
-        t.Fatalf("alpha factor mismatch")
-    }
-    if v := MinimumStake(100, 10, 5, 2); math.Abs(v-(100.0/(10.0*5.0))*2.0) > 1e-9 {
-        t.Fatalf("minimum stake mismatch")
-    }
-    if MinimumStake(100, 0, 5, 2) != 0 {
-        t.Fatalf("minimum stake should be zero when reward or supply zero")
-    }
-    if v := LockupDuration(10, 2, 4, 0.5); math.Abs(v-(10.0*(2.0/4.0*10.0)+0.5*20.0)) > 1e-9 {
-        t.Fatalf("lockup duration mismatch")
-    }
-    if LockupDuration(10, 2, 0, 0.5) != 10 {
-        t.Fatalf("lockup duration should return base when threshold zero")
-    }
-    ratio := PriceToSupplyRatio(100, 0)
-    if math.Abs(ratio-100.0/float64(CirculatingSupply(0))) > 1e-9 {
-        t.Fatalf("price to supply ratio mismatch")
-    }
+	if v := InitialPrice(1, 2, 3, 4, 5, 6); math.Abs(v-(1.0+2.0+(3.0*4.0)/5.0)*6.0) > 1e-9 {
+		t.Fatalf("initial price mismatch")
+	}
+	if v := AlphaFactor(1, 2, 3, 4); math.Abs(v-(3.0*1.0+2.0+3.0)/4.0) > 1e-9 {
+		t.Fatalf("alpha factor mismatch")
+	}
+	if v := MinimumStake(100, 10, 5, 2); math.Abs(v-(100.0/(10.0*5.0))*2.0) > 1e-9 {
+		t.Fatalf("minimum stake mismatch")
+	}
+	if MinimumStake(100, 0, 5, 2) != 0 {
+		t.Fatalf("minimum stake should be zero when reward or supply zero")
+	}
+	if v := LockupDuration(10, 2, 4, 0.5); math.Abs(v-(10.0*(2.0/4.0*10.0)+0.5*20.0)) > 1e-9 {
+		t.Fatalf("lockup duration mismatch")
+	}
+	if LockupDuration(10, 2, 0, 0.5) != 10 {
+		t.Fatalf("lockup duration should return base when threshold zero")
+	}
+	ratio := PriceToSupplyRatio(100, 0)
+	if math.Abs(ratio-100.0/float64(CirculatingSupply(0))) > 1e-9 {
+		t.Fatalf("price to supply ratio mismatch")
+	}
 }
-

--- a/core/consensus.go
+++ b/core/consensus.go
@@ -181,10 +181,10 @@ func (sc *SynnergyConsensus) SelectValidator(stakes map[string]uint64) string {
 // It verifies that the sub-block is non-nil, contains transactions and has a
 // valid signature from its declared validator.
 func (sc *SynnergyConsensus) ValidateSubBlock(sb *SubBlock) bool {
-	if sb == nil || len(sb.Transactions) == 0 {
+	if sb == nil {
 		return false
 	}
-	return sb.VerifySignature()
+	return sb.Validate() == nil
 }
 
 // MineBlock performs a simple SHA-256 proof-of-work using the provided
@@ -215,4 +215,13 @@ func clamp(v, min, max float64) float64 {
 	}
 	return v
 
+}
+
+// ValidateBlock checks that a block and its sub-blocks are well-formed.
+// It delegates to the block's internal validation routine.
+func (sc *SynnergyConsensus) ValidateBlock(b *Block) bool {
+	if b == nil {
+		return false
+	}
+	return b.Validate() == nil
 }

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -73,3 +73,18 @@ func TestValidateSubBlock(t *testing.T) {
 		t.Fatalf("expected invalid sub-block")
 	}
 }
+
+func TestValidateBlock(t *testing.T) {
+	sc := NewSynnergyConsensus()
+	tx := NewTransaction("a", "b", 1, 0, 0)
+	sb := NewSubBlock([]*Transaction{tx}, "val")
+	block := NewBlock([]*SubBlock{sb}, "")
+	sc.MineBlock(block, 1)
+	if !sc.ValidateBlock(block) {
+		t.Fatalf("expected valid block")
+	}
+	block.SubBlocks[0].Transactions = nil
+	if sc.ValidateBlock(block) {
+		t.Fatalf("expected invalid block")
+	}
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -67,7 +67,8 @@
 - Stage 59: Completed – content-node registry, secrets manager CLI, gas/opcode references and web UI wired for deterministic pricing.
 - Stage 60: Completed – contract language compatibility, contract registry and access utilities refined with tests.
 - Stage 61: Completed – audit, authority, banking, base-node peering and biometric modules hardened with Ed25519 signatures.
-- Stage 62: ✅ biometric authentication and banking node interfaces hardened with signature-verified registration and tests; CLI bank node tests run without hanging.
+- Stage 62: ✅ biometric authentication, block validation with timestamp, duplicate, and header hash checks, compression, synchronization, central banking, charity, coin (optimized supply calculations) and compliance modules with tests; gas table snapshots now emit deterministic JSON for CLI tooling, support persistence via `WriteGasTableSnapshot`, and the CLI can write snapshots directly to disk.
+- Stage 63: In Progress – consensus module now delegates block and sub-block validation to shared routines; connection pool components pending.
 - Stage 136: Pending – security assessment and benchmark scaffolds reserved for final stage.
 
 **Stage 1**
@@ -1367,27 +1368,32 @@
 - [x] core/biometrics_auth.go – input validation and error handling
 - [x] core/biometrics_auth_test.go – coverage for validation errors
 - [x] core/bank_institutional_node_test.go – rejects mismatched addresses and signatures
-- [ ] core/block.go
-- [ ] core/block_test.go
-- [ ] core/blockchain_compression.go
-- [ ] core/blockchain_compression_test.go
-- [ ] core/blockchain_synchronization.go
-- [ ] core/blockchain_synchronization_test.go
-- [ ] core/central_banking_node.go
-- [ ] core/central_banking_node_test.go
-- [ ] core/charity.go
-- [ ] core/charity_test.go
-- [ ] core/coin.go
-- [ ] core/coin_test.go
-- [ ] core/compliance.go
-- [ ] core/compliance_management.go
-- [ ] core/compliance_management_test.go
-- [ ] core/compliance_test.go
+- [x] core/block.go – added validation for sub-block and block structures with timestamp, duplicate transaction, sub-block ordering, and header hash verification checks
+- [x] core/block_test.go – exercises validation paths including timestamp, duplicate, ordering, hash required, and mismatch cases
+- [x] core/blockchain_compression.go – gzip ledger snapshot utilities
+- [x] core/blockchain_compression_test.go – round-trip compression test
+- [x] core/blockchain_synchronization.go – in-memory sync manager
+- [x] core/blockchain_synchronization_test.go – lifecycle coverage
+- [x] core/central_banking_node.go – CBDC minting with policy updates
+- [x] core/central_banking_node_test.go – verifies CBDC issuance restrictions
+- [x] core/charity.go – registration, voting and deposit handling
+- [x] core/charity_test.go – exercises deposit and voting flows
+- [x] core/coin.go – optimized capped supply economics helpers
+- [x] core/coin_test.go – reward and economics calculations
+- [x] core/compliance.go – KYC and fraud monitoring service
+- [x] core/compliance_management.go – address suspension and whitelist controls
+- [x] core/compliance_management_test.go – suspension and whitelist coverage
+- [x] core/compliance_test.go – KYC and anomaly detection tests
+- [x] core/gas_table.go – deterministic snapshot sorting and file persistence helper
+- [x] core/gas_table_test.go – verifies deterministic JSON output and persistence
+- [x] cli/gas_table.go – gas snapshot command writes to disk and prints JSON
+- [x] cli/gas_table_cli_test.go – covers JSON output and snapshot file writing
+- [x] cli/gas_table_test.go – ensures snapshot contains entries
 
 **Stage 63**
 - [ ] core/connection_pool.go
 - [ ] core/connection_pool_test.go
-- [ ] core/consensus.go
+- [x] core/consensus.go – delegates block and sub-block checks to internal validation
 - [ ] core/consensus_adaptive_management.go
 - [ ] core/consensus_adaptive_management_test.go
 - [ ] core/consensus_difficulty.go


### PR DESCRIPTION
## Summary
- guard `BlockReward` against excessive halving shifts
- compute circulating supply in halving intervals to cap at `MaxSupply`
- test reward zeroing and supply capping
- track optimized coin mechanics in Stage 62 progress
- expand block validation tests to cover missing and mismatched header hashes
- ensure gas table snapshots sort opcode keys for deterministic JSON
- add `WriteGasTableSnapshot` to persist deterministic gas schedules
- test gas table JSON output for determinism and validity
- document deterministic gas table snapshots in Stage 62 tracker
- CLI gas snapshot command can now write snapshots to disk with tests
- Stage 62 tracker records gas snapshot CLI persistence
- delegate consensus sub-block validation to shared routines and add `ValidateBlock` with tests; mark progress in Stage 63 tracker

## Testing
- `go test ./core -run GasTable -count=1`
- `go test ./cli -run 'GasSnapshot|GasTable' -count=1`
- `go test ./core -run Consensus -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68be67f6bff4832088013e8c1b8d5a3e