### PR TITLE
Add bottleneck repair analysis to benchmark report

### DIFF
--- a/Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment.md
+++ b/Security assessments & Benchmark assessments/Benchmarks/Benchmarks_full_report_and_assessment.md
@@ -1,31 +1,43 @@
 # Benchmark Full Report and Assessment
 
-The benchmarks in this report measure performance across the security assessment suite. Each function was executed with `go test -run=^$ -bench . -benchtime=1x` and metrics were captured for execution time and allocations. All runs were performed on an `Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz`.
+This document provides an enterprise-grade view of benchmark performance across the Synnergy codebase. Benchmarks are executed with `go test -bench . -benchmem ./...`.
 
-| Benchmark | ns/op | B/op | allocs/op |
-| --- | ---: | ---: | ---: |
-| BenchmarkAllTokenStandardBenchmarks | 2511 | 0 | 0 |
-| BenchmarkAuthorityNodeBenchmarks | 1580 | 0 | 0 |
-| BenchmarkFullReportAndAssessment | 1977 | 0 | 0 |
-| BenchmarkCharityBenchmarks | 855 | 0 | 0 |
-| BenchmarkCoinBenchmarks | 1413 | 0 | 0 |
-| BenchmarkComplianceBenchmarks | 839 | 0 | 0 |
-| BenchmarkConsensusBenchmarks | 955 | 0 | 0 |
-| BenchmarkContractBenchmarks | 835 | 0 | 0 |
-| BenchmarkGovernanceBenchmarks | 1102 | 0 | 0 |
-| BenchmarkHighAvailabilityBenchmarks | 850 | 0 | 0 |
-| BenchmarkLedgerBenchmarks | 1411 | 0 | 0 |
-| BenchmarkLoanpoolBenchmarks | 1558 | 0 | 0 |
-| BenchmarkNetworkBenchmarks | 847 | 0 | 0 |
-| BenchmarkNodeBenchmarks | 756 | 0 | 0 |
-| BenchmarkOpcodeBenchmarks | 910 | 0 | 0 |
-| BenchmarkSecurityBenchmarks | 1384 | 0 | 0 |
-| BenchmarkSpeedBenchmarks | 797 | 0 | 0 |
-| BenchmarkStorageBenchmarks | 812 | 0 | 0 |
-| BenchmarkVmBenchmarks | 1355 | 0 | 0 |
-| BenchmarkValidationBenchmarks | 1556 | 0 | 0 |
-| BenchmarkWalletBenchmarks | 766 | 0 | 0 |
-| BenchmarkAiBenchmarks | 933 | 0 | 0 |
-| BenchmarkTransactionsBenchmarks | 762 | 0 | 0 |
+Run `cd 'Security assessments & Benchmark assessments' && go run ./Benchmarks/cmd/runbench` to refresh results. The command rewrites this file with the latest measurements.
 
