### PR TITLE
stage86: harden configuration, governance logging, and docs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1894,25 +1894,25 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 - [ ] internal/auth/rbac_test.go
 
 **Stage 86**
-- [ ] internal/config/config.go
-- [ ] internal/config/config_test.go
-- [ ] internal/config/default.go
-- [ ] internal/config/default_default_test.go
-- [ ] internal/config/default_dev.go
-- [ ] internal/config/default_dev_test.go
-- [ ] internal/config/default_prod.go
-- [ ] internal/config/default_prod_test.go
-- [ ] internal/config/default_test.go
-- [ ] internal/core/README.md
-- [ ] internal/crosschain/README.md
-- [ ] internal/errors/errors.go
-- [ ] internal/errors/errors_test.go
-- [ ] internal/governance/audit_log.go
-- [ ] internal/governance/audit_log_test.go
-- [ ] internal/governance/replay_protection.go
-- [ ] internal/governance/replay_protection_test.go
-- [ ] internal/log/log.go
-- [ ] internal/log/log_test.go
+- [x] internal/config/config.go – Enterprise configuration surface with defaults for CLI, VM, consensus and web orchestration.
+- [x] internal/config/config_test.go – Comprehensive coverage for env overrides, profiles, fingerprinting and validation.
+- [x] internal/config/default.go – Documented fallback aligned with staged enterprise defaults.
+- [x] internal/config/default_default_test.go – Confirms default profile resolves to developer workflow.
+- [x] internal/config/default_dev.go – Build-tagged development profile kept in sync with enterprise defaults.
+- [x] internal/config/default_dev_test.go – Verifies dev profile discovery via stage-aware loader.
+- [x] internal/config/default_prod.go – Production profile pointer retained for hardened deployments.
+- [x] internal/config/default_prod_test.go – Ensures prod config loads and enforces production environment.
+- [x] internal/config/default_test.go – Build tag wiring maintained for staging/test runs.
+- [x] internal/core/README.md – Expanded architecture guidance with CLI/VM/consensus integration notes.
+- [x] internal/crosschain/README.md – Documented interoperability workflow and gas harmonisation strategy.
+- [x] internal/errors/errors.go – Structured error stack with severity, correlation IDs and retry semantics.
+- [x] internal/errors/errors_test.go – Validates metadata rendering, status mapping and parsing helpers.
+- [x] internal/governance/audit_log.go – Fault-tolerant audit ledger with HMAC signing, retention and observers.
+- [x] internal/governance/audit_log_test.go – Tests hash chaining, retention enforcement and subscriber hooks.
+- [x] internal/governance/replay_protection.go – Sliding window replay guard with eviction policies and callbacks.
+- [x] internal/governance/replay_protection_test.go – Window expiry, eviction and duplicate signalling covered.
+- [x] internal/log/log.go – Context-aware structured logging with OTEL integration and multiple outputs.
+- [x] internal/log/log_test.go – JSON/text rendering, level filtering and singleton safety validated.
 
 **Stage 87**
 - [ ] internal/monitoring/alerting.go

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,69 +1,550 @@
 // Package config provides centralized configuration management.
+//
+// The module exposes a strongly typed configuration tree that unifies runtime
+// settings for the CLI, core consensus, networking stack, virtual machine and
+// web control-plane services. Configuration values can be sourced from YAML or
+// JSON files, overridden via environment variables and validated against
+// enterprise grade constraints that ensure gas metering, governance policies and
+// security boundaries remain aligned across subsystems.
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-playground/validator/v10"
+	mapstructure "github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 )
 
-// Config represents the application configuration. Fields can be populated from
-// configuration files (YAML or JSON) and environment variables. Validation is
-// performed using struct tags.
+// Config represents the full runtime configuration. It captures operational
+// parameters for the CLI, consensus core, node services, gas metering rules and
+// telemetry surfaces that the function web consumes for orchestration.
 type Config struct {
-	Environment string         `mapstructure:"environment" validate:"required,oneof=development staging production"`
-	LogLevel    string         `mapstructure:"log_level" validate:"required,oneof=debug info warn error"`
-	Server      ServerConfig   `mapstructure:"server" validate:"required"`
-	Database    DatabaseConfig `mapstructure:"database" validate:"required"`
+	Version     string          `mapstructure:"version" validate:"omitempty"`
+	Environment string          `mapstructure:"environment" validate:"required,oneof=development staging production"`
+	Log         LogConfig       `mapstructure:"log" validate:"required"`
+	Server      ServerConfig    `mapstructure:"server" validate:"required"`
+	Database    DatabaseConfig  `mapstructure:"database" validate:"required"`
+	Consensus   ConsensusConfig `mapstructure:"consensus" validate:"required"`
+	VM          VMConfig        `mapstructure:"vm" validate:"required"`
+	Wallet      WalletConfig    `mapstructure:"wallet" validate:"required"`
+	CLI         CLIConfig       `mapstructure:"cli" validate:"required"`
+	Telemetry   TelemetryConfig `mapstructure:"telemetry" validate:"required"`
+	Security    SecurityConfig  `mapstructure:"security" validate:"required"`
+	Network     NetworkConfig   `mapstructure:"network" validate:"required"`
 }
 
-// ServerConfig holds configuration for the API server.
+// LogConfig describes structured logging behaviour used by the CLI, node
+// services and the governance dashboards.
+type LogConfig struct {
+	Level         string         `mapstructure:"level" validate:"required,oneof=debug info warn error"`
+	Format        string         `mapstructure:"format" validate:"required,oneof=json text"`
+	IncludeCaller bool           `mapstructure:"include_caller"`
+	Outputs       []string       `mapstructure:"outputs" validate:"min=1,dive,oneof=stdout stderr file eventstream"`
+	Sampling      LogSampling    `mapstructure:"sampling"`
+	StaticFields  map[string]any `mapstructure:"static_fields" validate:"omitempty"`
+}
+
+// LogSampling controls burst protection for very verbose workloads.
+type LogSampling struct {
+	Enabled    bool `mapstructure:"enabled"`
+	Initial    int  `mapstructure:"initial" validate:"gte=0"`
+	Thereafter int  `mapstructure:"thereafter" validate:"gte=0"`
+}
+
+// ServerConfig contains HTTP and gRPC server settings exposed through the CLI
+// and JavaScript control plane.
 type ServerConfig struct {
-	Host string `mapstructure:"host" validate:"required"`
-	Port int    `mapstructure:"port" validate:"required,min=1,max=65535"`
+	Host           string        `mapstructure:"host" validate:"required,hostname|ip"`
+	Port           int           `mapstructure:"port" validate:"required,min=1,max=65535"`
+	GRPCHost       string        `mapstructure:"grpc_host" validate:"required,hostname|ip"`
+	GRPCPort       int           `mapstructure:"grpc_port" validate:"required,min=1,max=65535"`
+	PublicEndpoint string        `mapstructure:"public_endpoint" validate:"required,uri"`
+	Timeout        time.Duration `mapstructure:"timeout" validate:"required,gt=0"`
+	ReadTimeout    time.Duration `mapstructure:"read_timeout" validate:"required,gt=0"`
+	WriteTimeout   time.Duration `mapstructure:"write_timeout" validate:"required,gt=0"`
+	RateLimit      RateLimit     `mapstructure:"rate_limit" validate:"required"`
+	TLS            TLSConfig     `mapstructure:"tls"`
+	HealthCheck    bool          `mapstructure:"health_check"`
 }
 
-// DatabaseConfig holds configuration for database connectivity.
+// RateLimit defines throttling behaviour for public RPC and CLI submissions.
+type RateLimit struct {
+	RequestsPerSecond float64 `mapstructure:"requests_per_second" validate:"gte=0"`
+	Burst             int     `mapstructure:"burst" validate:"gte=0"`
+}
+
+// TLSConfig encapsulates TLS expectations for all public facing surfaces.
+type TLSConfig struct {
+	Enabled         bool   `mapstructure:"enabled"`
+	CertFile        string `mapstructure:"cert_file" validate:"omitempty"`
+	KeyFile         string `mapstructure:"key_file" validate:"omitempty"`
+	ClientCAFile    string `mapstructure:"client_ca_file" validate:"omitempty"`
+	RequireClientCA bool   `mapstructure:"require_client_ca"`
+	MinVersion      string `mapstructure:"min_version" validate:"omitempty,oneof=1.2 1.3"`
+}
+
+// DatabaseConfig configures relational persistence.
 type DatabaseConfig struct {
-	URL string `mapstructure:"url" validate:"required,url"`
+	URL             string        `mapstructure:"url" validate:"required,url"`
+	ReadReplicaURLs []string      `mapstructure:"read_replicas" validate:"omitempty,dive,url"`
+	MaxConnections  int           `mapstructure:"max_connections" validate:"gt=0"`
+	ConnMaxIdleTime time.Duration `mapstructure:"conn_max_idle_time" validate:"gte=0"`
+	ConnMaxLifetime time.Duration `mapstructure:"conn_max_lifetime" validate:"gte=0"`
+	MigrationsPath  string        `mapstructure:"migrations_path" validate:"required"`
 }
 
-var validate = validator.New()
+// ConsensusConfig controls validator and committee behaviour to keep gas tables
+// aligned with the VM and CLI validators.
+type ConsensusConfig struct {
+	Engine            string        `mapstructure:"engine" validate:"required,oneof=synnergy-pos synnergy-dpos synnergy-ibft"`
+	CommitteeSize     int           `mapstructure:"committee_size" validate:"required,gt=0"`
+	BlockTime         time.Duration `mapstructure:"block_time" validate:"required,gt=0"`
+	FinalityThreshold float64       `mapstructure:"finality_threshold" validate:"gt=0,lte=1"`
+	MessageTTL        time.Duration `mapstructure:"message_ttl" validate:"required,gt=0"`
+	MaxDrift          time.Duration `mapstructure:"max_drift" validate:"required,gt=0"`
+	SafetyBuffer      int           `mapstructure:"safety_buffer" validate:"gte=0"`
+	GasFloor          uint64        `mapstructure:"gas_floor" validate:"gt=0"`
+	MaxBlockGas       uint64        `mapstructure:"max_block_gas" validate:"gt=0"`
+	AllowManualStop   bool          `mapstructure:"allow_manual_stop"`
+}
 
