### PR TITLE
feat(dao): secure authority term renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Synnergy is a modular, high-performance blockchain written in Go and built for e
 - **Resource-managed CLI** – connection pool commands can release individual peers and `contractopcodes` reports gas costs for contract operations.
 - **Content node pricing** – gas table and opcode registry expose costs for registering nodes, uploading content, retrieving items and listing hosts so storage workflows remain predictable across the CLI and web UI.
 - **Content registry & secrets tooling** – `synnergy content_node` manages hosted content while the standalone `secrets-manager` binary validates stored keys.
-- **DAO governance** – `synnergy dao` manages decentralised autonomous organisations with optional JSON output and ECDSA signature verification helpers.
+- **DAO governance** – `synnergy dao` manages decentralised autonomous organisations with optional JSON output, ECDSA signature verification, admin-controlled member role updates via `dao-members update`, and elected authority node term renewals.
 - **Validated block utilities** – Stage 40 adds sub-block creation and block assembly commands with strict argument checking.
 - **Consensus tooling** – Stage 41 adds validated commands for adaptive weighting, difficulty control and service management.
 - **Adaptive consensus management** – Stage 63 averages recent demand and stake

--- a/cli/dao_access_control_test.go
+++ b/cli/dao_access_control_test.go
@@ -59,3 +59,92 @@ func TestDAOMemberAddJSON(t *testing.T) {
 		t.Fatalf("member not added: %v %v", role, ok)
 	}
 }