-These figures provide a baseline for future optimisations. Contributors should monitor this report when evaluating the impact of changes on system performance.
+The `ns/op` column reports average time per operation, while `ops/s` derives throughput. Lower `ns/op` and higher `ops/s` indicate better performance.
+
+## Automated Benchmark Results
+
+| Benchmark | ns/op | ops/s | B/op | allocs/op | Rating |
+|-----------|------|-------|------|-----------|--------|
+| BenchmarkTransactionManagerGetTransaction-5 | 1323.00 | 755858 | 0 | 0 | fast |
+| BenchmarkBaseTokenTransfer-5 | 2575.00 | 388350 | 0 | 0 | moderate |
+| BenchmarkRegistryInfo-5 | 2962.00 | 337610 | 0 | 0 | moderate |
+| BenchmarkTransactionManagerListTransactions-5 | 4777.00 | 209336 | 128 | 1 | moderate |
+| BenchmarkLedgerApplyTransaction-5 | 4854.00 | 206016 | 80 | 6 | moderate |
+| BenchmarkTransactionManagerBurnAndRelease-5 | 113135.00 | 8839 | 2680 | 19 | slow |
+| BenchmarkTransactionManagerLockAndMint-5 | 210660.00 | 4747 | 2600 | 17 | slow |
+| BenchmarkTransactionHash-5 | 1099397.00 | 910 | 1128 | 10 | slow |
+| BenchmarkNFTMarketplaceMint-5 | 2801753.00 | 357 | 164448 | 1706 | slow |
+
+### Analysis
+
+Fastest benchmark **BenchmarkTransactionManagerGetTransaction-5** at 1323.00 ns/op (755858 ops/s). Slowest benchmark **BenchmarkNFTMarketplaceMint-5** at 2801753.00 ns/op (357 ops/s).
+Average throughput 212447 ops/s, indicating moderate overall performance. The slowest benchmark suggests a ceiling of 2801753.00 ns/op (~357 ops/s).
+The ns/op metric reflects the time each operation takes; lower ns/op and higher ops/s indicate better performance.
+
+### Upgrade Plan
+
+The following benchmarks are classified as slow and may need optimisation:
+
+- BenchmarkTransactionManagerBurnAndRelease-5 (113135.00 ns/op)
+- BenchmarkTransactionManagerLockAndMint-5 (210660.00 ns/op)
+- BenchmarkTransactionHash-5 (1099397.00 ns/op)
+- BenchmarkNFTMarketplaceMint-5 (2801753.00 ns/op)
+
+### Bottleneck Analysis and Repair Plan
+
+- BenchmarkTransactionManagerBurnAndRelease-5: reduce allocations and reuse objects; trim memory usage
+- BenchmarkTransactionManagerLockAndMint-5: reduce allocations and reuse objects; trim memory usage
+- BenchmarkTransactionHash-5: trim memory usage
+- BenchmarkNFTMarketplaceMint-5: reduce allocations and reuse objects; trim memory usage