-// Load reads the configuration from the provided file path. The file may be
-// YAML or JSON. Environment variables with the prefix "SYN" override file
-// values. Nested keys are represented with underscores. For example,
-// "SYN_SERVER_PORT" overrides server.port.
-func Load(path string) (*Config, error) {
+// VMConfig captures execution policies enforced by the Synnergy VM.
+type VMConfig struct {
+	ExecutionTimeout  time.Duration `mapstructure:"execution_timeout" validate:"required,gt=0"`
+	MaxStackDepth     int           `mapstructure:"max_stack_depth" validate:"gt=0"`
+	GasLimit          uint64        `mapstructure:"gas_limit" validate:"gt=0"`
+	SchedulePath      string        `mapstructure:"schedule_path" validate:"required"`
+	Deterministic     bool          `mapstructure:"deterministic"`
+	CacheSize         int           `mapstructure:"cache_size" validate:"gte=0"`
+	MeteringPrecision uint64        `mapstructure:"metering_precision" validate:"gt=0"`
+	OpcodeSet         string        `mapstructure:"opcode_set" validate:"required"`
+	Precompiles       []string      `mapstructure:"precompiles_enabled" validate:"min=1,dive,required"`
+}
+
+// WalletConfig controls multisig wallets and CLI key material.
+type WalletConfig struct {
+	KeystorePath      string `mapstructure:"keystore_path" validate:"required"`
+	DefaultAccount    string `mapstructure:"default_account" validate:"required"`
+	HSMEnabled        bool   `mapstructure:"hsm_enabled"`
+	HSMSlot           string `mapstructure:"hsm_slot" validate:"omitempty"`
+	SigningAlgorithm  string `mapstructure:"signing_algorithm" validate:"required,oneof=ed25519 secp256k1 sr25519"`
+	ApprovalThreshold int    `mapstructure:"approval_threshold" validate:"gte=1"`
+	MultiSigEnabled   bool   `mapstructure:"multi_sig_enabled"`
+}
+
+// CLIConfig configures the command line workflow for validators and operators.
+type CLIConfig struct {
+	DefaultNetwork     string        `mapstructure:"default_network" validate:"required"`
+	GasPrice           uint64        `mapstructure:"gas_price" validate:"gt=0"`
+	OutputFormat       string        `mapstructure:"output_format" validate:"required,oneof=json text table"`
+	AutoComplete       bool          `mapstructure:"auto_complete"`
+	DataDir            string        `mapstructure:"data_dir" validate:"required"`
+	MaxCommandDuration time.Duration `mapstructure:"max_command_duration" validate:"required,gt=0"`
+	BroadcastEndpoint  string        `mapstructure:"broadcast_endpoint" validate:"required,url"`
+}
+
+// TelemetryConfig wires metrics, tracing and health probes for the web UX.
+type TelemetryConfig struct {
+	Metrics MetricsConfig `mapstructure:"metrics" validate:"required"`
+	Tracing TracingConfig `mapstructure:"tracing" validate:"required"`
+	Health  HealthConfig  `mapstructure:"health" validate:"required"`
+}
+
+// MetricsConfig exposes Prometheus friendly settings.
+type MetricsConfig struct {
+	Enabled            bool          `mapstructure:"enabled"`
+	Endpoint           string        `mapstructure:"endpoint" validate:"required,hostname_port"`
+	CollectionInterval time.Duration `mapstructure:"collection_interval" validate:"required,gt=0"`
+	PushGatewayURL     string        `mapstructure:"push_gateway_url" validate:"omitempty,url"`
+}
+
+// TracingConfig exposes OTLP/Zipkin/Jaeger controls used by the function web.
+type TracingConfig struct {
+	Enabled     bool    `mapstructure:"enabled"`
+	Provider    string  `mapstructure:"provider" validate:"required,oneof=otlp jaeger zipkin"`
+	Endpoint    string  `mapstructure:"endpoint" validate:"required,hostname_port"`
+	SampleRatio float64 `mapstructure:"sample_ratio" validate:"gte=0,lte=1"`
+}
+
+// HealthConfig powers liveness/readiness endpoints for automation.
+type HealthConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+	Port    int  `mapstructure:"port" validate:"min=0,max=65535"`
+}
+
+// SecurityConfig ensures policy enforcement across wallet, consensus and web.
+type SecurityConfig struct {
+	EnableAudit         bool          `mapstructure:"enable_audit"`
+	AuditTrailRetention time.Duration `mapstructure:"audit_trail_retention" validate:"required,gt=0"`
+	PermitCIDRs         []string      `mapstructure:"permit_cidrs" validate:"min=1,dive,cidr"`
+	JWTSigningAlgorithm string        `mapstructure:"jwt_signing_algorithm" validate:"required,oneof=ed25519 es256 es256k rs256"`
+	JWTIssuer           string        `mapstructure:"jwt_issuer" validate:"required"`
+	KeyManagementURI    string        `mapstructure:"key_management_uri" validate:"required,uri"`
+	AllowedOrigins      []string      `mapstructure:"allowed_origins" validate:"min=1,dive,uri"`
+	MinPasswordLength   int           `mapstructure:"min_password_length" validate:"gte=12"`
+	SignatureScheme     string        `mapstructure:"signature_scheme" validate:"required,oneof=ed25519 bls12-381 secp256k1"`
+	ConfidentialTx      bool          `mapstructure:"confidential_transactions"`
+}
+
+// NetworkConfig tunes peer to peer and RPC transport parameters.
+type NetworkConfig struct {
+	P2PAddress        string        `mapstructure:"p2p_address" validate:"required,hostname_port"`
+	RPCAddress        string        `mapstructure:"rpc_address" validate:"required,hostname_port"`
+	MaxPeers          int           `mapstructure:"max_peers" validate:"gt=0"`
+	SeedNodes         []string      `mapstructure:"seed_nodes" validate:"min=1,dive,hostname_port"`
+	AuthorityNodes    []string      `mapstructure:"authority_nodes" validate:"min=1,dive,hostname_port"`
+	AllowPrivatePeers bool          `mapstructure:"allow_private_peers"`
+	SyncRetryInterval time.Duration `mapstructure:"sync_retry_interval" validate:"required,gt=0"`
+}
+
+var (
+	validatorOnce sync.Once
+	validate      *validator.Validate
+)
+
+// Option customises the behaviour of the Load helper.
+type Option func(*loadOptions)
+
+type loadOptions struct {
+	envPrefix    string
+	defaultPaths []string
+}
+
+// WithEnvPrefix customises the environment variable prefix used by Load.
+func WithEnvPrefix(prefix string) Option {
+	return func(lo *loadOptions) {
+		lo.envPrefix = prefix
+	}
+}
+
+// WithDefaultPaths overrides the search order for configuration files when a
+// path is not explicitly provided.
+func WithDefaultPaths(paths ...string) Option {
+	return func(lo *loadOptions) {
+		lo.defaultPaths = append([]string{}, paths...)
+	}
+}
+
+// Load reads configuration from disk, environment variables or defaults. The
+// function guarantees deterministic validation so that CLI and web orchestrators
+// observe an identical runtime view.
+func Load(path string, opts ...Option) (*Config, error) {
+	options := loadOptions{
+		envPrefix:    "SYN",
+		defaultPaths: []string{DefaultConfigPath},
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	v := viper.New()
+	applyDefaults(v)
+	registerAliases(v)
 
 	if path != "" {
 		v.SetConfigFile(path)
-		if err := v.ReadInConfig(); err != nil {
-			return nil, fmt.Errorf("read config: %w", err)
+		if err := readConfigFile(v); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := loadFromDefaultPaths(v, options.defaultPaths); err != nil {
+			return nil, err
 		}
 	}
 
-	v.SetEnvPrefix("syn")
+	v.SetEnvPrefix(strings.ToLower(options.envPrefix))
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 
-	// Set some sensible defaults.
-	v.SetDefault("environment", "development")
-	v.SetDefault("log_level", "info")
-	v.SetDefault("server.host", "0.0.0.0")
-	v.SetDefault("server.port", 8080)
-
 	var cfg Config
-	if err := v.Unmarshal(&cfg); err != nil {
+	if err := v.Unmarshal(&cfg, viper.DecodeHook(mapstructure.StringToTimeDurationHookFunc())); err != nil {
 		return nil, fmt.Errorf("unmarshal config: %w", err)
 	}
 
-	if err := validate.Struct(cfg); err != nil {
+	if err := cfg.applyBackwardsCompatibility(v); err != nil {
+		return nil, err
+	}
+
+	if err := ensureValidator().Struct(cfg); err != nil {
 		return nil, fmt.Errorf("validate config: %w", err)
 	}
 
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &cfg, nil
+}
+
+// Validate performs cross-field validations that cannot be expressed with
+// struct tags alone.
+func (c *Config) Validate() error {
+	if c.Server.TLS.Enabled {
+		if c.Server.TLS.CertFile == "" || c.Server.TLS.KeyFile == "" {
+			return errors.New("server.tls requires cert_file and key_file when enabled")
+		}
+	}
+
+	if c.Consensus.MaxBlockGas < c.Consensus.GasFloor {
+		return fmt.Errorf("consensus.max_block_gas must be >= consensus.gas_floor")
+	}
+
+	if c.VM.GasLimit < c.Consensus.GasFloor {
+		return fmt.Errorf("vm.gas_limit must be >= consensus.gas_floor")
+	}
+
+	if err := validateCIDRs(c.Security.PermitCIDRs); err != nil {
+		return fmt.Errorf("security.permit_cidrs: %w", err)
+	}
+
+	return nil
+}
+
+// Clone returns a deep copy of the configuration which can safely be mutated by
+// callers without affecting the shared runtime configuration.
+func (c *Config) Clone() Config {
+	clone := *c
+	clone.Log.Outputs = append([]string(nil), c.Log.Outputs...)
+	clone.Log.StaticFields = copyMap(c.Log.StaticFields)
+	clone.Database.ReadReplicaURLs = append([]string(nil), c.Database.ReadReplicaURLs...)
+	clone.VM.Precompiles = append([]string(nil), c.VM.Precompiles...)
+	clone.Security.PermitCIDRs = append([]string(nil), c.Security.PermitCIDRs...)
+	clone.Security.AllowedOrigins = append([]string(nil), c.Security.AllowedOrigins...)
+	clone.Network.SeedNodes = append([]string(nil), c.Network.SeedNodes...)
+	clone.Network.AuthorityNodes = append([]string(nil), c.Network.AuthorityNodes...)
+	return clone
+}
+
+// EffectiveHTTPAddress returns host:port string for HTTP server bindings.
+func (c *Config) EffectiveHTTPAddress() string {
+	return net.JoinHostPort(c.Server.Host, strconv.Itoa(c.Server.Port))
+}
+
+// EffectiveGRPCAddress returns host:port for gRPC services.
+func (c *Config) EffectiveGRPCAddress() string {
+	return net.JoinHostPort(c.Server.GRPCHost, strconv.Itoa(c.Server.GRPCPort))
+}
+
+func (c *Config) applyBackwardsCompatibility(v *viper.Viper) error {
+	if c.Log.Level == "" {
+		if lvl := v.GetString("log_level"); lvl != "" {
+			c.Log.Level = lvl
+		} else {
+			c.Log.Level = "info"
+		}
+	}
+	if c.Log.Format == "" {
+		if format := v.GetString("log_format"); format != "" {
+			c.Log.Format = format
+		} else {
+			c.Log.Format = "json"
+		}
+	}
+	if len(c.Log.Outputs) == 0 {
+		c.Log.Outputs = []string{"stdout"}
+	}
+	return nil
+}
+
+func copyMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func ensureValidator() *validator.Validate {
+	validatorOnce.Do(func() {
+		validate = validator.New(validator.WithRequiredStructEnabled())
+		_ = validate.RegisterValidation("cidr", func(fl validator.FieldLevel) bool {
+			_, _, err := net.ParseCIDR(fl.Field().String())
+			return err == nil
+		})
+	})
+	return validate
+}
+
+func readConfigFile(v *viper.Viper) error {
+	if err := v.ReadInConfig(); err != nil {
+		var nf viper.ConfigFileNotFoundError
+		if errors.As(err, &nf) {
+			return fmt.Errorf("config file %s not found", v.ConfigFileUsed())
+		}
+		return fmt.Errorf("read config: %w", err)
+	}
+	return nil
+}
+
+func loadFromDefaultPaths(v *viper.Viper, paths []string) error {
+	var lastErr error
+	for _, candidate := range paths {
+		if candidate == "" {
+			continue
+		}
+		abs := candidate
+		if !filepath.IsAbs(candidate) {
+			abs = filepath.Clean(candidate)
+		}
+		if _, err := os.Stat(abs); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				lastErr = err
+				continue
+			}
+			return fmt.Errorf("stat config %s: %w", abs, err)
+		}
+		v.SetConfigFile(abs)
+		if err := v.ReadInConfig(); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
+	}
+
+	if lastErr != nil {
+		// No config file was found, but defaults still apply.
+		return nil
+	}
+	return nil
+}
+
+func registerAliases(v *viper.Viper) {
+	v.RegisterAlias("log.level", "log_level")
+	v.RegisterAlias("log.format", "log_format")
+}
+
+func applyDefaults(v *viper.Viper) {
+	v.SetDefault("version", "latest")
+	v.SetDefault("environment", "development")
+
+	v.SetDefault("log.level", "info")
+	v.SetDefault("log.format", "json")
+	v.SetDefault("log.include_caller", true)
+	v.SetDefault("log.outputs", []string{"stdout"})
+	v.SetDefault("log.sampling.enabled", true)
+	v.SetDefault("log.sampling.initial", 100)
+	v.SetDefault("log.sampling.thereafter", 100)
+
+	v.SetDefault("server.host", "0.0.0.0")
+	v.SetDefault("server.port", 8080)
+	v.SetDefault("server.grpc_host", "0.0.0.0")
+	v.SetDefault("server.grpc_port", 9090)
+	v.SetDefault("server.public_endpoint", "http://localhost:8080")
+	v.SetDefault("server.timeout", 15*time.Second)
+	v.SetDefault("server.read_timeout", 10*time.Second)
+	v.SetDefault("server.write_timeout", 10*time.Second)
+	v.SetDefault("server.rate_limit.requests_per_second", 250.0)
+	v.SetDefault("server.rate_limit.burst", 500)
+	v.SetDefault("server.health_check", true)
+
+	v.SetDefault("database.url", "postgres://synnergy:synnergy@localhost:5432/synnergy?sslmode=disable")
+	v.SetDefault("database.max_connections", 32)
+	v.SetDefault("database.conn_max_idle_time", 5*time.Minute)
+	v.SetDefault("database.conn_max_lifetime", time.Hour)
+	v.SetDefault("database.migrations_path", "migrations")
+
+	v.SetDefault("consensus.engine", "synnergy-pos")
+	v.SetDefault("consensus.committee_size", 11)
+	v.SetDefault("consensus.block_time", 2*time.Second)
+	v.SetDefault("consensus.finality_threshold", 0.67)
+	v.SetDefault("consensus.message_ttl", 30*time.Second)
+	v.SetDefault("consensus.max_drift", 3*time.Second)
+	v.SetDefault("consensus.safety_buffer", 2)
+	v.SetDefault("consensus.gas_floor", uint64(50_000))
+	v.SetDefault("consensus.max_block_gas", uint64(25_000_000))
+
+	v.SetDefault("vm.execution_timeout", 5*time.Second)
+	v.SetDefault("vm.max_stack_depth", 2048)
+	v.SetDefault("vm.gas_limit", uint64(100_000_000))
+	v.SetDefault("vm.schedule_path", "configs/gas_table.yaml")
+	v.SetDefault("vm.deterministic", true)
+	v.SetDefault("vm.cache_size", 1024)
+	v.SetDefault("vm.metering_precision", uint64(4))
+	v.SetDefault("vm.opcode_set", "synnergy/v1")
+	v.SetDefault("vm.precompiles_enabled", []string{"bls12-381", "poseidon"})
+
+	v.SetDefault("wallet.keystore_path", "data/wallets")
+	v.SetDefault("wallet.default_account", "authority-0")
+	v.SetDefault("wallet.hsm_enabled", false)
+	v.SetDefault("wallet.signing_algorithm", "ed25519")
+	v.SetDefault("wallet.approval_threshold", 2)
+	v.SetDefault("wallet.multi_sig_enabled", true)
+
+	v.SetDefault("cli.default_network", "synnergy-devnet")
+	v.SetDefault("cli.gas_price", uint64(1_000_000))
+	v.SetDefault("cli.output_format", "table")
+	v.SetDefault("cli.auto_complete", true)
+	v.SetDefault("cli.data_dir", "~/.synnergy")
+	v.SetDefault("cli.max_command_duration", 2*time.Minute)
+	v.SetDefault("cli.broadcast_endpoint", "http://localhost:8080")
+
+	v.SetDefault("telemetry.metrics.enabled", true)
+	v.SetDefault("telemetry.metrics.endpoint", "0.0.0.0:9100")
+	v.SetDefault("telemetry.metrics.collection_interval", 15*time.Second)
+	v.SetDefault("telemetry.tracing.enabled", false)
+	v.SetDefault("telemetry.tracing.provider", "otlp")
+	v.SetDefault("telemetry.tracing.endpoint", "localhost:4317")
+	v.SetDefault("telemetry.tracing.sample_ratio", 0.1)
+	v.SetDefault("telemetry.health.enabled", true)
+	v.SetDefault("telemetry.health.port", 9091)
+
+	v.SetDefault("security.enable_audit", true)
+	v.SetDefault("security.audit_trail_retention", 30*24*time.Hour)
+	v.SetDefault("security.permit_cidrs", []string{"10.0.0.0/8", "192.168.0.0/16"})
+	v.SetDefault("security.jwt_signing_algorithm", "ed25519")
+	v.SetDefault("security.jwt_issuer", "synnergy-network")
+	v.SetDefault("security.key_management_uri", "kms://synnergy/local")
+	v.SetDefault("security.allowed_origins", []string{"https://console.synnergy.io"})
+	v.SetDefault("security.min_password_length", 16)
+	v.SetDefault("security.signature_scheme", "ed25519")
+	v.SetDefault("security.confidential_transactions", true)
+
+	v.SetDefault("network.p2p_address", "0.0.0.0:7070")
+	v.SetDefault("network.rpc_address", "0.0.0.0:8545")
+	v.SetDefault("network.max_peers", 2000)
+	v.SetDefault("network.seed_nodes", []string{"seed-1.synnergy.io:7070", "seed-2.synnergy.io:7070"})
+	v.SetDefault("network.authority_nodes", []string{"authority-1.synnergy.io:7070"})
+	v.SetDefault("network.allow_private_peers", false)
+	v.SetDefault("network.sync_retry_interval", 5*time.Second)
+}
+
+func validateCIDRs(cidrs []string) error {
+	sort.Strings(cidrs)
+	for _, cidr := range cidrs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("invalid cidr %s: %w", cidr, err)
+		}
+	}
+	return nil
+}
+
+// Fingerprint returns a deterministic hash of the configuration that can be
+// shared between CLI and authority nodes to ensure consensus over operational
+// parameters.
+func (c Config) Fingerprint() string {
+	clone := c.Clone()
+	data := fmt.Sprintf("%s|%s|%s|%s|%s|%d|%d|%d|%t|%t", clone.Version, clone.Environment, clone.Log.Level, clone.Consensus.Engine, clone.VM.OpcodeSet, clone.Consensus.GasFloor, clone.Consensus.MaxBlockGas, clone.Server.Port, clone.Security.ConfidentialTx, clone.Wallet.HSMEnabled)
+	for _, output := range clone.Log.Outputs {
+		data += "|log:" + output
+	}
+	for _, seed := range clone.Network.SeedNodes {
+		data += "|seed:" + seed
+	}
+	sum := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,15 +1,17 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // writeTempFile creates a temporary file with provided contents and returns its path.
-func writeTempFile(t *testing.T, dir, pattern, content string) string {
+func writeTempFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
-	file := filepath.Join(dir, pattern)
+	file := filepath.Join(dir, name)
 	if err := os.WriteFile(file, []byte(content), 0o600); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
@@ -17,15 +19,58 @@ func writeTempFile(t *testing.T, dir, pattern, content string) string {
 }
 
 func TestLoadYAML(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := writeTempFile(t, dir, "config.yaml", `
-log_level: debug
 environment: production
+log:
+  level: debug
+  outputs: ["stdout", "eventstream"]
+  format: json
 server:
   host: "127.0.0.1"
   port: 9000
+  grpc_port: 9100
+  grpc_host: "127.0.0.1"
+  public_endpoint: "https://api.synnergy.example"
+  timeout: 30s
+  read_timeout: 15s
+  write_timeout: 15s
+  rate_limit:
+    requests_per_second: 500
+    burst: 800
 database:
-  url: "https://db.example.com"
+  url: "postgres://admin:pass@db:5432/synnergy?sslmode=disable"
+  migrations_path: "schema"
+consensus:
+  engine: synnergy-ibft
+  committee_size: 21
+  block_time: 1s
+  finality_threshold: 0.75
+  gas_floor: 120000
+  max_block_gas: 40000000
+vm:
+  gas_limit: 42000000
+  schedule_path: "configs/enterprise_gas.yaml"
+  execution_timeout: 7s
+wallet:
+  keystore_path: "/secure"
+  default_account: "validator-1"
+  signing_algorithm: ed25519
+  approval_threshold: 2
+cli:
+  default_network: "synnergy-mainnet"
+  gas_price: 2100000
+  broadcast_endpoint: "https://cli.synnergy.example/api"
+telemetry:
+  tracing:
+    enabled: true
+    endpoint: "otel.collector:4317"
+security:
+  allowed_origins: ["https://console.synnergy.example"]
+network:
+  seed_nodes: ["seed-a.synnergy.example:7070", "seed-b.synnergy.example:7070"]
+  authority_nodes: ["auth-a.synnergy.example:7070"]
 `)
 
 	cfg, err := Load(path)
@@ -36,35 +81,219 @@ database:
 	if cfg.Server.Port != 9000 {
 		t.Fatalf("expected server port 9000 got %d", cfg.Server.Port)
 	}
-	if cfg.Environment != "production" {
-		t.Fatalf("expected environment production got %s", cfg.Environment)
+	if cfg.Consensus.CommitteeSize != 21 {
+		t.Fatalf("expected committee size 21 got %d", cfg.Consensus.CommitteeSize)
+	}
+	if cfg.VM.SchedulePath != "configs/enterprise_gas.yaml" {
+		t.Fatalf("expected custom gas schedule path, got %s", cfg.VM.SchedulePath)
+	}
+	if cfg.Security.AllowedOrigins[0] != "https://console.synnergy.example" {
+		t.Fatalf("expected allowed origin propagated")
 	}
 }
 
 func TestEnvOverrideAndJSON(t *testing.T) {
 	dir := t.TempDir()
-	path := writeTempFile(t, dir, "config.json", `{
-  "log_level": "info",
-  "environment": "staging",
-  "server": {"host": "0.0.0.0", "port": 8080},
-  "database": {"url": "https://db.example.com"}
-}`)
+	raw := map[string]any{
+		"environment": "staging",
+		"log_level":   "info",
+		"server": map[string]any{
+			"host": "0.0.0.0",
+			"port": 8080,
+		},
+	}
+	content, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	path := writeTempFile(t, dir, "config.json", string(content))
 
-	t.Setenv("SYN_SERVER_PORT", "8081")
+	t.Setenv("SYN_CLI_GAS_PRICE", "9000000")
 	cfg, err := Load(path)
 	if err != nil {
 		t.Fatalf("load JSON config: %v", err)
 	}
-	if cfg.Server.Port != 8081 {
-		t.Fatalf("expected env override to 8081 got %d", cfg.Server.Port)
+	if cfg.CLI.GasPrice != 9_000_000 {
+		t.Fatalf("expected env override to 9000000 got %d", cfg.CLI.GasPrice)
 	}
 }
 
 func TestValidation(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
-	path := writeTempFile(t, dir, "bad.yaml", `log_level: info`)
+	path := writeTempFile(t, dir, "bad.yaml", `server:
+  tls:
+    enabled: true
+`)
 
 	if _, err := Load(path); err == nil {
 		t.Fatalf("expected validation error, got nil")
+	}
+}
+
+func TestWithDefaultPathsFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := writeTempFile(t, dir, "custom.yaml", `environment: development`)
+
+	cfg, err := Load("", WithDefaultPaths(configPath))
+	if err != nil {
+		t.Fatalf("load with default paths: %v", err)
+	}
+	if cfg.Environment != "development" {
+		t.Fatalf("expected development environment fallback")
+	}
+}
+
+func TestFingerprintDeterministic(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load defaults: %v", err)
+	}
+	fp1 := cfg.Fingerprint()
+	fp2 := cfg.Clone().Fingerprint()
+	if fp1 != fp2 {
+		t.Fatalf("expected deterministic fingerprint, got %s and %s", fp1, fp2)
+	}
+	if len(fp1) == 0 {
+		t.Fatalf("fingerprint should not be empty")
+	}
+}
+
+func TestCloneIsolated(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load defaults: %v", err)
+	}
+	clone := cfg.Clone()
+	clone.Log.Outputs[0] = "stderr"
+	clone.Network.SeedNodes[0] = "overridden:7070"
+	if cfg.Log.Outputs[0] == "stderr" {
+		t.Fatalf("mutation leaked to original log outputs")
+	}
+	if cfg.Network.SeedNodes[0] == "overridden:7070" {
+		t.Fatalf("mutation leaked to original seed nodes")
+	}
+}
+
+func TestValidateCIDRFails(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load defaults: %v", err)
+	}
+	cfg.Security.PermitCIDRs = []string{"invalid"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected cidr validation failure")
+	}
+}
+
+func TestConsensusGasFloorValidation(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load defaults: %v", err)
+	}
+	cfg.Consensus.MaxBlockGas = cfg.Consensus.GasFloor - 1
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected validation error when gas floor exceeds max block gas")
+	}
+}
+
+func TestTimeoutsRemainPositive(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load defaults: %v", err)
+	}
+	cfg.Server.Timeout = -1
+	if err := ensureValidator().Struct(cfg); err == nil {
+		t.Fatalf("expected validator to reject negative timeout")
+	}
+}
+
+func TestLoadHonoursBackwardsCompatibleKeys(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "legacy.yaml", `
+log_level: warn
+environment: production
+server:
+  host: "0.0.0.0"
+database:
+  url: "postgres://legacy@localhost:5432/synnergy"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load legacy config: %v", err)
+	}
+	if cfg.Log.Level != "warn" {
+		t.Fatalf("expected legacy log level to map to structured log config, got %s", cfg.Log.Level)
+	}
+}
+
+func TestWithEnvPrefix(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "config.yaml", `environment: development`)
+	t.Setenv("CUSTOM_ENVIRONMENT", "production")
+	cfg, err := Load(path, WithEnvPrefix("CUSTOM"))
+	if err != nil {
+		t.Fatalf("load with custom prefix: %v", err)
+	}
+	if cfg.Environment != "production" {
+		t.Fatalf("expected environment override from custom prefix")
+	}
+}
+
+func TestLoadRejectsMissingTLSMaterial(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "config.yaml", `
+server:
+  tls:
+    enabled: true
+`)
+	if _, err := Load(path); err == nil {
+		t.Fatalf("expected tls validation error")
+	}
+}
+
+func TestApplyBackwardsCompatibilityDefaultsOutputs(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("load defaults: %v", err)
+	}
+	if len(cfg.Log.Outputs) == 0 {
+		t.Fatalf("log outputs should default to stdout")
+	}
+}
+
+func TestLoadFromDefaultPathsIgnoresMissing(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("", WithDefaultPaths(filepath.Join(t.TempDir(), "missing.yaml")))
+	if err != nil {
+		t.Fatalf("load should succeed even if default file missing: %v", err)
+	}
+	if cfg.Server.Timeout <= 0 {
+		t.Fatalf("expected defaults to apply")
+	}
+}
+
+func TestMaxCommandDurationDecodes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "config.yaml", `cli:
+  max_command_duration: 45s
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load with custom duration: %v", err)
+	}
+	if cfg.CLI.MaxCommandDuration != 45*time.Second {
+		t.Fatalf("expected CLI duration override, got %s", cfg.CLI.MaxCommandDuration)
 	}
 }

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -3,5 +3,6 @@
 package config
 
 // DefaultConfigPath specifies the configuration file used when no build tags are provided.
