### PR TITLE
Add SYN3700 index token and access audit gas entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Synnergy is a modular, high-performance blockchain written in Go and built for e
 - **Opcode-aware contracts** – sample Solidity bridges, liquidity, multisig, oracle and token contracts invoke SNVM opcodes with deterministic gas costs.
 - **On-chain governance token** – the SYN300 module supports delegated voting, proposal lifecycle management and CLI tooling with documented gas and opcode mappings.
 - **Regulatory node logging** – `synnergy regnode approve` surfaces rejection reasons and address logs for auditability.
+- **Regulatory audits** – `synnergy regnode audit` reports whether an address has been flagged and returns recorded reasons.
 - **Wallet-signed approvals** – regulatory nodes verify transactions against registered wallet public keys, and the CLI can load and sign with a wallet file before submitting for approval.
 - **Web regulatory console** – the `web/pages/regnode.js` interface exposes approval, flagging and log retrieval through a browser UI.
 - **Strict flagging** – regulatory flags require explicit non-empty reasons for improved audit integrity.

--- a/access_control.go
+++ b/access_control.go
@@ -61,3 +61,20 @@ func (a *AccessController) List(addr string) []string {
 	}
 	return out
 }
+
+// Audit snapshots all address-role assignments for inspection without
+// mutating internal state. The returned map is a copy and safe for
+// concurrent use by callers.
+func (a *AccessController) Audit() map[string][]string {
+        a.mu.RLock()
+        defer a.mu.RUnlock()
+        snapshot := make(map[string][]string, len(a.roles))
+        for addr, roles := range a.roles {
+                list := make([]string, 0, len(roles))
+                for r := range roles {
+                        list = append(list, r)
+                }
+                snapshot[addr] = list
+        }
+        return snapshot
+}

--- a/access_control_test.go
+++ b/access_control_test.go
@@ -1,6 +1,10 @@
 package synnergy
 
-import "testing"
+import (
+        "fmt"
+        "sync"
+        "testing"
+)
 
 func TestAccessController(t *testing.T) {
 	ac := NewAccessController()
@@ -16,4 +20,25 @@ func TestAccessController(t *testing.T) {
 	if ac.HasRole("admin", "addr1") {
 		t.Fatalf("role should be revoked")
 	}
+}
+
+func TestAccessControllerAuditConcurrent(t *testing.T) {
+        ac := NewAccessController()
+        var wg sync.WaitGroup
+        for i := 0; i < 10; i++ {
+                wg.Add(1)
+                go func(id int) {
+                        defer wg.Done()
+                        addr := fmt.Sprintf("addr%d", id)
+                        for j := 0; j < 100; j++ {
+                                ac.Grant("user", addr)
+                                _ = ac.Audit()
+                                ac.Revoke("user", addr)
+                        }
+                }(i)
+        }
+        wg.Wait()
+        if snap := ac.Audit(); len(snap) != 0 {
+                t.Fatalf("expected empty snapshot, got %v", snap)
+        }
 }

--- a/cli/regulatory_node.go
+++ b/cli/regulatory_node.go
@@ -67,17 +67,33 @@ func init() {
 		},
 	}
 
-	logsCmd := &cobra.Command{
-		Use:   "logs [addr]",
-		Args:  cobra.ExactArgs(1),
-		Short: "Show logs for an address",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			gasPrint("RegNodeLogs")
-			printOutput(regNode.Logs(args[0]))
-			return nil
-		},
-	}
+        logsCmd := &cobra.Command{
+                Use:   "logs [addr]",
+                Args:  cobra.ExactArgs(1),
+                Short: "Show logs for an address",
+                RunE: func(cmd *cobra.Command, args []string) error {
+                        gasPrint("RegNodeLogs")
+                        printOutput(regNode.Logs(args[0]))
+                        return nil
+                },
+        }
 
-	cmd.AddCommand(approveCmd, flagCmd, logsCmd)
+        auditCmd := &cobra.Command{
+                Use:   "audit [addr]",
+                Args:  cobra.ExactArgs(1),
+                Short: "Audit an address for regulatory flags",
+                RunE: func(cmd *cobra.Command, args []string) error {
+                        gasPrint("RegNodeAudit")
+                        logs, flagged := regNode.Audit(args[0])
+                        if !flagged {
+                                printOutput(map[string]string{"status": "clean"})
+                                return nil
+                        }
+                        printOutput(map[string]any{"status": "flagged", "logs": logs})
+                        return nil
+                },
+        }
+
+        cmd.AddCommand(approveCmd, flagCmd, logsCmd, auditCmd)
 	rootCmd.AddCommand(cmd)
 }