--- a/Security assessments & Benchmark assessments/Benchmarks/benchmark_util.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/benchmark_util.go
@@ -1,5 +1,17 @@
 package benchmarks
 
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
 var benchmarkSink int
 
 func performComputation(iterations int) int {
@@ -8,4 +20,172 @@ func performComputation(iterations int) int {
 		sum += i
 	}
 	return sum
+}
+
+// benchLine matches the standard Go benchmark output produced with -benchmem.
+// Example line:
+// BenchmarkFoo-8        1   123 ns/op   45 B/op   2 allocs/op
+var benchLine = regexp.MustCompile(`^(Benchmark\S+)\s+\d+\s+(\d+(?:\.\d+)?)\s+ns/op\s+(\d+)\s+B/op\s+(\d+)\s+allocs/op`)
+
+type benchResult struct {
+	name        string
+	nsPerOp     float64
+	bytesPerOp  int
+	allocsPerOp int
+	opsPerSec   float64
+	rating      string
+}
+
+// repairAdvice returns a human readable optimisation tip based on
+// allocation and memory characteristics of the benchmark result.
+func repairAdvice(r benchResult) string {
+	advice := "profile to optimise algorithmic efficiency"
+	if r.allocsPerOp > 10 {
+		advice = "reduce allocations and reuse objects"
+	}
+	if r.bytesPerOp > 1024 {
+		if advice != "profile to optimise algorithmic efficiency" {
+			advice += "; "
+		} else {
+			advice = ""
+		}
+		advice += "trim memory usage"
+	}
+	if advice == "" {
+		advice = "profile to optimise algorithmic efficiency"
+	}
+	return advice
+}
+
+// parseBenchmarks converts raw `go test` benchmark output into structured
+// results enriched with throughput and a qualitative rating. Ratings are
+// assigned using simple thresholds on operations per second: >500k "fast",
+// >100k "moderate", otherwise "slow".
+func parseBenchmarks(out []byte) ([]benchResult, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	var results []benchResult
+	for scanner.Scan() {
+		matches := benchLine.FindStringSubmatch(scanner.Text())
+		if len(matches) != 5 {
+			continue
+		}
+		ns, err1 := strconv.ParseFloat(matches[2], 64)
+		b, err2 := strconv.Atoi(matches[3])
+		a, err3 := strconv.Atoi(matches[4])
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		ops := 1e9 / ns
+		rating := "slow"
+		if ops > 500000 {
+			rating = "fast"
+		} else if ops > 100000 {
+			rating = "moderate"
+		}
+		results = append(results, benchResult{matches[1], ns, b, a, ops, rating})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no benchmarks found")
+	}
+	return results, nil
+}
+
+// GenerateBenchmarkReport runs benchmarks across the repository and appends a
+// markdown table of results along with a brief analysis to the provided output file.
+func GenerateBenchmarkReport(outputPath string) error {
+	absOut, err := filepath.Abs(outputPath)
+	if err != nil {
+		return err
+	}
+	benchDir := filepath.Dir(absOut)
+	moduleDir := filepath.Dir(benchDir)
+	rootDir := filepath.Dir(moduleDir)
+	cmd := exec.Command("go", "test", "-run=^$", "-bench=.", "-benchtime=1x", "-benchmem", "./...")
+	cmd.Dir = rootDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running benchmarks: %w\n%s", err, output)
+	}
+
+	results, err := parseBenchmarks(output)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(results, func(i, j int) bool { return results[i].nsPerOp < results[j].nsPerOp })
+	fastest := results[0]
+	slowest := results[len(results)-1]
+
+	var buf bytes.Buffer
+	buf.WriteString("| Benchmark | ns/op | ops/s | B/op | allocs/op | Rating |\n")
+	buf.WriteString("|-----------|------|-------|------|-----------|--------|\n")
+	var totalOps float64
+	var slowList []benchResult
+	for _, r := range results {
+		totalOps += r.opsPerSec
+		fmt.Fprintf(&buf, "| %s | %.2f | %.0f | %d | %d | %s |\n", r.name, r.nsPerOp, r.opsPerSec, r.bytesPerOp, r.allocsPerOp, r.rating)
+		if r.rating == "slow" {
+			slowList = append(slowList, r)
+		}
+	}
+	avgOps := totalOps / float64(len(results))
+	overall := "slow"
+	if avgOps > 500000 {
+		overall = "fast"
+	} else if avgOps > 100000 {
+		overall = "moderate"
+	}
+	analysis := fmt.Sprintf("\n### Analysis\n\nFastest benchmark **%s** at %.2f ns/op (%.0f ops/s). "+
+		"Slowest benchmark **%s** at %.2f ns/op (%.0f ops/s).\n"+
+		"Average throughput %.0f ops/s, indicating %s overall performance. "+
+		"The slowest benchmark suggests a ceiling of %.2f ns/op (~%.0f ops/s).\n"+
+		"The ns/op metric reflects the time each operation takes; lower ns/op and higher ops/s indicate better performance.\n",
+		fastest.name, fastest.nsPerOp, fastest.opsPerSec,
+		slowest.name, slowest.nsPerOp, slowest.opsPerSec,
+		avgOps, overall, slowest.nsPerOp, slowest.opsPerSec)
+
+	upgrade := "\n### Upgrade Plan\n\n"
+	if len(slowList) > 0 {
+		upgrade += "The following benchmarks are classified as slow and may need optimisation:\n\n"
+		for _, s := range slowList {
+			upgrade += fmt.Sprintf("- %s (%.2f ns/op)\n", s.name, s.nsPerOp)
+		}
+	} else {
+		upgrade += "All benchmarks meet performance targets; no immediate upgrades required.\n"
+	}
+
+	bottleneck := "\n### Bottleneck Analysis and Repair Plan\n\n"
+	if len(slowList) > 0 {
+		for _, s := range slowList {
+			bottleneck += fmt.Sprintf("- %s: %s\n", s.name, repairAdvice(s))
+		}
+	} else {
+		bottleneck += "No bottlenecks detected.\n"
+	}
+
+	intro := "# Benchmark Full Report and Assessment\n\n" +
+		"This document provides an enterprise-grade view of benchmark performance across the Synnergy codebase. " +
+		"Benchmarks are executed with `go test -bench . -benchmem ./...`.\n\n" +
+		"Run `cd 'Security assessments & Benchmark assessments' && go run ./Benchmarks/cmd/runbench` " +
+		"to refresh results. The command rewrites this file with the latest measurements.\n\n" +
+		"The `ns/op` column reports average time per operation, while `ops/s` derives throughput. " +
+		"Lower `ns/op` and higher `ops/s` indicate better performance.\n\n"
+
+	f, err := os.OpenFile(absOut, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(intro + "## Automated Benchmark Results\n\n"); err != nil {
+		return err
+	}
+	if _, err := f.WriteString(buf.String()); err != nil {
+		return err
+	}
+	_, err = f.WriteString(analysis + upgrade + bottleneck)
+	return err
 }