-// It points to the development configuration as a sensible fallback.
+// The development profile is selected so local CLI, VM and web workflows pick up
+// sane defaults without additional flags.
 const DefaultConfigPath = "configs/dev.yaml"

--- a/internal/config/default_dev.go
+++ b/internal/config/default_dev.go
@@ -3,4 +3,6 @@
 package config
 
 // DefaultConfigPath points to the development configuration file.
+// Developers and integration tests build with `-tags dev` to ensure feature
+// flags align with the richer defaults captured in configs/dev.yaml.
 const DefaultConfigPath = "configs/dev.yaml"

--- a/internal/config/default_dev_test.go
+++ b/internal/config/default_dev_test.go
@@ -1,7 +1,17 @@
 package config
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
-func TestDefaultdevPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestLoadUsesDevDefaultWhenNoPathProvided(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load("", WithDefaultPaths(filepath.Join("..", "..", "configs", "dev.yaml")))
+	if err != nil {
+		t.Fatalf("expected to load dev defaults, got error: %v", err)
+	}
+	if cfg.Environment != "development" {
+		t.Fatalf("expected development environment for dev defaults, got %s", cfg.Environment)
+	}
 }

--- a/internal/config/default_prod.go
+++ b/internal/config/default_prod.go
@@ -3,4 +3,6 @@
 package config
 
 // DefaultConfigPath points to the production configuration file.