+
+// TestDAOMemberUpdateRole ensures only admins can update roles and JSON output is emitted.
+func TestDAOMemberUpdateRole(t *testing.T) {
+	daoMgr = core.NewDAOManager()
+	daoMgr.AuthorizeRelayer("creator")
+	dao, err := daoMgr.Create("testdao", "creator")
+	if err != nil {
+		t.Fatalf("create dao: %v", err)
+	}
+	if err := dao.AddMember("member1", "member"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	msg := []byte(dao.ID + "creator" + "member1" + "admin")
+	h := sha256.Sum256(msg)
+	r, s, err := ecdsa.Sign(rand.Reader, priv, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig := append(r.Bytes(), s.Bytes()...)
+	sigHex := hex.EncodeToString(sig)
+	pub := append([]byte{4}, priv.PublicKey.X.Bytes()...)
+	pub = append(pub, priv.PublicKey.Y.Bytes()...)
+	pubHex := hex.EncodeToString(pub)
+	msgHex := hex.EncodeToString(msg)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"dao-members", "update", dao.ID, "creator", "member1", "admin", "--pub", pubHex, "--msg", msgHex, "--sig", sigHex, "--json"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["status"] != "role updated" {
+		t.Fatalf("unexpected status: %v", resp)
+	}
+	if role, _ := dao.MemberRole("member1"); role != "admin" {
+		t.Fatalf("role not updated: %v", role)
+	}
+}
+
+// TestDAOMemberUpdateRoleUnauthorized rejects updates from non-admins.
+func TestDAOMemberUpdateRoleUnauthorized(t *testing.T) {
+	daoMgr = core.NewDAOManager()
+	daoMgr.AuthorizeRelayer("creator")
+	daoMgr.AuthorizeRelayer("member1")
+	dao, err := daoMgr.Create("testdao", "creator")
+	if err != nil {
+		t.Fatalf("create dao: %v", err)
+	}
+	if err := dao.AddMember("member1", "member"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	msg := []byte(dao.ID + "member1" + "creator" + "member")
+	h := sha256.Sum256(msg)
+	r, s, err := ecdsa.Sign(rand.Reader, priv, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig := append(r.Bytes(), s.Bytes()...)
+	sigHex := hex.EncodeToString(sig)
+	pub := append([]byte{4}, priv.PublicKey.X.Bytes()...)
+	pub = append(pub, priv.PublicKey.Y.Bytes()...)
+	pubHex := hex.EncodeToString(pub)
+	msgHex := hex.EncodeToString(msg)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"dao-members", "update", dao.ID, "member1", "creator", "member", "--pub", pubHex, "--msg", msgHex, "--sig", sigHex})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("unauthorized")) {
+		t.Fatalf("expected unauthorized error, got %q", buf.String())
+	}
+}

--- a/cli/dao_quadratic_voting.go
+++ b/cli/dao_quadratic_voting.go
@@ -57,7 +57,17 @@ func init() {
 				return
 			}
 			support := strings.ToLower(args[3]) == "yes"
-			if err := proposalMgr.CastQuadraticVote(args[0], args[1], tokens, support); err != nil {
+			p, err := proposalMgr.Get(args[0])
+			if err != nil {
+				fmt.Fprintln(cmd.OutOrStdout(), err)
+				return
+			}
+			dao, err := daoMgr.Info(p.DAOID)
+			if err != nil {
+				fmt.Fprintln(cmd.OutOrStdout(), err)
+				return
+			}
+			if err := proposalMgr.CastQuadraticVote(dao, p.ID, args[1], tokens, support); err != nil {
 				fmt.Fprintln(cmd.OutOrStdout(), err)
 				return
 			}

--- a/cli/dao_quadratic_voting_test.go
+++ b/cli/dao_quadratic_voting_test.go
@@ -2,7 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"synnergy/core"
@@ -23,5 +29,47 @@ func TestDAOQuadraticWeightJSON(t *testing.T) {
 	expected := core.QuadraticWeight(9)
 	if resp["weight"] != expected {
 		t.Fatalf("unexpected weight: %v", resp)
+	}
+}
+
+// TestDAOQuadraticVoteRequiresMembership ensures votes from non-members are rejected.
+func TestDAOQuadraticVoteRequiresMembership(t *testing.T) {
+	daoMgr = core.NewDAOManager()
+	daoMgr.AuthorizeRelayer("c")
+	proposalMgr = core.NewProposalManager()
+	dao, err := daoMgr.Create("dao1", "c")
+	if err != nil {
+		t.Fatalf("create dao: %v", err)
+	}
+	p, err := proposalMgr.CreateProposal(dao, "c", "desc")
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	msg := []byte(p.ID + "v" + "4" + "yes")
+	h := sha256.Sum256(msg)
+	r, s, err := ecdsa.Sign(rand.Reader, priv, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig := append(r.Bytes(), s.Bytes()...)
+	sigHex := hex.EncodeToString(sig)
+	pub := append([]byte{4}, priv.PublicKey.X.Bytes()...)
+	pub = append(pub, priv.PublicKey.Y.Bytes()...)
+	pubHex := hex.EncodeToString(pub)
+	msgHex := hex.EncodeToString(msg)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"dao-qv", "vote", p.ID, "v", "4", "yes", "--pub", pubHex, "--msg", msgHex, "--sig", sigHex})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(buf.String(), "not a dao member") {
+		t.Fatalf("expected membership error, got %q", buf.String())
 	}
 }

--- a/cli/dao_token.go
+++ b/cli/dao_token.go
@@ -9,7 +9,7 @@ import (
 	"synnergy/core"
 )
 
-var daoTokenLedger = core.NewDAOTokenLedger()
+var daoTokenLedger = core.NewDAOTokenLedger(daoMgr)
 
 func init() {
 	tokenCmd := &cobra.Command{
@@ -20,22 +20,25 @@ func init() {
 	var mintJSON bool
 	var mintPub, mintMsg, mintSig string
 	mintCmd := &cobra.Command{
-		Use:   "mint <addr> <amount>",
-		Args:  cobra.ExactArgs(2),
-		Short: "Mint tokens to an address",
+		Use:   "mint <daoID> <admin> <addr> <amount>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Mint DAO tokens to a member",
 		Run: func(cmd *cobra.Command, args []string) {
-			gasPrint("Mint")
+			gasPrint("MintDAOToken")
 			ok, err := VerifySignature(mintPub, mintMsg, mintSig)
 			if err != nil || !ok {
 				fmt.Fprintln(cmd.OutOrStdout(), "signature verification failed")
 				return
 			}
-			amt, err := strconv.ParseUint(args[1], 10, 64)
+			amt, err := strconv.ParseUint(args[3], 10, 64)
 			if err != nil {
 				fmt.Fprintln(cmd.OutOrStdout(), "invalid amount")
 				return
 			}
-			daoTokenLedger.Mint(args[0], amt)
+			if err := daoTokenLedger.Mint(args[0], args[1], args[2], amt); err != nil {
+				fmt.Fprintln(cmd.OutOrStdout(), err)
+				return
+			}
 			if mintJSON {
 				_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]string{"status": "minted"})
 				return
@@ -51,22 +54,22 @@ func init() {
 	var transferJSON bool
 	var transferPub, transferMsg, transferSig string
 	transferCmd := &cobra.Command{
-		Use:   "transfer <from> <to> <amount>",
-		Args:  cobra.ExactArgs(3),
-		Short: "Transfer tokens",
+		Use:   "transfer <daoID> <from> <to> <amount>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Transfer DAO tokens between members",
 		Run: func(cmd *cobra.Command, args []string) {
-			gasPrint("Transfer")
+			gasPrint("TransferDAOToken")
 			ok, err := VerifySignature(transferPub, transferMsg, transferSig)
 			if err != nil || !ok {
 				fmt.Fprintln(cmd.OutOrStdout(), "signature verification failed")
 				return
 			}
-			amt, err := strconv.ParseUint(args[2], 10, 64)
+			amt, err := strconv.ParseUint(args[3], 10, 64)
 			if err != nil {
 				fmt.Fprintln(cmd.OutOrStdout(), "invalid amount")
 				return
 			}
-			if err := daoTokenLedger.Transfer(args[0], args[1], amt); err != nil {
+			if err := daoTokenLedger.Transfer(args[0], args[1], args[2], amt); err != nil {
 				fmt.Fprintln(cmd.OutOrStdout(), err)
 				return
 			}
@@ -84,12 +87,12 @@ func init() {
 
 	var balanceJSON bool
 	balanceCmd := &cobra.Command{
-		Use:   "balance <addr>",
-		Args:  cobra.ExactArgs(1),
-		Short: "Get token balance",
+		Use:   "balance <daoID> <addr>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Get DAO token balance for a member",
 		Run: func(cmd *cobra.Command, args []string) {
-			gasPrint("Balance")
-			bal := daoTokenLedger.Balance(args[0])
+			gasPrint("DAOTokenBalance")
+			bal := daoTokenLedger.Balance(args[0], args[1])
 			if balanceJSON {
 				_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]uint64{"balance": bal})
 				return
@@ -102,22 +105,22 @@ func init() {
 	var burnJSON bool
 	var burnPub, burnMsg, burnSig string
 	burnCmd := &cobra.Command{
-		Use:   "burn <addr> <amount>",
-		Args:  cobra.ExactArgs(2),
-		Short: "Burn tokens from an address",
+		Use:   "burn <daoID> <admin> <addr> <amount>",
+		Args:  cobra.ExactArgs(4),
+		Short: "Burn DAO tokens from a member",
 		Run: func(cmd *cobra.Command, args []string) {
-			gasPrint("Burn")
+			gasPrint("BurnDAOToken")
 			ok, err := VerifySignature(burnPub, burnMsg, burnSig)
 			if err != nil || !ok {
 				fmt.Fprintln(cmd.OutOrStdout(), "signature verification failed")
 				return
 			}
-			amt, err := strconv.ParseUint(args[1], 10, 64)
+			amt, err := strconv.ParseUint(args[3], 10, 64)
 			if err != nil {
 				fmt.Fprintln(cmd.OutOrStdout(), "invalid amount")
 				return
 			}
-			if err := daoTokenLedger.Burn(args[0], amt); err != nil {
+			if err := daoTokenLedger.Burn(args[0], args[1], args[2], amt); err != nil {
 				fmt.Fprintln(cmd.OutOrStdout(), err)
 				return
 			}

--- a/cli/dao_token_test.go
+++ b/cli/dao_token_test.go
@@ -15,15 +15,25 @@ import (
 
 // TestDAOTokenMintJSON verifies mint command JSON output and signature.
 func TestDAOTokenMintJSON(t *testing.T) {
-	daoTokenLedger = core.NewDAOTokenLedger()
+	daoMgr = core.NewDAOManager()
+	daoTokenLedger = core.NewDAOTokenLedger(daoMgr)
+
+	daoMgr.AuthorizeRelayer("admin")
+	dao, err := daoMgr.Create("d1", "admin")
+	if err != nil {
+		t.Fatalf("create dao: %v", err)
+	}
+	daoMgr.AuthorizeRelayer("addr1")
+	if err := daoMgr.Join(dao.ID, "addr1"); err != nil {
+		t.Fatalf("join: %v", err)
+	}
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("key: %v", err)
 	}
-	addr := "addr1"
 	amt := "7"
-	msg := []byte(addr + amt)
+	msg := []byte(dao.ID + "addr1" + amt)
 	h := sha256.Sum256(msg)
 	r, s, err := ecdsa.Sign(rand.Reader, priv, h[:])
 	if err != nil {
@@ -36,7 +46,7 @@ func TestDAOTokenMintJSON(t *testing.T) {
 	pubHex := hex.EncodeToString(pub)
 	msgHex := hex.EncodeToString(msg)
 
-	out, err := execCommand("dao-token", "mint", addr, amt, "--pub", pubHex, "--msg", msgHex, "--sig", sigHex, "--json")
+	out, err := execCommand("dao-token", "mint", dao.ID, "admin", "addr1", amt, "--pub", pubHex, "--msg", msgHex, "--sig", sigHex, "--json")
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
@@ -52,7 +62,7 @@ func TestDAOTokenMintJSON(t *testing.T) {
 	if resp["status"] != "minted" {
 		t.Fatalf("unexpected status: %v", resp)
 	}
-	if daoTokenLedger.Balance(addr) != 7 {
+	if daoTokenLedger.Balance(dao.ID, "addr1") != 7 {
 		t.Fatalf("mint not recorded")
 	}
 }

--- a/cmd/synnergy/main.go
+++ b/cmd/synnergy/main.go
@@ -44,6 +44,8 @@ func main() {
 	synn.LoadGasTable()
 	synn.RegisterGasCost("MineBlock", synn.GasCost("MineBlock"))
 	synn.RegisterGasCost("CreateDAO", synn.GasCost("CreateDAO"))
+	synn.RegisterGasCost("UpdateMemberRole", synn.GasCost("UpdateMemberRole"))
+	synn.RegisterGasCost("RenewAuthorityTerm", synn.GasCost("RenewAuthorityTerm"))
 	// Stage 24 cross-chain operations
 	synn.RegisterGasCost("RegisterBridge", synn.GasCost("RegisterBridge"))
 	synn.RegisterGasCost("BridgeDeposit", synn.GasCost("BridgeDeposit"))

--- a/core/dao_access_control.go
+++ b/core/dao_access_control.go
@@ -2,6 +2,23 @@ package core
 
 import "errors"
 
+// Role constants for DAO membership.
+const (
+	RoleMember = "member"
+	RoleAdmin  = "admin"
+)
+
+var (
+	errInvalidRole   = errors.New("invalid role")
+	errMemberExists  = errors.New("member exists")
+	errMemberMissing = errors.New("member not found")
+	errUnauthorized  = errors.New("unauthorized")
+)
+
+func validRole(role string) bool {
+	return role == RoleMember || role == RoleAdmin
+}
+
 // AddMember adds a member with a specified role to the DAO.
 func (d *DAO) AddMember(addr, role string) error {
 	d.mu.Lock()
@@ -9,11 +26,28 @@ func (d *DAO) AddMember(addr, role string) error {
 	if d.Members == nil {
 		d.Members = make(map[string]string)
 	}
-	if role != "member" && role != "admin" {
-		return errors.New("invalid role")
+	if !validRole(role) {
+		return errInvalidRole
 	}
 	if _, ok := d.Members[addr]; ok {
-		return errors.New("member exists")
+		return errMemberExists
+	}
+	d.Members[addr] = role
+	return nil
+}
+
+// UpdateMemberRole updates a member's role. Only an admin can change roles.
+func (d *DAO) UpdateMemberRole(requester, addr, role string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Members[requester] != RoleAdmin {
+		return errUnauthorized
+	}
+	if !validRole(role) {
+		return errInvalidRole
+	}
+	if _, ok := d.Members[addr]; !ok {
+		return errMemberMissing
 	}
 	d.Members[addr] = role
 	return nil
@@ -24,7 +58,7 @@ func (d *DAO) RemoveMember(addr string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if _, ok := d.Members[addr]; !ok {
-		return errors.New("member not found")
+		return errMemberMissing
 	}
 	delete(d.Members, addr)
 	return nil
@@ -36,6 +70,21 @@ func (d *DAO) MemberRole(addr string) (string, bool) {
 	defer d.mu.RUnlock()
 	role, ok := d.Members[addr]
 	return role, ok
+}
+
+// IsMember checks if an address is part of the DAO.
+func (d *DAO) IsMember(addr string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_, ok := d.Members[addr]
+	return ok
+}
+
+// IsAdmin checks if an address has admin privileges in the DAO.
+func (d *DAO) IsAdmin(addr string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.Members[addr] == RoleAdmin
 }
 
 // MembersList returns all DAO members with their roles.

--- a/core/dao_access_control_test.go
+++ b/core/dao_access_control_test.go
@@ -4,14 +4,27 @@ import "testing"
 
 func TestDAOAccessControl(t *testing.T) {
 	dao := &DAO{Members: make(map[string]string)}
-	if err := dao.AddMember("addr1", "member"); err != nil {
+	if err := dao.AddMember("addr1", RoleMember); err != nil {
 		t.Fatalf("add member: %v", err)
 	}
-	if err := dao.AddMember("addr1", "member"); err == nil {
+	if err := dao.AddMember("addr1", RoleMember); err == nil {
 		t.Fatalf("expected duplicate error")
 	}
-	if role, ok := dao.MemberRole("addr1"); !ok || role != "member" {
+	if role, ok := dao.MemberRole("addr1"); !ok || role != RoleMember {
 		t.Fatalf("unexpected role %v %v", role, ok)
+	}
+	if err := dao.UpdateMemberRole("addr1", "addr1", RoleAdmin); err == nil {
+		t.Fatalf("non-admin should not update role")
+	}
+	// grant admin rights to requester
+	if err := dao.AddMember("admin", RoleAdmin); err != nil {
+		t.Fatalf("add admin: %v", err)
+	}
+	if err := dao.UpdateMemberRole("admin", "addr1", RoleAdmin); err != nil {
+		t.Fatalf("update role: %v", err)
+	}
+	if !dao.IsAdmin("addr1") {
+		t.Fatalf("expected addr1 to be admin")
 	}
 	if err := dao.RemoveMember("addr1"); err != nil {
 		t.Fatalf("remove: %v", err)

--- a/core/dao_proposal_test.go
+++ b/core/dao_proposal_test.go
@@ -10,30 +10,52 @@ func TestDAOProposal(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	pm := NewProposalManager()
-	prop := pm.CreateProposal(dao, "c", "desc")
+	// Non-member cannot create proposal
+	if _, err := pm.CreateProposal(dao, "x", "desc"); err == nil {
+		t.Fatalf("expected non-member create failure")
+	}
+	prop, err := pm.CreateProposal(dao, "c", "desc")
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
 	if prop.DAOID != dao.ID {
 		t.Fatalf("dao id mismatch")
 	}
-	if err := pm.Vote(prop.ID, "v1", 4, true); err != nil {
+	// Non-member cannot vote
+	if err := pm.Vote(dao, prop.ID, "v1", 4, true); err == nil {
+		t.Fatalf("expected non-member vote failure")
+	}
+	// Add members for voting
+	if err := dao.AddMember("v1", RoleMember); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if err := dao.AddMember("v2", RoleMember); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if err := pm.Vote(dao, prop.ID, "v1", 4, true); err != nil {
 		t.Fatalf("vote: %v", err)
 	}
-	if err := pm.Vote(prop.ID, "v2", 1, false); err != nil {
+	if err := pm.Vote(dao, prop.ID, "v2", 1, false); err != nil {
 		t.Fatalf("vote: %v", err)
 	}
 	yes, no, err := pm.Results(prop.ID)
 	if err != nil || yes != 4 || no != 1 {
 		t.Fatalf("unexpected tally: %d %d %v", yes, no, err)
 	}
-	if err := pm.Execute(prop.ID); err != nil {
+	// Non-admin cannot execute
+	if err := pm.Execute(dao, prop.ID, "v1"); err == nil {
+		t.Fatalf("expected non-admin execute failure")
+	}
+	if err := pm.Execute(dao, prop.ID, "c"); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 	if !prop.Executed {
 		t.Fatalf("proposal not marked executed")
 	}
-	if err := pm.Vote(prop.ID, "v3", 1, true); err == nil {
+	if err := pm.Vote(dao, prop.ID, "v1", 1, true); err == nil {
 		t.Fatalf("expected vote on executed proposal to fail")
 	}
-	if err := pm.Execute(prop.ID); err == nil {
+	if err := pm.Execute(dao, prop.ID, "c"); err == nil {
 		t.Fatalf("expected second execute to fail")
 	}
 }

--- a/core/dao_quadratic_voting.go
+++ b/core/dao_quadratic_voting.go
@@ -12,10 +12,13 @@ func QuadraticWeight(tokens uint64) uint64 {
 
 // CastQuadraticVote records a quadratic vote on a proposal. A vote with zero
 // tokens is rejected to avoid no-op entries.
-func (pm *ProposalManager) CastQuadraticVote(id, voter string, tokens uint64, support bool) error {
+func (pm *ProposalManager) CastQuadraticVote(dao *DAO, id, voter string, tokens uint64, support bool) error {
+	if !dao.IsMember(voter) {
+		return errNotMember
+	}
 	if tokens == 0 {
 		return errors.New("tokens must be > 0")
 	}
 	weight := QuadraticWeight(tokens)
-	return pm.Vote(id, voter, weight, support)
+	return pm.Vote(dao, id, voter, weight, support)
 }

--- a/core/dao_quadratic_voting_test.go
+++ b/core/dao_quadratic_voting_test.go
@@ -16,8 +16,56 @@ func TestCastQuadraticVoteZeroTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	p := pm.CreateProposal(dao, "c", "desc")
-	if err := pm.CastQuadraticVote(p.ID, "v", 0, true); err == nil {
+	p, err := pm.CreateProposal(dao, "c", "desc")
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+	if err := pm.CastQuadraticVote(dao, p.ID, "v", 0, true); err == nil {
 		t.Fatalf("expected error for zero tokens")
+	}
+}
+
+func TestCastQuadraticVoteRequiresMembership(t *testing.T) {
+	pm := NewProposalManager()
+	mgr := NewDAOManager()
+	mgr.AuthorizeRelayer("c")
+	dao, err := mgr.Create("d", "c")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	p, err := pm.CreateProposal(dao, "c", "desc")
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+	if err := pm.CastQuadraticVote(dao, p.ID, "v", 4, true); err != errNotMember {
+		t.Fatalf("expected errNotMember got %v", err)
+	}
+}
+
+func TestCastQuadraticVoteSuccess(t *testing.T) {
+	pm := NewProposalManager()
+	mgr := NewDAOManager()
+	mgr.AuthorizeRelayer("c")
+	dao, err := mgr.Create("d", "c")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := dao.AddMember("v", RoleMember); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	p, err := pm.CreateProposal(dao, "c", "desc")
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+	if err := pm.CastQuadraticVote(dao, p.ID, "v", 9, true); err != nil {
+		t.Fatalf("vote: %v", err)
+	}
+	yes, no, err := pm.Results(p.ID)
+	if err != nil {
+		t.Fatalf("results: %v", err)
+	}
+	expected := QuadraticWeight(9)
+	if yes != expected || no != 0 {
+		t.Fatalf("unexpected results: %d %d", yes, no)
 	}
 }

--- a/core/dao_staking.go
+++ b/core/dao_staking.go
@@ -5,49 +5,73 @@ import (
 	"sync"
 )
 
-// DAOStaking tracks staked tokens for DAO members.
+// errInsufficientStake is returned when an unstake exceeds the balance.
+var errInsufficientStake = errors.New("insufficient stake")
+
+// DAOStaking tracks staked tokens for DAO members per DAO instance.
+// It references the DAOManager to enforce membership checks before any
+// staking operation is performed.
 type DAOStaking struct {
 	mu     sync.RWMutex
-	stakes map[string]uint64
+	stakes map[string]map[string]uint64 // daoID -> addr -> amount
+	mgr    *DAOManager
 }
 
-// NewDAOStaking creates a new DAOStaking instance.
-func NewDAOStaking() *DAOStaking {
-	return &DAOStaking{stakes: make(map[string]uint64)}
+// NewDAOStaking creates a new DAOStaking instance bound to a DAOManager.
+func NewDAOStaking(mgr *DAOManager) *DAOStaking {
+	return &DAOStaking{stakes: make(map[string]map[string]uint64), mgr: mgr}
 }
 
-// Stake adds tokens to a member's stake.
-func (s *DAOStaking) Stake(addr string, amount uint64) {
-	s.mu.Lock()
-	s.stakes[addr] += amount
-	s.mu.Unlock()
-}
-
-// Unstake removes tokens from a member's stake.
-func (s *DAOStaking) Unstake(addr string, amount uint64) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	bal, ok := s.stakes[addr]
-	if !ok || bal < amount {
-		return errors.New("insufficient stake")
+// Stake adds tokens to a member's stake. The caller must be a DAO member.
+func (s *DAOStaking) Stake(daoID, addr string, amount uint64) error {
+	dao, err := s.mgr.Info(daoID)
+	if err != nil {
+		return err
 	}
-	s.stakes[addr] = bal - amount
+	if !dao.IsMember(addr) {
+		return errUnauthorized
+	}
+	s.mu.Lock()
+	if s.stakes[daoID] == nil {
+		s.stakes[daoID] = make(map[string]uint64)
+	}
+	s.stakes[daoID][addr] += amount
+	s.mu.Unlock()
 	return nil
 }
 
-// Balance returns the staked balance for an address.
-func (s *DAOStaking) Balance(addr string) uint64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.stakes[addr]
+// Unstake removes tokens from a member's stake. Only DAO members can unstake.
+func (s *DAOStaking) Unstake(daoID, addr string, amount uint64) error {
+	dao, err := s.mgr.Info(daoID)
+	if err != nil {
+		return err
+	}
+	if !dao.IsMember(addr) {
+		return errUnauthorized
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	bal := s.stakes[daoID][addr]
+	if bal < amount {
+		return errInsufficientStake
+	}
+	s.stakes[daoID][addr] = bal - amount
+	return nil
 }
 
-// TotalStaked returns the sum of all staked tokens.
-func (s *DAOStaking) TotalStaked() uint64 {
+// Balance returns the staked balance for an address within a DAO.
+func (s *DAOStaking) Balance(daoID, addr string) uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.stakes[daoID][addr]
+}
+
+// TotalStaked returns the sum of all staked tokens for a DAO.
+func (s *DAOStaking) TotalStaked(daoID string) uint64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	var total uint64
-	for _, amt := range s.stakes {
+	for _, amt := range s.stakes[daoID] {
 		total += amt
 	}
 	return total

--- a/core/dao_staking_test.go
+++ b/core/dao_staking_test.go
@@ -2,20 +2,31 @@ package core
 
 import "testing"
 
+// TestDAOStaking verifies staking is gated by membership and tracks balances
+// per DAO.
 func TestDAOStaking(t *testing.T) {
-	s := NewDAOStaking()
-	s.Stake("a", 10)
-	s.Stake("b", 5)
-	if s.Balance("a") != 10 {
-		t.Fatalf("expected 10")
+	mgr := NewDAOManager()
+	mgr.AuthorizeRelayer("admin")
+	dao, err := mgr.Create("dao", "admin")
+	if err != nil {
+		t.Fatalf("create: %v", err)
 	}
-	if err := s.Unstake("a", 5); err != nil {
+
+	s := NewDAOStaking(mgr)
+	if err := s.Stake(dao.ID, "admin", 10); err != nil {
+		t.Fatalf("stake: %v", err)
+	}
+	// Non-member cannot stake
+	if err := s.Stake(dao.ID, "bob", 5); err == nil {
+		t.Fatalf("expected error for non-member stake")
+	}
+	if err := s.Unstake(dao.ID, "admin", 5); err != nil {
 		t.Fatalf("unstake: %v", err)
 	}
-	if s.Balance("a") != 5 {
-		t.Fatalf("expected 5")
+	if bal := s.Balance(dao.ID, "admin"); bal != 5 {
+		t.Fatalf("expected 5, got %d", bal)
 	}
-	if total := s.TotalStaked(); total != 10 {
+	if total := s.TotalStaked(dao.ID); total != 5 {
 		t.Fatalf("unexpected total %d", total)
 	}
 }

--- a/core/dao_test.go
+++ b/core/dao_test.go
@@ -23,6 +23,12 @@ func TestDAOManager(t *testing.T) {
 	if err := mgr.Join(dao.ID, "user1"); err != nil {
 		t.Fatalf("join: %v", err)
 	}
+	if info, err := mgr.Info(dao.ID); err != nil || len(info.Members) != 2 {
+		t.Fatalf("info: %v members=%d", err, len(info.Members))
+	}
+	if daos := mgr.List(); len(daos) != 1 {
+		t.Fatalf("expected one dao, got %d", len(daos))
+	}
 
 	mgr.RevokeRelayer("user1")
 	if err := mgr.Leave(dao.ID, "user1"); err == nil {

--- a/core/dao_token_test.go
+++ b/core/dao_token_test.go
@@ -3,24 +3,54 @@ package core
 import "testing"
 
 func TestDAOTokenLedger(t *testing.T) {
-	l := NewDAOTokenLedger()
-	l.Mint("a", 10)
-	if l.Balance("a") != 10 {
-		t.Fatalf("expected 10")
+	mgr := NewDAOManager()
+	mgr.AuthorizeRelayer("admin")
+	dao, err := mgr.Create("d1", "admin")
+	if err != nil {
+		t.Fatalf("create dao: %v", err)
 	}
-	if err := l.Transfer("a", "b", 5); err != nil {
+	mgr.AuthorizeRelayer("alice")
+	mgr.AuthorizeRelayer("bob")
+	if err := mgr.Join(dao.ID, "alice"); err != nil {
+		t.Fatalf("join alice: %v", err)
+	}
+	if err := mgr.Join(dao.ID, "bob"); err != nil {
+		t.Fatalf("join bob: %v", err)
+	}
+
+	l := NewDAOTokenLedger(mgr)
+
+	if err := l.Mint(dao.ID, "alice", "alice", 10); err == nil {
+		t.Fatalf("expected unauthorized mint")
+	}
+	if err := l.Mint(dao.ID, "admin", "carol", 10); err == nil {
+		t.Fatalf("expected member missing")
+	}
+	if err := l.Mint(dao.ID, "admin", "alice", 10); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if bal := l.Balance(dao.ID, "alice"); bal != 10 {
+		t.Fatalf("expected 10, got %d", bal)
+	}
+	if err := l.Transfer(dao.ID, "alice", "bob", 5); err != nil {
 		t.Fatalf("transfer: %v", err)
 	}
-	if l.Balance("a") != 5 || l.Balance("b") != 5 {
+	if l.Balance(dao.ID, "alice") != 5 || l.Balance(dao.ID, "bob") != 5 {
 		t.Fatalf("unexpected balances")
 	}
-	if err := l.Burn("b", 3); err != nil {
+	if err := l.Transfer(dao.ID, "alice", "carol", 1); err == nil {
+		t.Fatalf("expected transfer error")
+	}
+	if err := l.Burn(dao.ID, "admin", "bob", 3); err != nil {
 		t.Fatalf("burn: %v", err)
 	}
-	if l.Balance("b") != 2 {
+	if l.Balance(dao.ID, "bob") != 2 {
 		t.Fatalf("unexpected burn balance")
 	}
-	if err := l.Burn("b", 5); err == nil {
+	if err := l.Burn(dao.ID, "alice", "bob", 1); err == nil {
+		t.Fatalf("expected unauthorized burn")
+	}
+	if err := l.Burn(dao.ID, "admin", "bob", 5); err == nil {
 		t.Fatalf("expected burn error")
 	}
 }

--- a/core/elected_authority_node.go
+++ b/core/elected_authority_node.go
@@ -1,14 +1,21 @@
 package core
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // ElectedAuthorityNode represents an authority node with a fixed term.
+// A mutex guards the term so concurrent renewals are safe when multiple
+// governance operations attempt to extend a node's tenure.
 type ElectedAuthorityNode struct {
 	*AuthorityNode
+	mu      sync.RWMutex
 	TermEnd time.Time
 }
 
-// NewElectedAuthorityNode creates a new elected authority node with the given term duration.
+// NewElectedAuthorityNode creates a new elected authority node with the given
+// term duration and an empty vote set.
 func NewElectedAuthorityNode(addr, role string, term time.Duration) *ElectedAuthorityNode {
 	node := &AuthorityNode{Address: addr, Role: role, Votes: make(map[string]bool)}
 	return &ElectedAuthorityNode{AuthorityNode: node, TermEnd: time.Now().Add(term)}
@@ -16,5 +23,20 @@ func NewElectedAuthorityNode(addr, role string, term time.Duration) *ElectedAuth
 
 // IsActive returns true if the node's term has not expired.
 func (n *ElectedAuthorityNode) IsActive(now time.Time) bool {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 	return now.Before(n.TermEnd)
+}
+
+// RenewTerm extends the node's term. The requester must be a DAO admin.
+// This ensures that only authorized governance participants can prolong an
+// authority node's tenure.
+func (n *ElectedAuthorityNode) RenewTerm(requester string, dao *DAO, add time.Duration) error {
+	if dao == nil || !dao.IsAdmin(requester) {
+		return errUnauthorized
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.TermEnd = n.TermEnd.Add(add)
+	return nil
 }

--- a/core/elected_authority_node_test.go
+++ b/core/elected_authority_node_test.go
@@ -6,11 +6,23 @@ import (
 )
 
 func TestElectedAuthorityNode(t *testing.T) {
+	dao := &DAO{Members: map[string]string{"admin": RoleAdmin, "member": RoleMember}}
 	en := NewElectedAuthorityNode("addr", "validator", time.Minute)
 	if !en.IsActive(time.Now()) {
 		t.Fatalf("expected active")
 	}
 	if en.IsActive(time.Now().Add(time.Hour)) {
 		t.Fatalf("expected inactive after term")
+	}
+	// non-admin cannot renew
+	if err := en.RenewTerm("member", dao, time.Hour); err == nil {
+		t.Fatalf("expected unauthorized renewal")
+	}
+	// admin renews term
+	if err := en.RenewTerm("admin", dao, time.Hour); err != nil {
+		t.Fatalf("renew term: %v", err)
+	}
+	if !en.IsActive(time.Now().Add(59 * time.Minute)) {
+		t.Fatalf("expected renewed term")
 	}
 }

--- a/core/opcode.go
+++ b/core/opcode.go
@@ -504,6 +504,8 @@ var catalogue = []struct {
 	{"RemoveDAOMember", 0x0C0109},
 	{"RoleOfMember", 0x0C010A},
 	{"ListDAOMembers", 0x0C010B},
+	{"UpdateMemberRole", 0x0C010C},
+	{"RenewAuthorityTerm", 0x0C010D},
 	{"NewQuorumTracker", 0x0C000B},
 	{"QuorumAddVote", 0x0C000C},
 	{"QuorumHasQuorum", 0x0C000D},

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -70,7 +70,8 @@
 - Stage 62: ✅ biometric authentication, block validation with timestamp, duplicate, and header hash checks, compression, synchronization, central banking, charity, coin (optimized supply calculations) and compliance modules with tests; gas table snapshots now emit deterministic JSON for CLI tooling, support persistence via `WriteGasTableSnapshot`, and the CLI can write snapshots directly to disk.
 - Stage 63: Completed – connection pool and adaptive consensus manager use windowed metrics for stable weighting.
   - Stage 64: Completed – cross-chain registry, bridge manager, connection manager, protocol registry, contract registry, custodial nodes and DAO management enforce relayer authorization with safe deletion; cross-chain transactions and scaling networks now guarded by whitelisted relayers.
-- Stage 136: Pending – security assessment and benchmark scaffolds reserved for final stage.
+- Stage 65: Completed – DAO access control, proposal system, quadratic voting, staking, token ledger, member role management and elected authority node term renewals documented with gas/opcode updates.
+ - Stage 136: Pending – security assessment and benchmark scaffolds reserved for final stage.
 
 **Stage 1**
 - [x] .github/ISSUE_TEMPLATE/bug_report.md – expanded fields and severity levels
@@ -1444,21 +1445,35 @@
  - [x] cli/dao.go – auto-whitelist callers for DAO actions
  - [x] cli/dao_access_control_test.go – CLI tests ensure unauthorized relayers are rejected
  - [x] cli/dao_proposal_test.go – CLI tests validate authorized proposal flow
+ - [x] cli/dao_token.go – DAO ID aware token ledger commands with admin-gated mint/burn
+ - [x] cli/dao_token_test.go – ensures signed minting records balances
 
 **Stage 65**
-- [ ] core/dao_access_control.go
-- [ ] core/dao_access_control_test.go
-- [ ] core/dao_proposal.go
-- [ ] core/dao_proposal_test.go
-- [ ] core/dao_quadratic_voting.go
-- [ ] core/dao_quadratic_voting_test.go
-- [ ] core/dao_staking.go
-- [ ] core/dao_staking_test.go
-- [ ] core/dao_test.go
-- [ ] core/dao_token.go
-- [ ] core/dao_token_test.go
-- [ ] core/elected_authority_node.go
-- [ ] core/elected_authority_node_test.go
+- [x] core/dao_access_control.go – role constants and admin role enforcement
+- [x] core/dao_access_control_test.go – covers unauthorized role updates
+- [x] core/dao_proposal.go – membership-gated creation, voting, and admin execution
+- [x] core/dao_proposal_test.go – verifies membership and admin constraints
+ - [x] core/dao_quadratic_voting.go – enforces DAO membership before quadratic vote weight
+ - [x] core/dao_quadratic_voting_test.go – covers membership requirements and success path
+ - [x] core/dao_staking.go – membership-gated staking with DAO manager
+ - [x] core/dao_staking_test.go – verifies member-only staking and balances
+ - [x] core/dao_test.go – verifies DAO info/list and relayer enforcement
+ - [x] core/dao_token.go – membership-gated token ledger bound to DAO manager
+ - [x] core/dao_token_test.go – covers admin minting, transfers and burns
+- [x] cli/dao_access_control.go – member role update command requiring admin signature
+- [x] cli/dao_access_control_test.go – tests admin-only role updates and rejections
+ - [x] core/opcode.go – opcode assigned for UpdateMemberRole and RenewAuthorityTerm
+ - [x] gas_table.go – notes DAO role update and term renewal gas entries
+ - [x] cmd/synnergy/main.go – registers UpdateMemberRole and RenewAuthorityTerm gas costs
+ - [x] docs/reference/opcodes_list.md – documents UpdateMemberRole and RenewAuthorityTerm opcodes
+- [x] docs/reference/gas_table_list.md – prices UpdateMemberRole and RenewAuthorityTerm
+ - [x] docs/reference/functions_list.md – lists DAO role and authority term helpers
+- [x] docs/Whitepaper_detailed/guide/cli_guide.md – documents dao-members update command
+- [x] docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md – notes DAO token operations and authority term renewals
+- [x] web/pages/dao.js – web UI exposes DAO listing and role updates
+ - [x] README.md – highlights admin-controlled DAO role changes and term renewals
+- [x] core/elected_authority_node.go – term renewals gated by DAO admins
+- [x] core/elected_authority_node_test.go – covers admin and non-admin renewal paths
 - [ ] core/faucet.go
 - [ ] core/faucet_test.go
 - [ ] core/fees.go
@@ -3952,14 +3967,14 @@
 | 64 | core/custodial_node.go | [ ] |
 | 64 | core/custodial_node_test.go | [ ] |
 | 64 | core/dao.go | [ ] |
-| 65 | core/dao_access_control.go | [ ] |
-| 65 | core/dao_access_control_test.go | [ ] |
+| 65 | core/dao_access_control.go | [x] | role constants, admin-only updates |
+| 65 | core/dao_access_control_test.go | [x] | tests for role management |
 | 65 | core/dao_proposal.go | [ ] |
 | 65 | core/dao_proposal_test.go | [ ] |
 | 65 | core/dao_quadratic_voting.go | [ ] |
 | 65 | core/dao_quadratic_voting_test.go | [ ] |
-| 65 | core/dao_staking.go | [ ] |
-| 65 | core/dao_staking_test.go | [ ] |
+| 65 | core/dao_staking.go | [x] |
+| 65 | core/dao_staking_test.go | [x] |
 | 65 | core/dao_test.go | [ ] |
 | 65 | core/dao_token.go | [ ] |
 | 65 | core/dao_token_test.go | [ ] |

--- a/docs/Whitepaper_detailed/guide/cli_guide.md
+++ b/docs/Whitepaper_detailed/guide/cli_guide.md
@@ -11,8 +11,9 @@ robust block management with strict argument validation and accompanying test
 coverage.
 Stage 43 introduces DAO governance commands with optional JSON output and
 signature verification utilities for secure organisational workflows. Membership
-updates through `dao-members` now require valid ECDSA signatures before roles
-change, ensuring authenticated governance actions.
+actions through `dao-members`—including adding, updating and removing
+participants—require valid ECDSA signatures before roles change, ensuring
+authenticated governance actions.
 
 ### Options
 
@@ -5443,7 +5444,8 @@ Manage DAO membership roles
 * [synnergy dao-members add](#synnergy-dao-members-add)	 - Add member with role
 * [synnergy dao-members list](#synnergy-dao-members-list)	 - List members
 * [synnergy dao-members remove](#synnergy-dao-members-remove)	 - Remove a member
-* [synnergy dao-members role](#synnergy-dao-members-role)	 - Get member role
+* [synnergy dao-members role](#synnergy-dao-members-role)        - Get member role
+* [synnergy dao-members update](#synnergy-dao-members-update)    - Update member role
 
 
 ## synnergy dao-members add
@@ -5544,6 +5546,30 @@ synnergy dao-members role <daoID> <addr> [flags]
 ### SEE ALSO
 
 * [synnergy dao-members](#synnergy-dao-members)	 - Manage DAO membership roles
+
+## synnergy dao-members update
+
+Update member role
+
+```
+synnergy dao-members update <daoID> <admin> <addr> <role> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --json   output results in JSON
+```
+
+### SEE ALSO
+
+* [synnergy dao-members](#synnergy-dao-members)  - Manage DAO membership roles
 
 
 ## synnergy dao-proposal
@@ -5826,7 +5852,7 @@ DAO staking operations
 Show staked balance
 
 ```
-synnergy dao-stake balance <addr> [flags]
+synnergy dao-stake balance <daoID> <addr> [flags]
 ```
 
 ### Options
@@ -5851,7 +5877,7 @@ synnergy dao-stake balance <addr> [flags]
 Stake tokens
 
 ```
-synnergy dao-stake stake <addr> <amount> [flags]
+synnergy dao-stake stake <daoID> <addr> <amount> [flags]
 ```
 
 ### Options
@@ -5876,7 +5902,7 @@ synnergy dao-stake stake <addr> <amount> [flags]
 Show total staked tokens
 
 ```
-synnergy dao-stake total [flags]
+synnergy dao-stake total <daoID> [flags]
 ```
 
 ### Options
@@ -5901,7 +5927,7 @@ synnergy dao-stake total [flags]
 Unstake tokens
 
 ```
-synnergy dao-stake unstake <addr> <amount> [flags]
+synnergy dao-stake unstake <daoID> <addr> <amount> [flags]
 ```
 
 ### Options
@@ -5940,10 +5966,10 @@ DAO token ledger operations
 ### SEE ALSO
 
 * [synnergy](#synnergy)	 - Synnergy blockchain CLI
-* [synnergy dao-token balance](#synnergy-dao-token-balance)	 - Get token balance
-* [synnergy dao-token burn](#synnergy-dao-token-burn)	 - Burn tokens from an address
-* [synnergy dao-token mint](#synnergy-dao-token-mint)	 - Mint tokens to an address
-* [synnergy dao-token transfer](#synnergy-dao-token-transfer)	 - Transfer tokens
+* [synnergy dao-token balance](#synnergy-dao-token-balance)      - Get DAO token balance
+* [synnergy dao-token burn](#synnergy-dao-token-burn)    - Burn DAO tokens from a member
+* [synnergy dao-token mint](#synnergy-dao-token-mint)    - Mint DAO tokens to a member
+* [synnergy dao-token transfer](#synnergy-dao-token-transfer)    - Transfer DAO tokens between members
 
 
 ## synnergy dao-token balance
@@ -5951,7 +5977,7 @@ DAO token ledger operations
 Get token balance
 
 ```
-synnergy dao-token balance <addr> [flags]
+synnergy dao-token balance <daoID> <addr> [flags]
 ```
 
 ### Options
@@ -5976,7 +6002,7 @@ synnergy dao-token balance <addr> [flags]
 Burn tokens from an address
 
 ```
-synnergy dao-token burn <addr> <amount> [flags]
+synnergy dao-token burn <daoID> <admin> <addr> <amount> [flags]
 ```
 
 ### Options
@@ -6001,7 +6027,7 @@ synnergy dao-token burn <addr> <amount> [flags]
 Mint tokens to an address
 
 ```
-synnergy dao-token mint <addr> <amount> [flags]
+synnergy dao-token mint <daoID> <admin> <addr> <amount> [flags]
 ```
 
 ### Options
@@ -6026,7 +6052,7 @@ synnergy dao-token mint <addr> <amount> [flags]
 Transfer tokens
 
 ```
-synnergy dao-token transfer <from> <to> <amount> [flags]
+synnergy dao-token transfer <daoID> <from> <to> <amount> [flags]
 ```
 
 ### Options

--- a/docs/Whitepaper_detailed/guide/module_guide.md
+++ b/docs/Whitepaper_detailed/guide/module_guide.md
@@ -87,7 +87,8 @@ Protocol upgrades, on‑chain voting and regulatory hooks.
   creation, voting strategies and enactment of approved changes.
 - **dao.go**, **dao_proposal.go**, **dao_quadratic_voting.go**,
   **dao_staking.go** and **dao_token.go** – Building blocks for DAOs that use
-  Synnergy as their execution layer.
+  Synnergy as their execution layer. `dao_staking.go` restricts staking to
+  registered members for secure governance.
 - **compliance.go**, **audit_management.go**, **audit_node.go** and
   **regulatory_management.go** – Optional KYC/AML checks, audit logging and
   jurisdiction specific rules.
@@ -282,7 +283,7 @@ Every file under `core/` is listed below with a short description derived from i
 - **dao_access_control.go** – DAORole represents a simple role within the DAO access list.
 - **dao_proposal.go** – DAOProposal represents an on-chain proposal within a DAO.
 - **dao_quadratic_voting.go** – QuadraticVoteRecord stores an individual quadratic vote.
-- **dao_staking.go** – DAOStaking manages token staking for governance participation.
+- **dao_staking.go** – DAOStaking manages member-only token staking for governance participation.
 - **dao_token.go** – DAO2500Membership is persisted in the ledger for SYN2500 tokens.
 - **data.go** – Opcode identifiers for CDN module
 - **data_distribution.go** – DataSet represents a piece of content offered through the

--- a/docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md
+++ b/docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md
@@ -12,6 +12,7 @@ invocation.
 
 Stage 28 validates that storage marketplace and analytics dashboard operations leverage this canonical gas schedule, ensuring user interfaces surface accurate fee estimates when invoking CLI commands.
 Stage 43 adds pricing for DAO membership operations so governance tooling can anticipate the cost of adding or removing members via the `dao-members` CLI.
+Stage 65 introduces gas costs and opcodes for DAO token ledger operations so member-gated minting, burning and transfers remain predictable, and records authority term renewals.
 
 ## Opcode Structure
 

--- a/docs/reference/functions_list.md
+++ b/docs/reference/functions_list.md
@@ -104,10 +104,11 @@
 | `core/syn2900.go` | `43` | `func (p *TokenInsurancePolicy) Claim(now time.Time) (uint64, error) {` |
 | `core/authority_node_index_test.go` | `5` | `func TestAuthorityNodeIndex(t *testing.T) {` |
 | `core/regulatory_management_test.go` | `5` | `func TestRegulatoryManager(t *testing.T) {` |
-| `core/dao_token.go` | `11` | `func NewDAOTokenLedger() *DAOTokenLedger {` |
-| `core/dao_token.go` | `16` | `func (l *DAOTokenLedger) Mint(addr string, amount uint64) {` |
-| `core/dao_token.go` | `21` | `func (l *DAOTokenLedger) Transfer(from, to string, amount uint64) error {` |
-| `core/dao_token.go` | `31` | `func (l *DAOTokenLedger) Balance(addr string) uint64 {` |
+| `core/dao_token.go` | `18` | `func NewDAOTokenLedger(mgr *DAOManager) *DAOTokenLedger {` |
+| `core/dao_token.go` | `23` | `func (l *DAOTokenLedger) Mint(daoID, admin, addr string, amount uint64) error {` |
+| `core/dao_token.go` | `44` | `func (l *DAOTokenLedger) Transfer(daoID, from, to string, amount uint64) error {` |
+| `core/dao_token.go` | `63` | `func (l *DAOTokenLedger) Balance(daoID, addr string) uint64 {` |
+| `core/dao_token.go` | `74` | `func (l *DAOTokenLedger) Burn(daoID, admin, addr string, amount uint64) error {` |
 | `core/syn5000.go` | `27` | `func NewSYN5000Token(name, symbol string, decimals uint8) *SYN5000Token {` |
 | `core/syn5000.go` | `32` | `func (t *SYN5000Token) PlaceBet(bettor string, amount uint64, odds float64, game string) uint64 {` |
 | `core/syn5000.go` | `40` | `func (t *SYN5000Token) ResolveBet(betID uint64, win bool) (uint64, error) {` |
@@ -393,10 +394,13 @@
 | `Tokens/syn2900.go` | `69` | `func (r *InsuranceRegistry) FileClaim(policyID, desc string, amount uint64) (*ClaimRecord, error) {` |
 | `Tokens/syn2900.go` | `84` | `func (r *InsuranceRegistry) GetPolicy(policyID string) (*InsurancePolicy, bool) {` |
 | `Tokens/syn2900.go` | `97` | `func (r *InsuranceRegistry) ListPolicies() []*InsurancePolicy {` |
-| `core/dao_access_control.go` | `6` | `func (d *DAO) AddMember(addr, role string) error {` |
-| `core/dao_access_control.go` | `18` | `func (d *DAO) RemoveMember(addr string) {` |
-| `core/dao_access_control.go` | `23` | `func (d *DAO) MemberRole(addr string) (string, bool) {` |
-| `core/dao_access_control.go` | `29` | `func (d *DAO) MembersList() map[string]string {` |
+| `core/dao_access_control.go` | `23` | `func (d *DAO) AddMember(addr, role string) error {` |
+| `core/dao_access_control.go` | `40` | `func (d *DAO) UpdateMemberRole(requester, addr, role string) error {` |
+| `core/dao_access_control.go` | `57` | `func (d *DAO) RemoveMember(addr string) error {` |
+| `core/dao_access_control.go` | `68` | `func (d *DAO) MemberRole(addr string) (string, bool) {` |
+| `core/dao_access_control.go` | `76` | `func (d *DAO) IsMember(addr string) bool {` |
+| `core/dao_access_control.go` | `84` | `func (d *DAO) IsAdmin(addr string) bool {` |
+| `core/dao_access_control.go` | `91` | `func (d *DAO) MembersList() map[string]string {` |
 | `core/audit_node_test.go` | `7` | `func (m *mockBootstrap) Start() error {` |
 | `core/audit_node_test.go` | `12` | `func TestAuditNode_StartAndLog(t *testing.T) {` |
 | `core/gateway_node.go` | `22` | `func NewGatewayNode(id nodes.Address, cfg GatewayConfig) *GatewayNode {` |
@@ -627,13 +631,14 @@
 | `core/dao.go` | `51` | `func (m *DAOManager) Leave(id, addr string) error {` |
 | `core/dao.go` | `61` | `func (m *DAOManager) Info(id string) (*DAO, error) {` |
 | `core/dao.go` | `70` | `func (m *DAOManager) List() []*DAO {` |
-| `core/dao_staking.go` | `11` | `func NewDAOStaking() *DAOStaking {` |
-| `core/dao_staking.go` | `16` | `func (s *DAOStaking) Stake(addr string, amount uint64) {` |
-| `core/dao_staking.go` | `21` | `func (s *DAOStaking) Unstake(addr string, amount uint64) error {` |
-| `core/dao_staking.go` | `31` | `func (s *DAOStaking) Balance(addr string) uint64 {` |
-| `core/dao_staking_test.go` | `5` | `func TestDAOStaking(t *testing.T) {` |
-| `core/dao_quadratic_voting.go` | `6` | `func QuadraticWeight(tokens uint64) uint64 {` |
-| `core/dao_quadratic_voting.go` | `11` | `func (pm *ProposalManager) CastQuadraticVote(id, voter string, tokens uint64, support bool) error {` |
+| `core/dao_staking.go` | `21` | `func NewDAOStaking(mgr *DAOManager) *DAOStaking {` |
+| `core/dao_staking.go` | `26` | `func (s *DAOStaking) Stake(daoID, addr string, amount uint64) error {` |
+| `core/dao_staking.go` | `44` | `func (s *DAOStaking) Unstake(daoID, addr string, amount uint64) error {` |
+| `core/dao_staking.go` | `63` | `func (s *DAOStaking) Balance(daoID, addr string) uint64 {` |
+| `core/dao_staking.go` | `70` | `func (s *DAOStaking) TotalStaked(daoID string) uint64 {` |
+| `core/dao_staking_test.go` | `7` | `func TestDAOStaking(t *testing.T) {` |
+| `core/dao_quadratic_voting.go` | `9` | `func QuadraticWeight(tokens uint64) uint64 {` |
+| `core/dao_quadratic_voting.go` | `15` | `func (pm *ProposalManager) CastQuadraticVote(dao *DAO, id, voter string, tokens uint64, support bool) error {` |
 | `core/wallet.go` | `19` | `func NewWallet() (*Wallet, error) {` |
 | `core/wallet.go` | `29` | `func (w *Wallet) Sign(tx *Transaction) ([]byte, error) {` |
 | `core/wallet.go` | `45` | `func VerifySignature(tx *Transaction, sig []byte, pub *ecdsa.PublicKey) bool {` |
@@ -848,6 +853,9 @@
 | `core/access_control.go` | `51` | `func (a *AccessController) List(addr string) []string {` |
 | `core/dao_token_test.go` | `5` | `func TestDAOTokenLedger(t *testing.T) {` |
 | `core/dao_quadratic_voting_test.go` | `5` | `func TestQuadraticWeight(t *testing.T) {` |
+| `core/dao_quadratic_voting_test.go` | `11` | `func TestCastQuadraticVoteZeroTokens(t *testing.T) {` |
+| `core/dao_quadratic_voting_test.go` | `28` | `func TestCastQuadraticVoteRequiresMembership(t *testing.T) {` |
+| `core/dao_quadratic_voting_test.go` | `45` | `func TestCastQuadraticVoteSuccess(t *testing.T) {` |
 | `core/loanpool.go` | `18` | `func NewLoanPool(treasury uint64) *LoanPool {` |
 | `core/loanpool.go` | `27` | `func (lp *LoanPool) SubmitProposal(creator, recipient, typ string, amount uint64, desc string) (uint64, error) {` |
 | `core/loanpool.go` | `38` | `func (lp *LoanPool) VoteProposal(voter string, id uint64) error {` |
@@ -872,8 +880,9 @@
 | `core/initialization_replication.go` | `14` | `func NewInitService(r *Replicator) *InitService {` |
 | `core/initialization_replication.go` | `19` | `func (i *InitService) Start() {` |
 | `core/initialization_replication.go` | `30` | `func (i *InitService) Stop() {` |
-| `core/elected_authority_node.go` | `12` | `func NewElectedAuthorityNode(addr, role string, term time.Duration) *ElectedAuthorityNode {` |
-| `core/elected_authority_node.go` | `18` | `func (n *ElectedAuthorityNode) IsActive(now time.Time) bool {` |
+| `core/elected_authority_node.go` | `19` | `func NewElectedAuthorityNode(addr, role string, term time.Duration) *ElectedAuthorityNode {` |
+| `core/elected_authority_node.go` | `25` | `func (n *ElectedAuthorityNode) IsActive(now time.Time) bool {` |
+| `core/elected_authority_node.go` | `34` | `func (n *ElectedAuthorityNode) RenewTerm(requester string, dao *DAO, add time.Duration) error {` |
 | `core/government_authority_node.go` | `10` | `func NewGovernmentAuthorityNode(addr, role, department string) *GovernmentAuthorityNode {` |
 | `core/cross_chain_connection.go` | `24` | `func NewChainConnectionManager() *ChainConnectionManager {` |
 | `core/cross_chain_connection.go` | `29` | `func (m *ChainConnectionManager) Open(local, remote string) int {` |
@@ -947,11 +956,13 @@
 | `core/liquidity_views.go` | `26` | `func (r *LiquidityPoolRegistry) PoolInfo(id string) (LiquidityPoolView, bool) {` |
 | `core/liquidity_views.go` | `35` | `func (r *LiquidityPoolRegistry) PoolViews() []LiquidityPoolView {` |
 | `core/immutability_enforcement_test.go` | `5` | `func TestImmutabilityEnforcer(t *testing.T) {` |
-| `core/dao_proposal.go` | `25` | `func NewProposalManager() *ProposalManager {` |
-| `core/dao_proposal.go` | `30` | `func (pm *ProposalManager) CreateProposal(dao *DAO, creator, desc string) *DAOProposal {` |
-| `core/dao_proposal.go` | `41` | `func (pm *ProposalManager) Vote(id, voter string, weight uint64, support bool) error {` |
-| `core/dao_proposal.go` | `57` | `func (pm *ProposalManager) Get(id string) (*DAOProposal, error) {` |
-| `core/dao_proposal.go` | `66` | `func (pm *ProposalManager) List() []*DAOProposal {` |
+| `core/dao_proposal.go` | `29` | `func NewProposalManager() *ProposalManager {` |
+| `core/dao_proposal.go` | `41` | `func (pm *ProposalManager) CreateProposal(dao *DAO, creator, desc string) (*DAOProposal, error) {` |
+| `core/dao_proposal.go` | `59` | `func (pm *ProposalManager) Vote(dao *DAO, id, voter string, weight uint64, support bool) error {` |
+| `core/dao_proposal.go` | `85` | `func (pm *ProposalManager) Results(id string) (yes, no uint64, err error) {` |
+| `core/dao_proposal.go` | `104` | `func (pm *ProposalManager) Execute(dao *DAO, id, requester string) error {` |
+| `core/dao_proposal.go` | `124` | `func (pm *ProposalManager) Get(id string) (*DAOProposal, error) {` |
+| `core/dao_proposal.go` | `135` | `func (pm *ProposalManager) List() []*DAOProposal {` |
 | `core/virtual_machine.go` | `18` | `func NewSimpleVM() *SimpleVM { return &SimpleVM{} }` |
 | `core/virtual_machine.go` | `21` | `func (vm *SimpleVM) Start() error {` |
 | `core/virtual_machine.go` | `32` | `func (vm *SimpleVM) Stop() error {` |

--- a/docs/reference/gas_table_list.md
+++ b/docs/reference/gas_table_list.md
@@ -104,6 +104,7 @@
 | `DAO_Staked` | `1` |
 | `DAO_TotalStaked` | `1` |
 | `DAO_Unstake` | `5` |
+| `DAOTokenBalance` | `1` |
 | `DataDistributionMonitor_Status` | `1` |
 | `DataMonitorStatus` | `5` |
 | `DebugDump` | `1` |
@@ -346,6 +347,7 @@
 | `Mine` | `1` |
 | `MinimumStake` | `1` |
 | `MintAsset` | `1` |
+| `MintDAOToken` | `3` |
 | `MintNFT` | `1200` |
 | `Mint` | `10` |
 | `Mode` | `1` |
@@ -710,6 +712,7 @@
 | `TradeContract` | `100` |
 | `Transactions` | `1` |
 | `TransferAsset` | `1` |
+| `TransferDAOToken` | `3` |
 | `TransferItem` | `1` |
 | `TransferTicket` | `1` |
 | `Transfer` | `1` |
@@ -724,6 +727,8 @@
 | `UpdateAttributes` | `1` |
 | `UpdateBaseline` | `1` |
 | `UpdateConfig` | `1` |
+| `UpdateMemberRole` | `5` |
+| `RenewAuthorityTerm` | `7` |
 | `UpdatePolicy` | `2` |
 | `UpdateRate` | `1` |
 | `UpdateStatus` | `1` |

--- a/docs/reference/opcodes_list.md
+++ b/docs/reference/opcodes_list.md
@@ -321,6 +321,8 @@ and warfare nodes as well as UI integrations.
 | `RemoveDAOMember` | `0x0C0109` |
 | `RoleOfMember` | `0x0C010A` |
 | `ListDAOMembers` | `0x0C010B` |
+| `UpdateMemberRole` | `0x0C010C` |
+| `RenewAuthorityTerm` | `0x0C010D` |
 | `SubmitProposal` | `0x0C0005` |
 | `CastVote` | `0x0C0007` |
 | `ExecuteProposal` | `0x0C0008` |
@@ -331,6 +333,9 @@ and warfare nodes as well as UI integrations.
 | `DAO_Staked` | `0x0C0102` |
 | `DAO_TotalStaked` | `0x0C0103` |
 | `BurnDAOToken` | `0x0C0112` |
+| `DAOTokenBalance` | `0x0C0113` |
+| `MintDAOToken` | `0x0C0114` |
+| `TransferDAOToken` | `0x0C0115` |
 | `RemoveConsensusNetwork` | `0x0C0111` |
 | `NewDataDistribution` | `0x100128` |
 | `NewDataFeed` | `0x100129` |

--- a/gas_table.go
+++ b/gas_table.go
@@ -37,7 +37,9 @@ import (
 // liquidity pool and loan pool operations so their costs are exposed via the CLI.
 // Stage 59 registers content node management and content storage operations so
 // hosts and registries expose deterministic pricing for publish, retrieval and
-// discovery workflows used by the CLI and web interfaces.
+// discovery workflows used by the CLI and web interfaces. Stage 65 records DAO
+// role update operations so governance tooling prices admin-managed role
+// changes and authority term renewals.
 type GasTable map[string]uint64
 
 // DefaultGasCost is used when an opcode is missing from the guide.

--- a/web/pages/dao.js
+++ b/web/pages/dao.js
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 export default function DAO() {
   const [daos, setDaos] = useState([]);
+  const [form, setForm] = useState({ dao: '', admin: '', addr: '', role: '' });
+  const [status, setStatus] = useState('');
   useEffect(() => {
     fetch('/api/run', {
       method: 'POST',
@@ -26,6 +28,24 @@ export default function DAO() {
           <li key={d.ID}>{d.ID} - {d.Name}</li>
         ))}
       </ul>
+      <h2>Update Member Role</h2>
+      <form onSubmit={e => {
+        e.preventDefault();
+        fetch('/api/run', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command: 'dao-members', args: ['update', form.dao, form.admin, form.addr, form.role, '--json'] })
+        })
+          .then(res => res.json())
+          .then(data => setStatus(data.output || ''));
+      }}>
+        <input placeholder="DAO ID" value={form.dao} onChange={e => setForm({ ...form, dao: e.target.value })} />
+        <input placeholder="Admin" value={form.admin} onChange={e => setForm({ ...form, admin: e.target.value })} />
+        <input placeholder="Member" value={form.addr} onChange={e => setForm({ ...form, addr: e.target.value })} />
+        <input placeholder="Role" value={form.role} onChange={e => setForm({ ...form, role: e.target.value })} />
+        <button type="submit">Update</button>
+      </form>
+      {status && <pre>{status}</pre>}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- gate authority node term renewals behind DAO admin approval
- document RenewAuthorityTerm opcode and gas cost and register at startup
- mark Stage 65 complete in tracker

## Testing
- `go test ./core -run ElectedAuthority -count=1`
- `go test ./core -run DAOAccessControl -count=1`
- `go test -run GasTable -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68c215c80f4483209afa73882c6f31f0