--- a/cli/regulatory_node_test.go
+++ b/cli/regulatory_node_test.go
@@ -60,3 +60,18 @@ func TestRegNodeFlagRequiresReason(t *testing.T) {
 		t.Fatalf("expected no logs, got %v", logs)
 	}
 }
+
+func TestRegNodeAuditReturnsStatus(t *testing.T) {
+        regManager = core.NewRegulatoryManager()
+        regNode = core.NewRegulatoryNode("regnode1", regManager)
+        _ = regNode.FlagEntity("mallory", "fraud")
+        cmd := RootCmd()
+        cmd.SetArgs([]string{"regnode", "audit", "mallory"})
+        if err := cmd.Execute(); err != nil {
+                t.Fatalf("audit failed: %v", err)
+        }
+        cmd.SetArgs([]string{"regnode", "audit", "trent"})
+        if err := cmd.Execute(); err != nil {
+                t.Fatalf("audit clean address failed: %v", err)
+        }
+}

--- a/cli/syn3600.go
+++ b/cli/syn3600.go
@@ -75,7 +75,10 @@ func init() {
 			if err != nil {
 				return fmt.Errorf("invalid price")
 			}
-			pnl := contract.Settle(price)
+			pnl, err := contract.Settle(price)
+			if err != nil {
+				return err
+			}
 			cmd.Printf("pnl %d\n", pnl)
 			return nil
 		},

--- a/core/regulatory_node.go
+++ b/core/regulatory_node.go
@@ -68,6 +68,18 @@ func (n *RegulatoryNode) Logs(addr string) []string {
 	return out
 }
 
+// Audit reports whether an address has been flagged and returns a copy of its logs.
+// It allows external systems or CLI users to verify regulatory status without
+// mutating internal state.
+func (n *RegulatoryNode) Audit(addr string) ([]string, bool) {
+        n.mu.RLock()
+        entries, ok := n.logs[addr]
+        out := make([]string, len(entries))
+        copy(out, entries)
+        n.mu.RUnlock()
+        return out, ok
+}
+
 // ClearLogs removes all flags recorded for an address.
 func (n *RegulatoryNode) ClearLogs(addr string) {
 	n.mu.Lock()

--- a/core/regulatory_node_test.go
+++ b/core/regulatory_node_test.go
@@ -61,6 +61,22 @@ func TestFlagRequiresReason(t *testing.T) {
 	}
 }
 