+// Authority nodes compile with `-tags prod` to enforce the hardened operating
+// posture and telemetry requirements encoded in configs/prod.yaml.
 const DefaultConfigPath = "configs/prod.yaml"

--- a/internal/config/default_prod_test.go
+++ b/internal/config/default_prod_test.go
@@ -1,7 +1,17 @@
 package config
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
-func TestDefaultprodPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestLoadUsesProdProfileWhenProvided(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load(filepath.Join("..", "..", "configs", "prod.yaml"))
+	if err != nil {
+		t.Fatalf("expected prod config to load, got error: %v", err)
+	}
+	if cfg.Environment != "production" {
+		t.Fatalf("expected production environment from prod profile, got %s", cfg.Environment)
+	}
 }

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -3,4 +3,6 @@
 package config
 
 // DefaultConfigPath points to the staging/test configuration file.
+// Integration test binaries rely on this tag to exercise quorum safe defaults
+// without mutating production grade configuration.
 const DefaultConfigPath = "configs/test.yaml"

--- a/internal/core/README.md
+++ b/internal/core/README.md
@@ -1,3 +1,50 @@
-# Core
+# Core Module Overview
 
-Placeholder for core blockchain logic, consensus algorithms, and state management modules.
+The core package houses the execution plane that turns Synnergy into an
+enterprise-grade, regulator friendly blockchain. It is the single source of
+truth for consensus coordination, deterministic state transitions and the gas
+economy that both the CLI and the web-based function hub consume.
+
+## Responsibilities
+
+* **Ledger State Management** – Maintains the canonical state tree, executes
+  transactions inside the Synnergy Virtual Machine (SNVM) and enforces opcode
+  gas rules defined in `configs/gas_table.yaml`.
+* **Consensus Integration** – Orchestrates validator rotation, committee
+  selection and finality using the parameters supplied by
+  `internal/config.ConsensusConfig`. The module exposes hooks for authority and
+  bank nodes so governance tooling can enact upgrades without downtime.
+* **Fault Tolerance** – Utilises the shared logging (`internal/log`) and audit
+  trails (`internal/governance`) to checkpoint every state transition, ensuring
+  replay protection and deterministic recovery after crashes.
+* **CLI Alignment** – Exposes RPC and gRPC handlers consumed by the
+  `synnergy` CLI to submit transactions, inspect gas utilisation and stream
+  validator metrics. Every handler mirrors the web UI workflows surfaced in the
+  `web/` package so operators can switch between automation surfaces without
+  drift.
+* **Security and Compliance** – Applies privacy controls from
+  `internal/security` (confidential transactions, permissioned channels) and the
+  governance replay guard to satisfy jurisdictional requirements around digital
+  signatures, data retention and regulatory reporting.
+
+## Interfaces
+
+| Component | Integration Points |
+|-----------|--------------------|
+| Virtual Machine | `internal/virtual_machine` executes opcode pipelines with gas metering and returns deterministic receipts. |
+| Consensus | `internal/nodes` validators call into the core to propose/verify blocks, while consensus events are published to telemetry for UI dashboards. |
+| Wallet & CLI | Wallet approvals and CLI commands use the `SubmitTransaction` and `DryRun` APIs, which honour multi-signature policies and gas budgets configured in `internal/config`. |
+| Function Web | The JavaScript control plane streams status via WebSockets exported from the core event bus and can trigger safe-mode toggles during incident response. |
+
+## Extensibility Roadmap
+
+1. **Runtime Upgrades:** Hot-swap SNVM opcode bundles with staged signing by the
+   SYN300 governance contract.
+2. **Cross-Chain Bridges:** Consume the queueing interfaces in
+   `internal/crosschain` to settle wrapped assets with deterministic finality.
+3. **High Availability:** Coordinate multi-region replicas using the audit log
+   hash chain so authority nodes can validate failover integrity instantly.
+
+For implementation details refer to the architecture guide in
+`docs/Whitepaper_detailed/architecture/virtual_machine_architecture.md` and the
+CLI guide in `docs/Whitepaper_detailed/guide/cli_guide.md`.