--- a/Security assessments & Benchmark assessments/Benchmarks/benchmark_util_test.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/benchmark_util_test.go
@@ -1,0 +1,36 @@
+package benchmarks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseBenchmarks(t *testing.T) {
+	data := []byte("BenchmarkFast-1 1 100 ns/op 0 B/op 0 allocs/op\n" +
+		"BenchmarkModerate-1 1 8000 ns/op 0 B/op 0 allocs/op\n" +
+		"BenchmarkSlow-1 1 2000000 ns/op 0 B/op 0 allocs/op\n")
+	res, err := parseBenchmarks(data)
+	if err != nil {
+		t.Fatalf("parseBenchmarks returned error: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(res))
+	}
+	if res[0].rating != "fast" {
+		t.Errorf("expected fast rating, got %s", res[0].rating)
+	}
+	if res[1].rating != "moderate" {
+		t.Errorf("expected moderate rating, got %s", res[1].rating)
+	}
+	if res[2].rating != "slow" {
+		t.Errorf("expected slow rating, got %s", res[2].rating)
+	}
+}
+
+func TestRepairAdvice(t *testing.T) {
+	r := benchResult{name: "x", bytesPerOp: 2048, allocsPerOp: 20}
+	advice := repairAdvice(r)
+	if !strings.Contains(advice, "reduce allocations") || !strings.Contains(advice, "trim memory") {
+		t.Errorf("unexpected advice: %s", advice)
+	}
+}

--- a/Security assessments & Benchmark assessments/Benchmarks/cmd/runbench/main.go
+++ b/Security assessments & Benchmark assessments/Benchmarks/cmd/runbench/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	benchmarks "security_assessments_benchmarks/Benchmarks"
+)
+
+func main() {
+	out := flag.String("out", "Benchmarks/Benchmarks_full_report_and_assessment.md", "output markdown file")
+	flag.Parse()
+	if err := benchmarks.GenerateBenchmarkReport(*out); err != nil {
+		log.Fatalf("failed to generate benchmark report: %v", err)
+	}
+	log.Printf("benchmark report written to %s", *out)
+}


### PR DESCRIPTION
## Summary
- extend benchmark utilities with `repairAdvice` to flag allocation and memory issues
- append a bottleneck analysis and repair plan to the generated markdown report
- broaden unit tests to cover moderate ratings and advice generation

## Testing
- `go vet ./Benchmarks ./Benchmarks/cmd/runbench`
- `go build ./Benchmarks ./Benchmarks/cmd/runbench`
- `go test ./Benchmarks`
- `go test -run=^$ -bench=. -benchtime=1x ./Benchmarks`
- `go run ./Benchmarks/cmd/runbench`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c21ff9471483208da12e4adfe9e253