+func TestAuditReportsFlags(t *testing.T) {
+        mgr := NewRegulatoryManager()
+        node := NewRegulatoryNode("node", mgr)
+        _ = node.FlagEntity("carol", "suspicious activity")
+        logs, flagged := node.Audit("carol")
+        if !flagged {
+                t.Fatalf("expected carol to be flagged")
+        }
+        if len(logs) != 1 {
+                t.Fatalf("expected one log, got %v", logs)
+        }
+        if _, flagged := node.Audit("dave"); flagged {
+                t.Fatalf("expected dave to be clean")
+        }
+}
+
 func TestApproveTransactionNoManager(t *testing.T) {
 	node := NewRegulatoryNode("n", nil)
 	tx := Transaction{From: "alice", Amount: 100}

--- a/core/syn3200_test.go
+++ b/core/syn3200_test.go
@@ -1,7 +1,57 @@
 package core
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestSyn3200Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestBillRegistryLifecycle(t *testing.T) {
+	r := NewBillRegistry()
+	due := time.Now().Add(24 * time.Hour)
+	b, err := r.Create("1", "issuer", "payer", 100, due, "meta")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if b.Amount != 100 {
+		t.Fatalf("expected amount 100 got %d", b.Amount)
+	}
+
+	if err := r.Pay("1", "payer", 40); err != nil {
+		t.Fatalf("pay: %v", err)
+	}
+	if b.Amount != 60 {
+		t.Fatalf("expected amount 60 got %d", b.Amount)
+	}
+
+	if err := r.Adjust("1", 80); err != nil {
+		t.Fatalf("adjust: %v", err)
+	}
+	if b.Amount != 80 {
+		t.Fatalf("expected amount 80 got %d", b.Amount)
+	}
+
+	got, ok := r.Get("1")
+	if !ok || got.ID != "1" {
+		t.Fatalf("get failed")
+	}
+}
+
+func TestBillRegistryConcurrentPay(t *testing.T) {
+	r := NewBillRegistry()
+	r.Create("2", "issuer", "payer", 100, time.Now(), "")
+
+	done := make(chan struct{})
+	for i := 0; i < 5; i++ {
+		go func() {
+			_ = r.Pay("2", "payer", 10)
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 5; i++ {
+		<-done
+	}
+	b, _ := r.Get("2")
+	if b.Amount != 50 {
+		t.Fatalf("expected 50 got %d", b.Amount)
+	}
 }

--- a/core/syn3500_token_test.go
+++ b/core/syn3500_token_test.go
@@ -2,6 +2,24 @@ package core
 
 import "testing"
 
-func TestSyn3500tokenPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN3500TokenLifecycle(t *testing.T) {
+	tok := NewSYN3500Token("Dollar", "USD", "bank", 1.0)
+	tok.Mint("alice", 100)
+	if bal := tok.BalanceOf("alice"); bal != 100 {
+		t.Fatalf("expected 100 got %d", bal)
+	}
+	if err := tok.Redeem("alice", 40); err != nil {
+		t.Fatalf("redeem: %v", err)
+	}
+	if bal := tok.BalanceOf("alice"); bal != 60 {
+		t.Fatalf("expected 60 got %d", bal)
+	}
+	if err := tok.Redeem("alice", 1000); err == nil {
+		t.Fatalf("expected error on excessive redeem")
+	}
+	tok.SetRate(1.1)
+	_, _, rate := tok.Info()
+	if rate != 1.1 {
+		t.Fatalf("expected rate 1.1 got %f", rate)
+	}
 }

--- a/core/syn3600.go
+++ b/core/syn3600.go
@@ -1,13 +1,16 @@
 package core
 
 import (
+	"errors"
 	"math"
 	"math/big"
+	"sync"
 	"time"
 )
 
 // FuturesContract defines the essential metadata of a futures contract.
 type FuturesContract struct {
+	mu         sync.RWMutex
 	Underlying string
 	Quantity   uint64
 	Price      uint64 // entry price per unit
@@ -22,22 +25,33 @@ func NewFuturesContract(underlying string, quantity, price uint64, expiration ti
 
 // IsExpired returns true if the contract has reached expiration.
 func (f *FuturesContract) IsExpired(now time.Time) bool {
-	return !now.Before(f.Expiration)
+	f.mu.RLock()
+	exp := f.Expiration
+	f.mu.RUnlock()
+	return !now.Before(exp)
 }
 
 // Settle marks the contract settled and returns PnL for the long side.
-func (f *FuturesContract) Settle(marketPrice uint64) int64 {
+// Subsequent settlement attempts return an error to guard against double
+// settlement in concurrent environments.
+func (f *FuturesContract) Settle(marketPrice uint64) (int64, error) {
+	f.mu.Lock()
+	if f.Settled {
+		f.mu.Unlock()
+		return 0, errors.New("contract already settled")
+	}
 	f.Settled = true
+	f.mu.Unlock()
 	m := new(big.Int).SetUint64(marketPrice)
 	p := new(big.Int).SetUint64(f.Price)
 	q := new(big.Int).SetUint64(f.Quantity)
 	diff := new(big.Int).Sub(m, p)
 	pnl := new(big.Int).Mul(diff, q)
 	if pnl.IsInt64() {
-		return pnl.Int64()
+		return pnl.Int64(), nil
 	}
 	if pnl.Sign() >= 0 {
-		return math.MaxInt64
+		return math.MaxInt64, nil
 	}
-	return math.MinInt64
+	return math.MinInt64, nil
 }

--- a/core/syn3600_test.go
+++ b/core/syn3600_test.go
@@ -1,19 +1,50 @@
 package core
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
 
-func TestFuturesContract(t *testing.T) {
+func TestFuturesContractConcurrentSettlement(t *testing.T) {
 	exp := time.Unix(100, 0)
 	f := NewFuturesContract("BTC", 2, 1000, exp)
-	pnl := f.Settle(1100)
+
+	var wg sync.WaitGroup
+	successes := make(chan int64, 10)
+	errs := make(chan error, 10)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pnl, err := f.Settle(1100)
+			if err != nil {
+				errs <- err
+				return
+			}
+			successes <- pnl
+		}()
+	}
+	wg.Wait()
+	close(successes)
+	close(errs)
+
+	var okCount int
+	var pnl int64
+	for p := range successes {
+		okCount++
+		pnl = p
+	}
+	if okCount != 1 {
+		t.Fatalf("expected exactly one successful settlement, got %d", okCount)
+	}
 	if pnl != 200 {
 		t.Fatalf("expected pnl 200, got %d", pnl)
 	}
-	if !f.Settled {
-		t.Fatalf("contract should be settled")
+	for err := range errs {
+		if err.Error() != "contract already settled" {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	}
 	if !f.IsExpired(time.Unix(200, 0)) {
 		t.Fatalf("expected expired")

--- a/core/syn3700_token_test.go
+++ b/core/syn3700_token_test.go
@@ -1,7 +1,42 @@
 package core
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
-func TestSyn3700tokenPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN3700TokenLifecycle(t *testing.T) {
+	tok := NewSYN3700Token("Index", "IDX")
+	tok.AddComponent("AAA", 0.5)
+	tok.AddComponent("BBB", 0.5)
+	if err := tok.RemoveComponent("CCC"); err == nil {
+		t.Fatalf("expected missing component error")
+	}
+	if err := tok.RemoveComponent("BBB"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	comps := tok.ListComponents()
+	if len(comps) != 1 || comps[0].Token != "AAA" {
+		t.Fatalf("unexpected components %+v", comps)
+	}
+	val := tok.Value(map[string]float64{"AAA": 2})
+	if val != 1 { // 0.5 * 2
+		t.Fatalf("expected value 1 got %f", val)
+	}
+}
+
+func TestSYN3700TokenConcurrentAdd(t *testing.T) {
+	tok := NewSYN3700Token("Index", "IDX")
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tok.AddComponent(string(rune('A'+i)), 0.1)
+		}(i)
+	}
+	wg.Wait()
+	if len(tok.ListComponents()) != 10 {
+		t.Fatalf("expected 10 components")
+	}
 }

--- a/core/system_health_logging.go
+++ b/core/system_health_logging.go
@@ -23,6 +23,9 @@ func NewSystemHealthLogger() *SystemHealthLogger {
 // Collect gathers metrics from the runtime and records them as the latest snapshot.
 // Caller may supply optional peer count and block height information.
 func (l *SystemHealthLogger) Collect(peerCount int, height uint64) watchtower.Metrics {
+	if peerCount < 0 {
+		peerCount = 0
+	}
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 

--- a/core/system_health_logging_test.go
+++ b/core/system_health_logging_test.go
@@ -1,7 +1,17 @@
 package core
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestSystemhealthloggingPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSystemHealthLogger(t *testing.T) {
+	l := NewSystemHealthLogger()
+	m := l.Collect(-1, 10)
+	if m.PeerCount != 0 {
+		t.Fatalf("expected peer count clamped to 0 got %d", m.PeerCount)
+	}
+	snap := l.Snapshot()
+	if snap.LastBlockHeight != 10 {
+		t.Fatalf("snapshot mismatch")
+	}
 }

--- a/core/token_syn130_test.go
+++ b/core/token_syn130_test.go
@@ -1,7 +1,51 @@
 package core
 
-import "testing"
+import (
+	"sync"
+	"testing"
+	"time"
+)
 
-func TestTokensyn130Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestTangibleAssetRegistryConcurrency(t *testing.T) {
+	r := NewTangibleAssetRegistry()
+	if _, err := r.Register("a1", "alice", "house", 100); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.UpdateValuation("a1", 200)
+		}()
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.RecordSale("a1", "bob", 150)
+		}()
+	}
+	start := time.Now()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = r.StartLease("a1", "lessee", 10, start, start.Add(time.Hour))
+	}()
+	wg.Wait()
+
+	asset, ok := r.Get("a1")
+	if !ok {
+		t.Fatalf("asset not found")
+	}
+	if asset.Valuation != 200 {
+		t.Fatalf("expected valuation 200, got %d", asset.Valuation)
+	}
+	if asset.Owner != "bob" {
+		t.Fatalf("expected owner bob, got %s", asset.Owner)
+	}
+	if asset.Lease == nil || asset.Lease.Lessee != "lessee" {
+		t.Fatalf("lease not set correctly")
+	}
 }

--- a/core/token_syn4900_test.go
+++ b/core/token_syn4900_test.go
@@ -1,7 +1,45 @@
 package core
 
-import "testing"
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
 
-func TestTokensyn4900Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestAgriculturalRegistryConcurrency(t *testing.T) {
+	r := NewAgriculturalRegistry()
+	harvest := time.Now()
+	expiry := harvest.Add(24 * time.Hour)
+	if _, err := r.Register("f1", "grain", "alice", "farm", 10, harvest, expiry, "cert"); err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			_ = r.Transfer("f1", id)
+		}(fmt.Sprintf("owner%d", i))
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(status string) {
+			defer wg.Done()
+			_ = r.UpdateStatus("f1", status)
+		}(fmt.Sprintf("status%d", i))
+	}
+	wg.Wait()
+
+	asset, ok := r.Get("f1")
+	if !ok {
+		t.Fatalf("asset not found")
+	}
+	if asset.Owner == "alice" {
+		t.Fatalf("owner should have changed")
+	}
+	if len(asset.History) == 0 {
+		t.Fatalf("expected history entries")
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,7 +7,9 @@
 - Stage 67: Complete – ledger, light node, and liquidity pool validation with Kademlia gas tracking and CLI distance tests, plus identity service and wallet registry checks finalized.
 - Stage 68: Complete – mining node context control, fee distribution, and CLI mine-until integration finalized with gas pricing and opcode docs extended.
 - Stage 69: Complete – node and plasma modules hardened with concurrency-safe mempools, pause checks, opcode lookup tests and peer count CLI.
-- Stage 73: Complete – SYN300 governance token validated with wallet-signed regulatory approvals, regulatory node console and CLI alignment, gas/opcode entries and consensus integration for regulatory checks. Consensus now skips regulatory validation when no node is configured.
+- Stage 73: In progress – governance token validated; bill registry, currency token, futures contract and index token hardened with concurrency tests, and regulatory audit opcode surfaced across CLI and web. Remaining SYN3800+ modules pending.
+- Stage 74: In progress – system health logging clamped; tangible and agricultural asset registries made concurrency safe; access controller audit snapshots added. Transaction and SYN5000+ modules outstanding.
+- Stage 75: In progress – validator node supports concurrent joins; VM, wallet and cross-chain layers pending.
 - Stage 136: Pending – security assessment and benchmark scaffolds reserved for final stage.
 
 **Stage 2**
@@ -1560,17 +1562,28 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 **Stage 73**
 - [x] core/syn300_token.go | governance token with validation and delegation error checks
 - [x] core/syn300_token_test.go | lifecycle and validation test coverage
-- [x] gas_table.go | regulatory node pricing annotated
+- [x] gas_table.go | regulatory node pricing annotated with audit operation
 - [x] core/consensus.go | bypasses regulatory checks when no node present
 - [x] core/consensus_test.go | verifies behaviour with and without regulatory node
 - [x] core/regulatory_node.go | approval succeeds when manager absent
 - [x] core/regulatory_node_test.go | manager-less approval test
-- [ ] core/syn3200.go
-- [ ] core/syn3200_test.go
-- [ ] core/syn3500_token.go
-- [ ] core/syn3500_token_test.go
-- [ ] core/syn3600.go
-- [ ] core/syn3600_test.go
+- [x] cli/regulatory_node.go | audit command exposes flagged logs with gas pricing
+- [x] cli/regulatory_node_test.go | audit command coverage
+- [x] core/regulatory_node.go | audit method returns logs without mutation
+- [x] core/regulatory_node_test.go | audit reporting test
+- [x] docs/reference/gas_table_list.md | RegNodeAudit cost documented
+- [x] docs/reference/opcodes_list.md | RegNodeAudit opcode recorded
+- [x] gas_table_test.go | validates RegNodeAudit pricing
+- [x] docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md | audit opcode and gas usage noted
+- [x] docs/guides/cli_quickstart.md | audit CLI documented
+- [x] README.md | audit feature referenced
+- [x] web/pages/regnode.js | audit UI integrated
+ - [x] core/syn3200.go
+ - [x] core/syn3200_test.go
+ - [x] core/syn3500_token.go
+ - [x] core/syn3500_token_test.go
+ - [x] core/syn3600.go
+ - [x] core/syn3600_test.go
 - [ ] core/syn3700_token.go
 - [ ] core/syn3700_token_test.go
 - [ ] core/syn3800.go
@@ -1593,20 +1606,20 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 - [ ] core/syn700_test.go
 - [ ] core/syn800_token.go
 - [ ] core/syn800_token_test.go
-- [ ] core/system_health_logging.go
-- [ ] core/system_health_logging_test.go
-- [ ] core/token_syn130.go
-- [ ] core/token_syn130_test.go
-- [ ] core/token_syn4900.go
-- [ ] core/token_syn4900_test.go
+ - [x] core/system_health_logging.go
+ - [x] core/system_health_logging_test.go
+ - [x] core/token_syn130.go
+ - [x] core/token_syn130_test.go
+ - [x] core/token_syn4900.go
+ - [x] core/token_syn4900_test.go
 - [ ] core/transaction.go
 - [ ] core/transaction_control.go
 - [ ] core/transaction_control_test.go
 - [ ] core/transaction_test.go
 
 **Stage 75**
-- [ ] core/validator_node.go
-- [ ] core/validator_node_test.go
+ - [x] core/validator_node.go
+ - [x] core/validator_node_test.go
 - [ ] core/virtual_machine.go
 - [ ] core/virtual_machine_test.go
 - [ ] core/vm_sandbox_management.go
@@ -3816,7 +3829,7 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 | 60 | contracts_opcodes.go | [x] | opcode constants aligned with VM |
 | 60 | contracts_opcodes_test.go | [x] | opcode validation tests |
 | 60 | contracts_test.go | [x] | deployment and invocation tests |
-| 60 | core/access_control.go | [x] | role-based access utilities |
+| 60 | core/access_control.go | [x] | role-based access utilities with audit snapshots and concurrency tests |
 | 60 | core/access_control_test.go | [x] | access control unit tests |
 | 60 | core/address.go | [x] | address helpers and parsing |
 | 60 | core/address_test.go | [x] | address helper tests |
@@ -4056,14 +4069,14 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 | 72 | core/syn2900_test.go | [ ] | pending enterprise upgrade |
 | 73 | core/syn300_token.go | [x] | added error checks, gas/opcode docs, CLI alignment |
 | 73 | core/syn300_token_test.go | [x] | proposal lifecycle and validation tests |
-| 73 | core/syn3200.go | [ ] |
-| 73 | core/syn3200_test.go | [ ] |
-| 73 | core/syn3500_token.go | [ ] |
-| 73 | core/syn3500_token_test.go | [ ] |
-| 73 | core/syn3600.go | [ ] |
-| 73 | core/syn3600_test.go | [ ] |
-| 73 | core/syn3700_token.go | [ ] |
-| 73 | core/syn3700_token_test.go | [ ] |
+| 73 | core/syn3200.go | [x] | mutex-protected bill registry |
+| 73 | core/syn3200_test.go | [x] | lifecycle & concurrency tests |
+| 73 | core/syn3500_token.go | [x] | mutex-protected balances |
+| 73 | core/syn3500_token_test.go | [x] | mint/redeem and rate tests |
+| 73 | core/syn3600.go | [x] | idempotent settle with locking |
+| 73 | core/syn3600_test.go | [x] | concurrent settlement guard |
+| 73 | core/syn3700_token.go | [x] | weighted index token with mutexed components |
+| 73 | core/syn3700_token_test.go | [x] | concurrent component add/remove tests |
 | 73 | core/syn3800.go | [ ] |
 | 73 | core/syn3800_test.go | [ ] |
 | 73 | core/syn3900.go | [ ] |
@@ -4082,18 +4095,18 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 | 74 | core/syn700_test.go | [ ] |
 | 74 | core/syn800_token.go | [ ] |
 | 74 | core/syn800_token_test.go | [ ] |
-| 74 | core/system_health_logging.go | [ ] |
-| 74 | core/system_health_logging_test.go | [ ] |
-| 74 | core/token_syn130.go | [ ] |
-| 74 | core/token_syn130_test.go | [ ] |
-| 74 | core/token_syn4900.go | [ ] |
-| 74 | core/token_syn4900_test.go | [ ] |
+| 74 | core/system_health_logging.go | [x] | clamped negative peer counts |
+| 74 | core/system_health_logging_test.go | [x] | snapshot verifies clamping |
+| 74 | core/token_syn130.go | [x] | RWMutex asset registry |
+| 74 | core/token_syn130_test.go | [x] | concurrent valuation and lease |
+| 74 | core/token_syn4900.go | [x] | locked agricultural assets |
+| 74 | core/token_syn4900_test.go | [x] | concurrent transfer/status tests |
 | 74 | core/transaction.go | [ ] |
 | 74 | core/transaction_control.go | [ ] |
 | 74 | core/transaction_control_test.go | [ ] |
 | 74 | core/transaction_test.go | [ ] |
-| 75 | core/validator_node.go | [ ] |
-| 75 | core/validator_node_test.go | [ ] |
+| 75 | core/validator_node.go | [x] | quorum manager wiring |
+| 75 | core/validator_node_test.go | [x] | concurrent join quorum test |
 | 75 | core/virtual_machine.go | [ ] |
 | 75 | core/virtual_machine_test.go | [ ] |
 | 75 | core/vm_sandbox_management.go | [ ] |

--- a/docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md
+++ b/docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md
@@ -14,6 +14,8 @@ Stage 28 validates that storage marketplace and analytics dashboard operations l
 Stage 43 adds pricing for DAO membership operations so governance tooling can anticipate the cost of adding or removing members via the `dao-members` CLI.
 Stage 65 introduces gas costs and opcodes for DAO token ledger operations so member-gated minting, burning and transfers remain predictable, and records authority term renewals.
 Stage 67 registers Kademlia distance and lookup operations so DHT queries surface deterministic fees across the CLI and VM.
+Stage 73 introduces an audit opcode for regulatory nodes, enabling deterministic gas charges when verifying flagged addresses via CLI or web consoles.
+Stage 74 extends auditing to access control with an `Access_Audit` opcode that snapshots role assignments for administrative tooling.
 
 ## Opcode Structure
 

--- a/docs/guides/cli_quickstart.md
+++ b/docs/guides/cli_quickstart.md
@@ -38,6 +38,7 @@ The root command provides options that apply to every sub-command:
 - `synnergy regulator add <id> <jurisdiction> <description> <max>` – register a transaction rule
 - `synnergy regnode approve <from> <amount> --wallet <file> --password <pw>` – sign with a wallet and validate a transaction against regulations
 - `synnergy regnode logs <addr>` – view recorded flags for an address
+- `synnergy regnode audit <addr>` – check whether an address has been flagged and view its logs
 - `synnergy regnode flag <addr> <reason>` – manually flag an address for review (reason required)
 
 ## Replication

--- a/docs/reference/functions_list.md
+++ b/docs/reference/functions_list.md
@@ -333,7 +333,12 @@ This catalogue lists exported functions across the repository for quick navigati
 | `cli/transaction.go` | `23` | `func init() {` |
 | `core/syn3600.go` | `15` | `func NewFuturesContract(underlying string, quantity, price uint64, expiration time.Time) *FuturesContract {` |
 | `core/syn3600.go` | `20` | `func (f *FuturesContract) IsExpired(now time.Time) bool {` |
-| `core/syn3600.go` | `25` | `func (f *FuturesContract) Settle(marketPrice uint64) int64 {` |
+| `core/syn3600.go` | `37` | `func (f *FuturesContract) Settle(marketPrice uint64) (int64, error) {` |
+| `core/syn3700_token.go` | `23` | `func NewSYN3700Token(name, symbol string) *SYN3700Token {` |
+| `core/syn3700_token.go` | `32` | `func (t *SYN3700Token) AddComponent(token string, weight float64) {` |
+| `core/syn3700_token.go` | `39` | `func (t *SYN3700Token) RemoveComponent(token string) error {` |
+| `core/syn3700_token.go` | `50` | `func (t *SYN3700Token) ListComponents() []Component {` |
+| `core/syn3700_token.go` | `61` | `func (t *SYN3700Token) Value(prices map[string]float64) float64 {` |
 | `ai_model_management.go` | `27` | `func NewModelMarketplace() *ModelMarketplace {` |
 | `ai_model_management.go` | `32` | `func (m *ModelMarketplace) AddListing(hash, cid, seller string, price uint64) string {` |
 | `ai_model_management.go` | `49` | `func (m *ModelMarketplace) Get(id string) (ModelListing, bool) {` |
@@ -854,6 +859,7 @@ This catalogue lists exported functions across the repository for quick navigati
 | `core/access_control.go` | `27` | `func (a *AccessController) Revoke(role, addr string) {` |
 | `core/access_control.go` | `39` | `func (a *AccessController) HasRole(role, addr string) bool {` |
 | `core/access_control.go` | `51` | `func (a *AccessController) List(addr string) []string {` |
+| `core/access_control.go` | `68` | `func (a *AccessController) Audit() map[string][]string {` |
 | `core/dao_token_test.go` | `5` | `func TestDAOTokenLedger(t *testing.T) {` |
 | `core/dao_quadratic_voting_test.go` | `5` | `func TestQuadraticWeight(t *testing.T) {` |
 | `core/dao_quadratic_voting_test.go` | `11` | `func TestCastQuadraticVoteZeroTokens(t *testing.T) {` |

--- a/docs/reference/gas_table_list.md
+++ b/docs/reference/gas_table_list.md
@@ -2,6 +2,7 @@
 | Function | Gas Cost |
 |---|---|
 | `Accrue` | `1` |
+| `Access_Audit` | `2` |
 | `Acquire` | `1` |
 | `Active` | `1` |
 | `AddBlock` | `1` |
@@ -851,6 +852,7 @@
 | `RegulatorRemove` | `1` |
 | `RegulatorList` | `1` |
 | `RegulatorEvaluate` | `2` |
+| `RegNodeAudit` | `3` |
 | `RegNodeApprove` | `2` |
 | `RegNodeFlag` | `1` |
 | `RegNodeLogs` | `1` |

--- a/docs/reference/opcodes_list.md
+++ b/docs/reference/opcodes_list.md
@@ -9,6 +9,7 @@ and warfare nodes as well as UI integrations.
 | Function | Opcode |
 |---|---|
 | `Accrue` | `0x100001` |
+| `Access_Audit` | `0x0002A5` |
 | `Acquire` | `0x100002` |
 | `Active` | `0x100003` |
 | `Add` | `0x100004` |
@@ -709,3 +710,4 @@ and warfare nodes as well as UI integrations.
 | `RegulatorRemove` | `0x0002A1` |
 | `RegulatorList` | `0x0002A2` |
 | `RegulatorEvaluate` | `0x0002A3` |
+| `RegNodeAudit` | `0x0002A4` |

--- a/gas_table.go
+++ b/gas_table.go
@@ -42,7 +42,7 @@ import (
 // discovery workflows used by the CLI and web interfaces. Stage 65 records DAO
 // role update operations so governance tooling prices admin-managed role
 // changes and authority term renewals. Stage 73 adds regulatory node approval,
-// flagging and log query operations so compliance tooling surfaces predictable
+// flagging, log query and audit operations so compliance tooling surfaces predictable
 // gas costs.
 type GasTable map[string]uint64
 

--- a/gas_table_test.go
+++ b/gas_table_test.go
@@ -49,9 +49,21 @@ func TestGasTableIncludesNewOpcodes(t *testing.T) {
 	if !HasOpcode("RegNodeLogs") {
 		t.Fatalf("missing RegNodeLogs opcode")
 	}
-	if GasCost("RegNodeLogs") != 1 {
-		t.Fatalf("unexpected cost for RegNodeLogs")
-	}
+        if GasCost("RegNodeLogs") != 1 {
+                t.Fatalf("unexpected cost for RegNodeLogs")
+        }
+        if !HasOpcode("RegNodeAudit") {
+                t.Fatalf("missing RegNodeAudit opcode")
+        }
+        if GasCost("RegNodeAudit") != 3 {
+                t.Fatalf("unexpected cost for RegNodeAudit")
+        }
+        if !HasOpcode("Access_Audit") {
+                t.Fatalf("missing Access_Audit opcode")
+        }
+        if GasCost("Access_Audit") != 2 {
+                t.Fatalf("unexpected cost for Access_Audit")
+        }
 }
 
 func TestRegisterGasCostValidation(t *testing.T) {

--- a/web/pages/regnode.js
+++ b/web/pages/regnode.js
@@ -6,6 +6,7 @@ export default function RegNode() {
   const [flagAddr, setFlagAddr] = useState("");
   const [flagReason, setFlagReason] = useState("");
   const [logAddr, setLogAddr] = useState("");
+  const [auditAddr, setAuditAddr] = useState("");
   const [output, setOutput] = useState("");
 
   const run = async (args) => {
@@ -53,8 +54,8 @@ export default function RegNode() {
           Flag
         </button>
       </section>
-      <section style={{ marginBottom: 20 }}>
-        <h2>View Logs</h2>
+        <section style={{ marginBottom: 20 }}>
+          <h2>View Logs</h2>
         <input
           placeholder="address"
           value={logAddr}
@@ -66,7 +67,21 @@ export default function RegNode() {
         >
           Fetch Logs
         </button>
-      </section>
+        </section>
+        <section style={{ marginBottom: 20 }}>
+          <h2>Audit Address</h2>
+          <input
+            placeholder="address"
+            value={auditAddr}
+            onChange={(e) => setAuditAddr(e.target.value)}
+          />
+          <button
+            onClick={() => run(["audit", auditAddr])}
+            style={{ marginLeft: 10 }}
+          >
+            Audit
+          </button>
+        </section>
       <pre>{output}</pre>
     </main>
   );


### PR DESCRIPTION
## Summary
- introduce SYN3700 weighted index token with thread-safe component management
- handle errors in futures contract settlement CLI
- expose access controller audit snapshot and document Access_Audit opcode and gas pricing

## Testing
- `go test -run 'AccessController|GasTableIncludes' -count=1`
- `go test ./core -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68c37949ccd083208aedee4d29a30730