--- a/internal/crosschain/README.md
+++ b/internal/crosschain/README.md
@@ -1,3 +1,39 @@
-# Cross-Chain
+# Cross-Chain Services
 
-Modules for interoperability, bridges, and transaction routing across different blockchains.
+The cross-chain package coordinates bridge operations, settlement proofs and
+state synchronisation with external ledgers. It enables the Synnergy CLI and web
+interface to execute asset transfers, governance actions and oracle updates
+across heterogeneous ecosystems without compromising gas determinism or replay
+protection.
+
+## Capabilities
+
+* **Bridge Orchestration** – Manages validator attestations, signature
+  aggregation and encrypted payload distribution when tokens are wrapped or
+  redeemed across partner networks.
+* **Gas Harmonisation** – Consumes the shared gas tables defined in
+  `internal/config.VMConfig` so that outbound transactions stay within the
+  limits enforced by the Synnergy virtual machine.
+* **Consensus Awareness** – Hooks into `internal/config.ConsensusConfig` to
+  delay settlement until finality thresholds are met, preventing forks from
+  leaking into bridged chains.
+* **Wallet and CLI Integration** – Provides deterministic APIs for the CLI
+  (`synnergy bridge send`) and the JavaScript dashboard to display proof
+  progress, audit log references and real-time throughput metrics.
+* **Security Controls** – Applies policy from `internal/security` to enforce
+  permissioned access, double-spend detection and encrypted payload routing
+  between authority nodes.
+
+## Workflow Overview
+
+1. A user submits a cross-chain command through the CLI or web UI.
+2. The request is authenticated via the governance audit log and queued with a
+   deterministic replay-protected identifier.
+3. Bridge relayers collect signatures from authority nodes using the wallet
+   module’s multi-signature configuration.
+4. Finalised proofs are broadcast to the destination chain and the resulting
+   receipts are streamed back to telemetry for operator visibility.
+
+This module ties together the consensus, VM, wallet and telemetry layers to
+deliver fault-tolerant interoperability suitable for regulated enterprise
+deployments.

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,9 +1,18 @@
 package errors
 
-import "fmt"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
 
 // Code identifies a class of application error.
 type Code string
+
+// Severity qualifies how critical an error is for routing and alerting.
+type Severity string
 
 const (
 	// NotFound indicates a missing resource.
@@ -12,17 +21,65 @@ const (
 	Invalid Code = "invalid"
 	// Internal marks unexpected internal errors.
 	Internal Code = "internal"
+	// Unauthorized indicates the caller failed authentication/authorization.
+	Unauthorized Code = "unauthorized"
+	// Conflict indicates a state conflict (optimistic locking, replay, etc.).
+	Conflict Code = "conflict"
 )
 
-// Error wraps an underlying error with a code and message.
+const (
+	// SeverityInfo represents a non-critical informational error.
+	SeverityInfo Severity = "info"
+	// SeverityWarn signals an issue that should be surfaced to operators.
+	SeverityWarn Severity = "warn"
+	// SeverityError marks high priority failures that require attention.
+	SeverityError Severity = "error"
+)
+
+// Error wraps an underlying error with structured metadata suitable for the CLI
+// renderer, REST handlers and telemetry pipeline.
 type Error struct {
-	Code    Code
-	Message string
-	Err     error
+	Code          Code           `json:"code"`
+	Message       string         `json:"message"`
+	Err           error          `json:"-"`
+	Severity      Severity       `json:"severity"`
+	CorrelationID string         `json:"correlation_id,omitempty"`
+	Status        int            `json:"status"`
+	Retryable     bool           `json:"retryable"`
+	Timestamp     time.Time      `json:"timestamp"`
+	Details       map[string]any `json:"details,omitempty"`
+}
+
+// Option mutates an error during construction.
+type Option func(*Error)
+
+// New creates a coded error without an underlying cause.
+func New(code Code, msg string, opts ...Option) *Error {
+	return Wrap(code, msg, nil, opts...)
+}
+
+// Wrap attaches a code and message to an existing error and applies options.
+func Wrap(code Code, msg string, err error, opts ...Option) *Error {
+	e := &Error{
+		Code:      code,
+		Message:   msg,
+		Err:       err,
+		Severity:  SeverityError,
+		Status:    defaultStatus(code),
+		Timestamp: time.Now().UTC(),
+		Details:   map[string]any{},
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // Error implements the error interface.
 func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %s: %v", e.Code, e.Message, e.Err)
 	}
@@ -32,18 +89,102 @@ func (e *Error) Error() string {
 // Unwrap returns the wrapped error for errors.Is/As.
 func (e *Error) Unwrap() error { return e.Err }
 
-// New creates a coded error without an underlying cause.
-func New(code Code, msg string) *Error { return &Error{Code: code, Message: msg} }
-
-// Wrap attaches a code and message to an existing error.
-func Wrap(code Code, msg string, err error) *Error {
-	return &Error{Code: code, Message: msg, Err: err}
-}
-
 // IsCode reports whether err is an *Error with the given code.
 func IsCode(err error, code Code) bool {
-	if e, ok := err.(*Error); ok {
-		return e.Code == code
+	var coded *Error
+	if errors.As(err, &coded) {
+		return coded.Code == code
 	}
 	return false
+}
+
+// ToMap returns a representation suitable for CLI and JSON output.
+func (e *Error) ToMap() map[string]any {
+	if e == nil {
+		return nil
+	}
+	cloned := map[string]any{
+		"code":      e.Code,
+		"message":   e.Message,
+		"severity":  e.Severity,
+		"status":    e.Status,
+		"retryable": e.Retryable,
+		"timestamp": e.Timestamp.Format(time.RFC3339Nano),
+	}
+	if e.CorrelationID != "" {
+		cloned["correlation_id"] = e.CorrelationID
+	}
+	if len(e.Details) > 0 {
+		cloned["details"] = e.Details
+	}
+	return cloned
+}
+
+// MarshalJSON ensures the wrapped error is omitted while the structured fields
+// remain serialisable.
+func (e *Error) MarshalJSON() ([]byte, error) {
+	type alias Error
+	return json.Marshal((*alias)(e))
+}
+
+// WithCorrelation assigns a correlation identifier.
+func WithCorrelation(id string) Option {
+	return func(e *Error) {
+		e.CorrelationID = id
+	}
+}
+
+// WithSeverity sets a custom severity.
+func WithSeverity(sev Severity) Option {
+	return func(e *Error) {
+		e.Severity = sev
+	}
+}
+
+// WithStatus overrides the HTTP status code mapping.
+func WithStatus(status int) Option {
+	return func(e *Error) {
+		e.Status = status
+	}
+}
+
+// WithRetryable toggles the retryable flag.
+func WithRetryable(retryable bool) Option {
+	return func(e *Error) {
+		e.Retryable = retryable
+	}
+}
+
+// WithDetail adds a key/value pair to the error metadata.
+func WithDetail(key string, value any) Option {
+	return func(e *Error) {
+		if e.Details == nil {
+			e.Details = map[string]any{}
+		}
+		e.Details[key] = value
+	}
+}
+
+// Parse attempts to unwrap an error back into the structured Error type.
+func Parse(err error) (*Error, bool) {
+	var coded *Error
+	if errors.As(err, &coded) {
+		return coded, true
+	}
+	return nil, false
+}
+
+func defaultStatus(code Code) int {
+	switch code {
+	case NotFound:
+		return http.StatusNotFound
+	case Invalid:
+		return http.StatusBadRequest
+	case Unauthorized:
+		return http.StatusUnauthorized
+	case Conflict:
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,13 +1,17 @@
 package errors
 
 import (
+	"encoding/json"
+	goerrors "errors"
 	"fmt"
+	"net/http"
 	"testing"
+	"time"
 )
 
 func TestErrorWrapping(t *testing.T) {
 	base := fmt.Errorf("boom")
-	err := Wrap(Invalid, "failed", base)
+	err := Wrap(Invalid, "failed", base, WithSeverity(SeverityWarn), WithCorrelation("corr-123"), WithRetryable(true))
 	if err.Error() == "" {
 		t.Fatalf("empty error")
 	}
@@ -16,5 +20,74 @@ func TestErrorWrapping(t *testing.T) {
 	}
 	if err.Unwrap() != base {
 		t.Fatalf("unwrap mismatch")
+	}
+	if err.Severity != SeverityWarn {
+		t.Fatalf("expected severity warn, got %s", err.Severity)
+	}
+	if !err.Retryable {
+		t.Fatalf("expected retryable flag")
+	}
+	if err.CorrelationID != "corr-123" {
+		t.Fatalf("expected correlation id propagated")
+	}
+}
+
+func TestMarshalJSONOmitsWrappedError(t *testing.T) {
+	err := Wrap(NotFound, "missing resource", fmt.Errorf("cause"))
+	payload, marshalErr := json.Marshal(err)
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	if string(payload) == "" {
+		t.Fatalf("expected json output")
+	}
+	if goerrors.Is(fmt.Errorf("%s", payload), err.Err) {
+		t.Fatalf("wrapped error should not be marshalled")
+	}
+}
+
+func TestToMapContainsMetadata(t *testing.T) {
+	err := Wrap(Unauthorized, "denied", nil, WithDetail("role", "auditor"), WithStatus(http.StatusForbidden))
+	err.Timestamp = time.Unix(0, 0).UTC()
+	out := err.ToMap()
+	if out["status"] != http.StatusForbidden {
+		t.Fatalf("expected custom status reflected")
+	}
+	details := out["details"].(map[string]any)
+	if details["role"] != "auditor" {
+		t.Fatalf("expected detail preserved")
+	}
+	if _, ok := out["correlation_id"]; ok {
+		t.Fatalf("unexpected correlation id")
+	}
+	if out["timestamp"].(string) == "" {
+		t.Fatalf("timestamp should be present")
+	}
+}
+
+func TestParseReturnsStructuredError(t *testing.T) {
+	original := Wrap(Conflict, "version mismatch", nil)
+	wrapped := fmt.Errorf("outer: %w", original)
+	parsed, ok := Parse(wrapped)
+	if !ok {
+		t.Fatalf("expected to parse structured error")
+	}
+	if parsed.Code != Conflict {
+		t.Fatalf("expected conflict code")
+	}
+}
+
+func TestDefaultStatusMapping(t *testing.T) {
+	cases := map[Code]int{
+		NotFound:     http.StatusNotFound,
+		Invalid:      http.StatusBadRequest,
+		Unauthorized: http.StatusUnauthorized,
+		Conflict:     http.StatusConflict,
+		Internal:     http.StatusInternalServerError,
+	}
+	for code, status := range cases {
+		if got := defaultStatus(code); got != status {
+			t.Fatalf("expected %d for code %s got %d", status, code, got)
+		}
 	}
 }

--- a/internal/governance/audit_log.go
+++ b/internal/governance/audit_log.go
@@ -1,28 +1,257 @@
 package governance
 
-import "sync"
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
 
-// AuditLog stores simple string entries.
+// AuditEvent captures the context for a governance action.
+type AuditEvent struct {
+	ID        string            `json:"id"`
+	Actor     string            `json:"actor"`
+	Action    string            `json:"action"`
+	Scope     string            `json:"scope"`
+	NodeID    string            `json:"node_id"`
+	Reason    string            `json:"reason"`
+	GasBudget uint64            `json:"gas_budget"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Timestamp time.Time         `json:"timestamp"`
+}
+
+// AuditRecord represents an immutable entry in the governance log.
+type AuditRecord struct {
+	Sequence   uint64 `json:"sequence"`
+	PrevHash   string `json:"prev_hash"`
+	Hash       string `json:"hash"`
+	Signature  string `json:"signature,omitempty"`
+	AuditEvent `json:",inline"`
+}
+
+// Signer generates and validates signatures for audit entries.
+type Signer interface {
+	Sign(message []byte) (string, error)
+	Verify(message []byte, signature string) bool
+}
+
+// HMACSigner implements Signer using HMAC-SHA256.
+type HMACSigner struct {
+	key []byte
+}
+
+// NewHMACSigner instantiates a signer from the supplied secret.
+func NewHMACSigner(key []byte) *HMACSigner {
+	buf := make([]byte, len(key))
+	copy(buf, key)
+	return &HMACSigner{key: buf}
+}
+
+// Sign produces a base64 encoded HMAC signature.
+func (s *HMACSigner) Sign(message []byte) (string, error) {
+	mac := hmac.New(sha256.New, s.key)
+	if _, err := mac.Write(message); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+// Verify validates a base64 encoded HMAC signature.
+func (s *HMACSigner) Verify(message []byte, signature string) bool {
+	mac := hmac.New(sha256.New, s.key)
+	if _, err := mac.Write(message); err != nil {
+		return false
+	}
+	expected := mac.Sum(nil)
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false
+	}
+	return hmac.Equal(expected, sig)
+}
+
+// Observer receives notifications for newly appended audit records.
+type Observer func(AuditRecord)
+
+// AuditLog stores tamper evident governance events with optional signing.
 type AuditLog struct {
-	mu      sync.Mutex
-	entries []string
+	mu          sync.RWMutex
+	entries     []AuditRecord
+	retention   int
+	signer      Signer
+	observers   []Observer
+	nextSeq     uint64
+	lastHashHex string
 }
 
-// NewAuditLog creates an AuditLog.
-func NewAuditLog() *AuditLog { return &AuditLog{} }
+// AuditOption mutates log configuration.
+type AuditOption func(*AuditLog)
 
-// Append adds an entry to the log.
-func (a *AuditLog) Append(e string) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.entries = append(a.entries, e)
+// WithRetention limits the maximum number of retained entries.
+func WithRetention(limit int) AuditOption {
+	return func(log *AuditLog) {
+		if limit > 0 {
+			log.retention = limit
+		}
+	}
 }
 
-// Entries returns a copy of log entries.
-func (a *AuditLog) Entries() []string {
+// WithSigner attaches a signing implementation to the audit log.
+func WithSigner(s Signer) AuditOption {
+	return func(log *AuditLog) {
+		log.signer = s
+	}
+}
+
+// WithObserver registers an observer callback for new entries.
+func WithObserver(obs Observer) AuditOption {
+	return func(log *AuditLog) {
+		if obs != nil {
+			log.observers = append(log.observers, obs)
+		}
+	}
+}
+
+// NewAuditLog creates an AuditLog with optional retention and signing.
+func NewAuditLog(opts ...AuditOption) *AuditLog {
+	log := &AuditLog{retention: 10_000, nextSeq: 1}
+	for _, opt := range opts {
+		opt(log)
+	}
+	return log
+}
+
+// Append stores an event in the audit log and returns the resulting record.
+func (a *AuditLog) Append(event AuditEvent) (AuditRecord, error) {
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	if event.ID == "" {
+		generated, err := randomID()
+		if err != nil {
+			return AuditRecord{}, err
+		}
+		event.ID = generated
+	}
+	if event.Actor == "" || event.Action == "" {
+		return AuditRecord{}, fmt.Errorf("actor and action are required")
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	out := make([]string, len(a.entries))
+
+	record := AuditRecord{
+		Sequence:   a.nextSeq,
+		PrevHash:   a.lastHashHex,
+		AuditEvent: event,
+	}
+	payload := digestPayload(record.Sequence, record.PrevHash, event)
+	sum := sha256.Sum256(payload)
+	record.Hash = hex.EncodeToString(sum[:])
+	if a.signer != nil {
+		sig, err := a.signer.Sign(sum[:])
+		if err != nil {
+			return AuditRecord{}, fmt.Errorf("sign audit entry: %w", err)
+		}
+		record.Signature = sig
+	}
+
+	a.entries = append(a.entries, record)
+	a.lastHashHex = record.Hash
+	a.nextSeq++
+	a.enforceRetention()
+	a.notify(record)
+	return record, nil
+}
+
+// Entries returns a copy of log entries in chronological order.
+func (a *AuditLog) Entries() []AuditRecord {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	out := make([]AuditRecord, len(a.entries))
 	copy(out, a.entries)
 	return out
+}
+
+// VerifyChain ensures hash continuity and valid signatures for all entries.
+func (a *AuditLog) VerifyChain() error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	prevHash := ""
+	for _, record := range a.entries {
+		if record.PrevHash != prevHash {
+			return fmt.Errorf("hash continuity broken at sequence %d", record.Sequence)
+		}
+		payload := digestPayload(record.Sequence, record.PrevHash, record.AuditEvent)
+		expected := sha256.Sum256(payload)
+		if hex.EncodeToString(expected[:]) != record.Hash {
+			return fmt.Errorf("hash mismatch at sequence %d", record.Sequence)
+		}
+		if a.signer != nil && record.Signature != "" {
+			if !a.signer.Verify(expected[:], record.Signature) {
+				return fmt.Errorf("signature mismatch at sequence %d", record.Sequence)
+			}
+		}
+		prevHash = record.Hash
+	}
+	return nil
+}
+
+// Latest returns the newest record if one exists.
+func (a *AuditLog) Latest() (AuditRecord, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.entries) == 0 {
+		return AuditRecord{}, false
+	}
+	return a.entries[len(a.entries)-1], true
+}
+
+func (a *AuditLog) enforceRetention() {
+	if a.retention <= 0 || len(a.entries) <= a.retention {
+		return
+	}
+	excess := len(a.entries) - a.retention
+	a.entries = append([]AuditRecord(nil), a.entries[excess:]...)
+}
+
+func (a *AuditLog) notify(record AuditRecord) {
+	for _, obs := range a.observers {
+		obs(record)
+	}
+}
+
+func digestPayload(seq uint64, prevHash string, event AuditEvent) []byte {
+	metadata := ""
+	if len(event.Metadata) > 0 {
+		keys := make([]string, 0, len(event.Metadata))
+		for k := range event.Metadata {
+			keys = append(keys, k)
+		}
+		// Deterministic ordering ensures consistent digests.
+		sort.Strings(keys)
+		pairs := make([]string, 0, len(keys))
+		for _, k := range keys {
+			pairs = append(pairs, k+"="+event.Metadata[k])
+		}
+		metadata = strings.Join(pairs, ";")
+	}
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("%d|%s|%s|%s|%s|%s|%d|%s|%s|%s|", seq, prevHash, event.ID, event.Actor, event.Action, event.Scope, event.GasBudget, event.NodeID, event.Reason, metadata))
+	builder.WriteString(event.Timestamp.UTC().Format(time.RFC3339Nano))
+	return []byte(builder.String())
+}
+
+func randomID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate audit id: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
 }

--- a/internal/governance/audit_log_test.go
+++ b/internal/governance/audit_log_test.go
@@ -1,11 +1,92 @@
 package governance
 
-import "testing"
+import (
+	"sync"
+	"testing"
+	"time"
+)
 
-func TestAuditLog(t *testing.T) {
-	a := NewAuditLog()
-	a.Append("entry")
-	if len(a.Entries()) != 1 {
-		t.Fatalf("expected one entry")
+func TestAuditLogAppendAndVerify(t *testing.T) {
+	signer := NewHMACSigner([]byte("secret"))
+	log := NewAuditLog(WithSigner(signer), WithRetention(5))
+	first, err := log.Append(AuditEvent{Actor: "validator-1", Action: "approve", Scope: "consensus", GasBudget: 5000})
+	if err != nil {
+		t.Fatalf("append first event: %v", err)
+	}
+	if first.Sequence != 1 {
+		t.Fatalf("expected sequence 1, got %d", first.Sequence)
+	}
+	if first.Hash == "" || first.Signature == "" {
+		t.Fatalf("expected hash and signature")
+	}
+
+	second, err := log.Append(AuditEvent{Actor: "validator-2", Action: "approve", Scope: "consensus", GasBudget: 5000})
+	if err != nil {
+		t.Fatalf("append second event: %v", err)
+	}
+	if second.PrevHash != first.Hash {
+		t.Fatalf("expected hash chaining")
+	}
+
+	if err := log.VerifyChain(); err != nil {
+		t.Fatalf("verify chain: %v", err)
+	}
+}
+
+func TestAuditLogRetention(t *testing.T) {
+	log := NewAuditLog(WithRetention(2))
+	for i := 0; i < 3; i++ {
+		if _, err := log.Append(AuditEvent{Actor: "node", Action: "test", Scope: "retention"}); err != nil {
+			t.Fatalf("append event: %v", err)
+		}
+	}
+	if len(log.Entries()) != 2 {
+		t.Fatalf("expected retention to keep only two entries")
+	}
+}
+
+func TestAuditLogObservers(t *testing.T) {
+	var mu sync.Mutex
+	observed := 0
+	observer := func(AuditRecord) {
+		mu.Lock()
+		defer mu.Unlock()
+		observed++
+	}
+	log := NewAuditLog(WithObserver(observer))
+	if _, err := log.Append(AuditEvent{Actor: "validator", Action: "approve"}); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	mu.Lock()
+	count := observed
+	mu.Unlock()
+	if count != 1 {
+		t.Fatalf("expected observer to run once, got %d", count)
+	}
+}
+
+func TestAuditLogGeneratesDeterministicIDs(t *testing.T) {
+	log := NewAuditLog()
+	record, err := log.Append(AuditEvent{Actor: "validator", Action: "approve"})
+	if err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	if record.ID == "" {
+		t.Fatalf("expected generated id")
+	}
+}
+
+func TestAuditLogLatest(t *testing.T) {
+	log := NewAuditLog()
+	if _, ok := log.Latest(); ok {
+		t.Fatalf("expected empty log to have no latest record")
+	}
+	inserted, err := log.Append(AuditEvent{Actor: "node", Action: "rotate", Timestamp: time.Unix(1, 0)})
+	if err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	latest, ok := log.Latest()
+	if !ok || latest.Sequence != inserted.Sequence {
+		t.Fatalf("expected latest record to match appended entry")
 	}
 }

--- a/internal/governance/replay_protection.go
+++ b/internal/governance/replay_protection.go
@@ -1,25 +1,143 @@
 package governance
 
-import "sync"
+import (
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+// ErrReplayDetected indicates that a duplicate identifier was observed within the protection window.
+var ErrReplayDetected = errors.New("replay detected")
+
+// ReplayOption customises the replay protector.
+type ReplayOption func(*ReplayProtector)
 
 // ReplayProtector prevents processing of duplicate IDs.
 type ReplayProtector struct {
-	mu   sync.Mutex
-	seen map[string]struct{}
+	mu          sync.Mutex
+	seen        map[string]time.Time
+	window      time.Duration
+	maxEntries  int
+	onDuplicate func(string)
+	onEvict     func(string)
 }
 
 // NewReplayProtector creates a ReplayProtector.
-func NewReplayProtector() *ReplayProtector {
-	return &ReplayProtector{seen: make(map[string]struct{})}
+func NewReplayProtector(opts ...ReplayOption) *ReplayProtector {
+	rp := &ReplayProtector{
+		seen:       make(map[string]time.Time),
+		window:     10 * time.Minute,
+		maxEntries: 100_000,
+	}
+	for _, opt := range opts {
+		opt(rp)
+	}
+	return rp
 }
 
-// Seen checks if the ID has been observed.
+// WithWindow overrides the replay detection window.
+func WithWindow(window time.Duration) ReplayOption {
+	return func(r *ReplayProtector) {
+		if window > 0 {
+			r.window = window
+		}
+	}
+}
+
+// WithMaxEntries caps the number of stored identifiers.
+func WithMaxEntries(max int) ReplayOption {
+	return func(r *ReplayProtector) {
+		if max > 0 {
+			r.maxEntries = max
+		}
+	}
+}
+
+// WithDuplicateCallback registers a callback for duplicates.
+func WithDuplicateCallback(cb func(string)) ReplayOption {
+	return func(r *ReplayProtector) {
+		r.onDuplicate = cb
+	}
+}
+
+// WithEvictionCallback registers a callback when identifiers are evicted.
+func WithEvictionCallback(cb func(string)) ReplayOption {
+	return func(r *ReplayProtector) {
+		r.onEvict = cb
+	}
+}
+
+// Seen checks if the ID has been observed inside the configured window. It returns true if the identifier is a replay.
 func (r *ReplayProtector) Seen(id string) bool {
+	_, duplicate := r.check(id, time.Now().UTC())
+	return duplicate
+}
+
+// Check evaluates the identifier at a given timestamp and returns ErrReplayDetected when the id is a duplicate.
+func (r *ReplayProtector) Check(id string, ts time.Time) error {
+	_, duplicate := r.check(id, ts)
+	if duplicate {
+		return ErrReplayDetected
+	}
+	return nil
+}
+
+func (r *ReplayProtector) check(id string, ts time.Time) (time.Time, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, ok := r.seen[id]; ok {
-		return true
+
+	r.cleanup(ts)
+	if firstSeen, ok := r.seen[id]; ok {
+		if r.onDuplicate != nil {
+			r.onDuplicate(id)
+		}
+		return firstSeen, true
 	}
-	r.seen[id] = struct{}{}
-	return false
+
+	if len(r.seen) >= r.maxEntries {
+		r.evictOldest()
+	}
+
+	r.seen[id] = ts
+	return ts, false
+}
+
+func (r *ReplayProtector) cleanup(now time.Time) {
+	limit := now.Add(-r.window)
+	for id, firstSeen := range r.seen {
+		if firstSeen.Before(limit) {
+			delete(r.seen, id)
+			if r.onEvict != nil {
+				r.onEvict(id)
+			}
+		}
+	}
+}
+
+func (r *ReplayProtector) evictOldest() {
+	if len(r.seen) == 0 {
+		return
+	}
+	type entry struct {
+		id string
+		ts time.Time
+	}
+	entries := make([]entry, 0, len(r.seen))
+	for id, ts := range r.seen {
+		entries = append(entries, entry{id: id, ts: ts})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ts.Before(entries[j].ts) })
+	oldest := entries[0]
+	delete(r.seen, oldest.id)
+	if r.onEvict != nil {
+		r.onEvict(oldest.id)
+	}
+}
+
+// Size returns the number of tracked identifiers (useful for tests and metrics).
+func (r *ReplayProtector) Size() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.seen)
 }

--- a/internal/governance/replay_protection_test.go
+++ b/internal/governance/replay_protection_test.go
@@ -1,6 +1,9 @@
 package governance
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestReplayProtectorSeen(t *testing.T) {
 	r := NewReplayProtector()
@@ -10,4 +13,58 @@ func TestReplayProtectorSeen(t *testing.T) {
 	if !r.Seen("abc") {
 		t.Fatal("ID should be seen second time")
 	}
+}
+
+func TestReplayProtectorWindowExpiry(t *testing.T) {
+	r := NewReplayProtector(WithWindow(1 * time.Second))
+	ts := time.Unix(0, 0)
+	if err := r.Check("abc", ts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := r.Check("abc", ts.Add(500*time.Millisecond)); !IsReplayError(err) {
+		t.Fatalf("expected replay within window")
+	}
+	if err := r.Check("abc", ts.Add(2*time.Second)); err != nil {
+		t.Fatalf("expected identifier to expire, got %v", err)
+	}
+}
+
+func TestReplayProtectorEvictsOldest(t *testing.T) {
+	evicted := make(chan string, 1)
+	r := NewReplayProtector(WithMaxEntries(1), WithEvictionCallback(func(id string) { evicted <- id }))
+	if err := r.Check("first", time.Now()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := r.Check("second", time.Now()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	select {
+	case id := <-evicted:
+		if id != "first" {
+			t.Fatalf("expected first to be evicted, got %s", id)
+		}
+	default:
+		t.Fatalf("expected eviction callback to fire")
+	}
+}
+
+func TestReplayProtectorDuplicateCallback(t *testing.T) {
+	duplicates := make(chan string, 1)
+	r := NewReplayProtector(WithDuplicateCallback(func(id string) { duplicates <- id }))
+	_ = r.Check("dup", time.Now())
+	if err := r.Check("dup", time.Now()); err == nil {
+		t.Fatalf("expected replay error")
+	}
+	select {
+	case id := <-duplicates:
+		if id != "dup" {
+			t.Fatalf("expected duplicate callback for dup, got %s", id)
+		}
+	default:
+		t.Fatalf("expected duplicate callback to trigger")
+	}
+}
+
+func IsReplayError(err error) bool {
+	return err == ErrReplayDetected
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,40 +1,268 @@
 package log
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"runtime"
+	"strings"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
-// entry represents a single log line.
-type entry map[string]interface{}
+// Level represents a logging severity level.
+type Level int
 
-var mu sync.Mutex
+const (
+	// DebugLevel emits verbose diagnostic information.
+	DebugLevel Level = iota
+	// InfoLevel captures standard operational events.
+	InfoLevel
+	// WarnLevel highlights anomalies that should be triaged.
+	WarnLevel
+	// ErrorLevel records failures that require immediate attention.
+	ErrorLevel
+)
 
-// log writes a structured JSON entry with level and message.
-func log(level, msg string, kv []interface{}) {
-	e := entry{
-		"level": level,
+// Settings configure a logger instance.
+type Settings struct {
+	Level         Level
+	Format        string
+	IncludeCaller bool
+	Writers       []io.Writer
+	StaticFields  map[string]any
+}
+
+// Logger emits structured log lines that align with the enterprise CLI and web dashboards.
+type Logger struct {
+	mu            sync.Mutex
+	level         Level
+	format        string
+	includeCaller bool
+	writers       []io.Writer
+	staticFields  map[string]any
+}
+
+var (
+	defaultLogger *Logger
+	once          sync.Once
+)
+
+// NewLogger creates a Logger from the supplied settings.
+func NewLogger(settings Settings) *Logger {
+	writers := settings.Writers
+	if len(writers) == 0 {
+		writers = []io.Writer{os.Stdout}
+	}
+	format := settings.Format
+	if format == "" {
+		format = "json"
+	}
+	return &Logger{
+		level:         settings.Level,
+		format:        strings.ToLower(format),
+		includeCaller: settings.IncludeCaller,
+		writers:       append([]io.Writer(nil), writers...),
+		staticFields:  copyMap(settings.StaticFields),
+	}
+}
+
+// Configure installs the global logger using the provided settings.
+func Configure(settings Settings) {
+	once.Do(func() {})
+	defaultLogger = NewLogger(settings)
+}
+
+// Default returns the process wide logger, initialising it if required.
+func Default() *Logger {
+	once.Do(func() {
+		defaultLogger = NewLogger(Settings{Level: InfoLevel, Format: "json", IncludeCaller: true})
+	})
+	return defaultLogger
+}
+
+// WithFields returns a derived logger with the provided fields attached to every event.
+func (l *Logger) WithFields(fields map[string]any) *Logger {
+	clone := *l
+	clone.staticFields = mergeMaps(l.staticFields, fields)
+	return &clone
+}
+
+// WithContext returns a derived logger enriched with trace identifiers from the context.
+func (l *Logger) WithContext(ctx context.Context) *Logger {
+	if ctx == nil {
+		return l
+	}
+	span := trace.SpanFromContext(ctx)
+	if !span.SpanContext().IsValid() {
+		return l
+	}
+	sc := span.SpanContext()
+	return l.WithFields(map[string]any{
+		"trace_id": sc.TraceID().String(),
+		"span_id":  sc.SpanID().String(),
+	})
+}
+
+// SetLevel updates the minimum severity level for the logger.
+func (l *Logger) SetLevel(level Level) { l.level = level }
+
+// Debug logs a debug level message.
+func (l *Logger) Debug(msg string, kv ...any) { l.log(DebugLevel, msg, kv...) }
+
+// Info logs an info level message.
+func (l *Logger) Info(msg string, kv ...any) { l.log(InfoLevel, msg, kv...) }
+
+// Warn logs a warning level message.
+func (l *Logger) Warn(msg string, kv ...any) { l.log(WarnLevel, msg, kv...) }
+
+// Error logs an error level message.
+func (l *Logger) Error(msg string, kv ...any) { l.log(ErrorLevel, msg, kv...) }
+
+func (l *Logger) log(level Level, msg string, kv ...any) {
+	if l == nil {
+		return
+	}
+	if level < l.level {
+		return
+	}
+	entry := map[string]any{
+		"level": levelString(level),
 		"msg":   msg,
 		"ts":    time.Now().UTC().Format(time.RFC3339Nano),
 	}
-	for i := 0; i+1 < len(kv); i += 2 {
-		key := fmt.Sprint(kv[i])
-		e[key] = kv[i+1]
+	for k, v := range l.staticFields {
+		entry[k] = v
 	}
-	b, err := json.Marshal(e)
-	if err != nil {
-		return
+	if l.includeCaller {
+		if pc, file, line, ok := runtime.Caller(2); ok {
+			fn := runtime.FuncForPC(pc)
+			entry["caller"] = fmt.Sprintf("%s:%d", trimPath(file), line)
+			if fn != nil {
+				entry["function"] = fn.Name()
+			}
+		}
 	}
-	mu.Lock()
-	defer mu.Unlock()
-	os.Stdout.Write(append(b, '\n'))
+	fields := kvToMap(kv)
+	for k, v := range fields {
+		entry[k] = v
+	}
+	l.write(entry)
 }
 
-// Info logs at info level.
-func Info(msg string, kv ...interface{}) { log("info", msg, kv) }
+func (l *Logger) write(entry map[string]any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
-// Error logs at error level.
-func Error(msg string, kv ...interface{}) { log("error", msg, kv) }
+	var payload []byte
+	switch l.format {
+	case "text":
+		payload = []byte(formatText(entry))
+	default:
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return
+		}
+		payload = append(data, '\n')
+	}
+
+	for _, w := range l.writers {
+		_, _ = w.Write(payload)
+	}
+}
+
+func levelString(level Level) string {
+	switch level {
+	case DebugLevel:
+		return "debug"
+	case InfoLevel:
+		return "info"
+	case WarnLevel:
+		return "warn"
+	default:
+		return "error"
+	}
+}
+
+func kvToMap(kv []any) map[string]any {
+	out := map[string]any{}
+	for i := 0; i < len(kv); i += 2 {
+		key := fmt.Sprint(kv[i])
+		var value any = "<missing>"
+		if i+1 < len(kv) {
+			value = kv[i+1]
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func copyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	cp := make(map[string]any, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}
+
+func mergeMaps(base, overlay map[string]any) map[string]any {
+	merged := copyMap(base)
+	if merged == nil {
+		merged = map[string]any{}
+	}
+	for k, v := range overlay {
+		merged[k] = v
+	}
+	return merged
+}
+
+func formatText(entry map[string]any) string {
+	timestamp := entry["ts"].(string)
+	level := entry["level"].(string)
+	msg := entry["msg"].(string)
+	delete(entry, "ts")
+	delete(entry, "level")
+	delete(entry, "msg")
+	builder := strings.Builder{}
+	builder.WriteString(timestamp)
+	builder.WriteString(" ")
+	builder.WriteString(level)
+	builder.WriteString(" ")
+	builder.WriteString(msg)
+	for k, v := range entry {
+		builder.WriteString(" ")
+		builder.WriteString(k)
+		builder.WriteString("=")
+		builder.WriteString(fmt.Sprint(v))
+	}
+	builder.WriteString("\n")
+	return builder.String()
+}
+
+func trimPath(path string) string {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
+}
+
+// Convenience helpers using the default logger -------------------------------------------------
+
+// Debug logs using the default logger.
+func Debug(msg string, kv ...any) { Default().Debug(msg, kv...) }
+
+// Info logs at info level using the default logger.
+func Info(msg string, kv ...any) { Default().Info(msg, kv...) }
+
+// Warn logs at warn level using the default logger.
+func Warn(msg string, kv ...any) { Default().Warn(msg, kv...) }
+
+// Error logs at error level using the default logger.
+func Error(msg string, kv ...any) { Default().Error(msg, kv...) }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,7 +1,76 @@
 package log
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
 
-func TestLogPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestLoggerWritesJSON(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	logger := NewLogger(Settings{Level: DebugLevel, Writers: []io.Writer{buf}, StaticFields: map[string]any{"service": "test"}})
+	logger.Info("component ready", "status", "ok")
+	if buf.Len() == 0 {
+		t.Fatalf("expected log output")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if payload["msg"] != "component ready" || payload["status"] != "ok" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if payload["service"] != "test" {
+		t.Fatalf("expected static field propagated")
+	}
+}
+
+func TestLoggerFiltersLevels(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	logger := NewLogger(Settings{Level: ErrorLevel, Writers: []io.Writer{buf}})
+	logger.Info("suppressed")
+	if buf.Len() != 0 {
+		t.Fatalf("expected info log suppressed at error level")
+	}
+}
+
+func TestLoggerIncludesTraceContext(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	logger := NewLogger(Settings{Level: DebugLevel, Writers: []io.Writer{buf}})
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: trace.TraceID{1}, SpanID: trace.SpanID{2}, TraceFlags: 1, Remote: false})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	logger.WithContext(ctx).Info("with trace")
+	if buf.Len() == 0 {
+		t.Fatalf("expected log output")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if payload["trace_id"] == nil || payload["span_id"] == nil {
+		t.Fatalf("expected trace context fields")
+	}
+}
+
+func TestLoggerTextFormat(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	logger := NewLogger(Settings{Level: InfoLevel, Format: "text", Writers: []io.Writer{buf}})
+	logger.Info("hello", "k", "v")
+	if !strings.Contains(buf.String(), "hello k=v") {
+		t.Fatalf("expected text formatted output, got %s", buf.String())
+	}
+}
+
+func TestDefaultLoggerSingleton(t *testing.T) {
+	Configure(Settings{Level: InfoLevel})
+	first := Default()
+	second := Default()
+	if first != second {
+		t.Fatalf("expected default logger singleton")
+	}
 }


### PR DESCRIPTION
## Summary
- expand the internal configuration schema with enterprise-ready sections, defaults, validation, and fingerprinting helpers
- implement structured logging with OTEL context support plus a signed, retention-aware governance audit log and replay protection callbacks
- refresh CLI bootstrap and documentation while marking Stage 86 complete in the tracker

## Testing
- `go test ./internal/config ./internal/errors ./internal/governance ./internal/log`
- `go test ./...` *(fails: existing cli tests reference missing stage73 helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d09cd0c9f48320b508aff0ae74949f