### PR TITLE
Stage 93 token suite hardening

### DIFF
--- a/cli/syn3400.go
+++ b/cli/syn3400.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
-        "fmt"
-        "strconv"
+	"fmt"
+	"strconv"
 
-        "github.com/spf13/cobra"
-        "synnergy/internal/tokens"
+	"github.com/spf13/cobra"
+	"synnergy/internal/tokens"
 )
 
 var forexRegistry = tokens.NewForexRegistry()
@@ -16,75 +16,78 @@ func init() {
 		Short: "Forex pair registry",
 	}
 
-        registerCmd := &cobra.Command{
-                Use:   "register",
-                Short: "Register a forex pair",
-                RunE: func(cmd *cobra.Command, args []string) error {
-                        base, _ := cmd.Flags().GetString("base")
-                        quote, _ := cmd.Flags().GetString("quote")
-                        rate, _ := cmd.Flags().GetFloat64("rate")
-                        if base == "" || quote == "" {
-                                return fmt.Errorf("base and quote are required")
-                        }
-                        if rate <= 0 {
-                                return fmt.Errorf("rate must be positive")
-                        }
-                        p := forexRegistry.Register(base, quote, rate)
-                        fmt.Fprintln(cmd.OutOrStdout(), p.PairID)
-                        return nil
-                },
-        }
-        registerCmd.Flags().String("base", "", "base currency")
-        registerCmd.Flags().String("quote", "", "quote currency")
-        registerCmd.Flags().Float64("rate", 0, "exchange rate")
-        registerCmd.MarkFlagRequired("base")
-        registerCmd.MarkFlagRequired("quote")
-        registerCmd.MarkFlagRequired("rate")
-        cmd.AddCommand(registerCmd)
+	registerCmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a forex pair",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			base, _ := cmd.Flags().GetString("base")
+			quote, _ := cmd.Flags().GetString("quote")
+			rate, _ := cmd.Flags().GetFloat64("rate")
+			if base == "" || quote == "" {
+				return fmt.Errorf("base and quote are required")
+			}
+			if rate <= 0 {
+				return fmt.Errorf("rate must be positive")
+			}
+			p, err := forexRegistry.Register(base, quote, rate)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), p.PairID)
+			return nil
+		},
+	}
+	registerCmd.Flags().String("base", "", "base currency")
+	registerCmd.Flags().String("quote", "", "quote currency")
+	registerCmd.Flags().Float64("rate", 0, "exchange rate")
+	registerCmd.MarkFlagRequired("base")
+	registerCmd.MarkFlagRequired("quote")
+	registerCmd.MarkFlagRequired("rate")
+	cmd.AddCommand(registerCmd)
 
-        updateCmd := &cobra.Command{
-                Use:   "update <id> <rate>",
-                Short: "Update exchange rate",
-                Args:  cobra.ExactArgs(2),
-                RunE: func(cmd *cobra.Command, args []string) error {
-                        r, err := strconv.ParseFloat(args[1], 64)
-                        if err != nil || r <= 0 {
-                                return fmt.Errorf("invalid rate")
-                        }
-                        if err := forexRegistry.UpdateRate(args[0], r); err != nil {
-                                return err
-                        }
-                        return nil
-                },
-        }
-        cmd.AddCommand(updateCmd)
+	updateCmd := &cobra.Command{
+		Use:   "update <id> <rate>",
+		Short: "Update exchange rate",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, err := strconv.ParseFloat(args[1], 64)
+			if err != nil || r <= 0 {
+				return fmt.Errorf("invalid rate")
+			}
+			if err := forexRegistry.UpdateRate(args[0], r); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(updateCmd)
 
-        getCmd := &cobra.Command{
-                Use:   "get <id>",
-                Short: "Get pair info",
-                Args:  cobra.ExactArgs(1),
-                RunE: func(cmd *cobra.Command, args []string) error {
-                        p, ok := forexRegistry.Get(args[0])
-                        if !ok {
-                                return fmt.Errorf("pair not found")
-                        }
-                        fmt.Fprintf(cmd.OutOrStdout(), "ID:%s %s/%s Rate:%f\n", p.PairID, p.Base, p.Quote, p.Rate)
-                        return nil
-                },
-        }
-        cmd.AddCommand(getCmd)
+	getCmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get pair info",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := forexRegistry.Get(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "ID:%s %s/%s Rate:%f\n", p.PairID, p.Base, p.Quote, p.Rate)
+			return nil
+		},
+	}
+	cmd.AddCommand(getCmd)
 
-        listCmd := &cobra.Command{
-                Use:   "list",
-                Short: "List forex pairs",
-                Run: func(cmd *cobra.Command, args []string) {
-                        pairs := forexRegistry.List()
-                        for _, p := range pairs {
-                                fmt.Fprintf(cmd.OutOrStdout(), "%s %s/%s %f\n", p.PairID, p.Base, p.Quote, p.Rate)
-                        }
-                },
-        }
-        cmd.AddCommand(listCmd)
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List forex pairs",
+		Run: func(cmd *cobra.Command, args []string) {
+			pairs := forexRegistry.List()
+			for _, p := range pairs {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s %s/%s %f\n", p.PairID, p.Base, p.Quote, p.Rate)
+			}
+		},
+	}
+	cmd.AddCommand(listCmd)
 
 	rootCmd.AddCommand(cmd)
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -10,6 +10,7 @@
 - Stage 73: Complete – enterprise index, grant, benefit, charity, legal and utility modules now require wallet-signed workflows, persist their state for CLI/web automation, expose telemetry across CLI, VM and web, and refreshed docs/guides capture the expanded gas/opcode catalogue.
 - Stage 74: In progress – system health logging clamped; tangible and agricultural asset registries made concurrency safe; access controller audit snapshots added. Transaction and SYN5000+ modules outstanding.
 - Stage 75: In progress – validator node supports concurrent joins; VM, wallet and cross-chain layers pending.
+- Stage 93: Complete – governance and financial token suites hardened with audited gas-safe flows, CLI alignment and dedicated tests.
 - Stage 136: Pending – security assessment and benchmark scaffolds reserved for final stage.
 
 **Stage 2**
@@ -2042,28 +2043,28 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 - [ ] internal/tokens/syn2600_test.go
 
 **Stage 93**
-- [ ] internal/tokens/syn2700.go
-- [ ] internal/tokens/syn2700_test.go
-- [ ] internal/tokens/syn2800.go
-- [ ] internal/tokens/syn2800_test.go
-- [ ] internal/tokens/syn2900.go
-- [ ] internal/tokens/syn2900_test.go
-- [ ] internal/tokens/syn300_token.go
-- [ ] internal/tokens/syn300_token_test.go
-- [ ] internal/tokens/syn3200.go
-- [ ] internal/tokens/syn3200_test.go
-- [ ] internal/tokens/syn3400.go
-- [ ] internal/tokens/syn3400_test.go
-- [ ] internal/tokens/syn3500_token.go
-- [ ] internal/tokens/syn3500_token_test.go
-- [ ] internal/tokens/syn3600.go
-- [ ] internal/tokens/syn3600_test.go
-- [ ] internal/tokens/syn3700_token.go
-- [ ] internal/tokens/syn3700_token_test.go
-- [ ] internal/tokens/syn3800.go
+- [x] internal/tokens/syn2700.go | dividend engine now enforces pro-rata rounding with audit history and holder lifecycle helpers
+- [x] internal/tokens/syn2700_test.go | verifies lifecycle validation, fair remainder distribution and concurrent snapshots
+- [x] internal/tokens/syn2800.go | life policy registry gains grace period controls, settlement tracking and stronger validation
+- [x] internal/tokens/syn2800_test.go | exercises premium flows, claim settlement and grace period handling
+- [x] internal/tokens/syn2900.go | general insurance registry now reserves coverage, tracks settlements and exposes exposure stats
+- [x] internal/tokens/syn2900_test.go | ensures premium validation, claim reservation and exhaustion workflows
+- [x] internal/tokens/syn300_token.go | governance token adds mint/burn/transfer, delegation-aware quorum with deadline enforcement
+- [x] internal/tokens/syn300_token_test.go | covers supply changes, delegation voting and executed proposal safeguards
+- [x] internal/tokens/syn3200.go | conversion module now uses rational math with exact snapshots and guarded ratio updates
+- [x] internal/tokens/syn3200_test.go | validates fractional ratio rounding and guard rails
+- [x] internal/tokens/syn3400.go | forex registry deduplicates pairs, supports symbol lookups and safe removals
+- [x] internal/tokens/syn3400_test.go | checks registration, updates, symbol queries and removal
+- [x] internal/tokens/syn3500_token.go | fiat token now tracks allowances, freezing, total supply and guarded transfers
+- [x] internal/tokens/syn3500_token_test.go | validates lifecycle, allowance spending and rate updates
+- [x] internal/tokens/syn3600.go | governance weights expose total accounting and top holder introspection
+- [x] internal/tokens/syn3600_test.go | verifies weight adjustments and ranking helpers
+- [x] internal/tokens/syn3700_token.go | index token supports component updates, normalization and contribution insights
+- [x] internal/tokens/syn3700_token_test.go | checks normalization, value breakdowns and removal errors
+- [x] internal/tokens/syn3800.go | capped token now surfaces cap controls, remaining capacity and defensive mint/burn checks
 
 **Stage 94**
-- [ ] internal/tokens/syn3800_test.go
+- [x] internal/tokens/syn3800_test.go | aligned with enhanced cap logic and error guards
 - [ ] internal/tokens/syn3900.go
 - [ ] internal/tokens/syn3900_test.go
 - [ ] internal/tokens/syn4200_token.go

--- a/internal/tokens/dao_tokens_test.go
+++ b/internal/tokens/dao_tokens_test.go
@@ -22,7 +22,10 @@ func TestSYN223TokenTransfer(t *testing.T) {
 func TestSYN300TokenGovernanceFlow(t *testing.T) {
 	tok := NewSYN300Token(map[string]uint64{"alice": 100, "bob": 50})
 	tok.Delegate("bob", "alice")
-	id := tok.CreateProposal("alice", "test proposal")
+	id, err := tok.CreateProposal("alice", "test proposal")
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
 	if err := tok.Vote(id, "alice", true); err != nil {
 		t.Fatalf("vote: %v", err)
 	}

--- a/internal/tokens/syn2700.go
+++ b/internal/tokens/syn2700.go
@@ -1,13 +1,46 @@
 package tokens
 
-import "sync"
+import (
+	"errors"
+	"math/big"
+	"sort"
+	"sync"
+	"time"
+)
+
+// ErrHolderNotFound is returned when the requested holder does not exist.
+var ErrHolderNotFound = errors.New("tokens: holder not found")
+
+// ErrInvalidAmount indicates that a provided amount is zero.
+var ErrInvalidAmount = errors.New("tokens: amount must be greater than zero")
+
+// ErrNoHolders is returned when an operation requires at least one registered holder.
+var ErrNoHolders = errors.New("tokens: no holders registered")
+
+// DividendResult captures the outcome of a dividend distribution including any
+// unallocated remainder caused by integer rounding.
+type DividendResult struct {
+	Amounts     map[string]uint64
+	Distributed uint64
+	Unallocated uint64
+	TotalSupply uint64
+}
+
+// DividendRecord stores a historical dividend distribution with the timestamp
+// of when it was calculated.
+type DividendRecord struct {
+	DividendResult
+	Timestamp time.Time
+}
 
 // SYN2700Token distributes dividends to registered holders based on their share
-// of the total supply. It is concurrency-safe for use by multiple goroutines.
+// of the total supply. It is concurrency-safe for use by multiple goroutines and
+// keeps an auditable ledger of dividend calculations.
 type SYN2700Token struct {
 	mu      sync.RWMutex
 	holders map[string]uint64
 	total   uint64
+	history []DividendRecord
 }
 
 // NewSYN2700Token initialises an empty dividend token.
@@ -16,26 +49,187 @@ func NewSYN2700Token() *SYN2700Token {
 }
 
 // AddHolder registers balance for an address. The total supply is increased
-// accordingly.
-func (t *SYN2700Token) AddHolder(addr string, amount uint64) {
+// accordingly. Zero amounts are rejected so upstream accounting mistakes do not
+// silently pass through.
+func (t *SYN2700Token) AddHolder(addr string, amount uint64) error {
+	if amount == 0 {
+		return ErrInvalidAmount
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.holders[addr] += amount
 	t.total += amount
+	return nil
+}
+
+// UpdateHolder sets the balance for a holder, adjusting the total supply to
+// reflect the new value.
+func (t *SYN2700Token) UpdateHolder(addr string, amount uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	current, ok := t.holders[addr]
+	if !ok {
+		return ErrHolderNotFound
+	}
+	t.holders[addr] = amount
+	if amount > current {
+		t.total += amount - current
+	} else {
+		t.total -= current - amount
+	}
+	return nil
+}
+
+// RemoveHolder removes a holder from the register.
+func (t *SYN2700Token) RemoveHolder(addr string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	bal, ok := t.holders[addr]
+	if !ok {
+		return ErrHolderNotFound
+	}
+	delete(t.holders, addr)
+	t.total -= bal
+	return nil
+}
+
+// HolderBalance returns the balance of an address and whether it exists.
+func (t *SYN2700Token) HolderBalance(addr string) (uint64, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	bal, ok := t.holders[addr]
+	return bal, ok
+}
+
+// TotalSupply returns the aggregate balance of all holders.
+func (t *SYN2700Token) TotalSupply() uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.total
+}
+
+// Snapshot returns a copy of the holders map for inspection or reporting.
+func (t *SYN2700Token) Snapshot() map[string]uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	cp := make(map[string]uint64, len(t.holders))
+	for addr, bal := range t.holders {
+		cp[addr] = bal
+	}
+	return cp
 }
 
 // Distribute splits the dividend across all holders proportionally and returns
-// the distribution map. The token state is not modified so callers can apply
-// transfers separately.
+// only the distribution map for backwards compatibility.
 func (t *SYN2700Token) Distribute(dividend uint64) map[string]uint64 {
+	res, _ := t.DistributeDetailed(dividend)
+	return res.Amounts
+}
+
+// DistributeDetailed performs a pro-rata distribution using the largest
+// remainder method to fairly allocate any remainder. The resulting allocation is
+// recorded in the internal history for auditability.
+func (t *SYN2700Token) DistributeDetailed(dividend uint64) (DividendResult, error) {
+	holders := t.Snapshot()
+	total := uint64(0)
+	for _, bal := range holders {
+		total += bal
+	}
+	if total == 0 {
+		return DividendResult{Amounts: map[string]uint64{}, Unallocated: dividend}, ErrNoHolders
+	}
+
+	allocations := make(map[string]uint64, len(holders))
+	type remainder struct {
+		addr      string
+		remainder uint64
+	}
+	remainders := make([]remainder, 0, len(holders))
+
+	divBig := new(big.Int).SetUint64(dividend)
+	totalBig := new(big.Int).SetUint64(total)
+
+	var distributed uint64
+	for addr, bal := range holders {
+		balBig := new(big.Int).SetUint64(bal)
+		product := new(big.Int).Mul(divBig, balBig)
+		quotient := new(big.Int)
+		rem := new(big.Int)
+		quotient.QuoRem(product, totalBig, rem)
+		amount := quotient.Uint64()
+		allocations[addr] = amount
+		distributed += amount
+		remainders = append(remainders, remainder{addr: addr, remainder: rem.Uint64()})
+	}
+
+	leftover := dividend - distributed
+	sort.SliceStable(remainders, func(i, j int) bool {
+		if remainders[i].remainder == remainders[j].remainder {
+			return remainders[i].addr < remainders[j].addr
+		}
+		return remainders[i].remainder > remainders[j].remainder
+	})
+
+	for i := 0; i < len(remainders) && leftover > 0; i++ {
+		if remainders[i].remainder == 0 {
+			break
+		}
+		allocations[remainders[i].addr]++
+		leftover--
+		distributed++
+	}
+
+	result := DividendResult{
+		Amounts:     allocations,
+		Distributed: distributed,
+		Unallocated: leftover,
+		TotalSupply: total,
+	}
+
+	record := DividendRecord{DividendResult: cloneDividendResult(result), Timestamp: time.Now()}
+	t.mu.Lock()
+	t.history = append(t.history, record)
+	t.mu.Unlock()
+
+	return result, nil
+}
+
+// History returns the most recent dividend records up to the specified limit.
+func (t *SYN2700Token) History(limit int) []DividendRecord {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	out := make(map[string]uint64)
-	if t.total == 0 {
-		return out
+	if limit <= 0 || limit > len(t.history) {
+		limit = len(t.history)
 	}
-	for addr, bal := range t.holders {
-		out[addr] = dividend * bal / t.total
+	res := make([]DividendRecord, limit)
+	for i := 0; i < limit; i++ {
+		res[i] = cloneDividendRecord(t.history[len(t.history)-1-i])
 	}
-	return out
+	return res
+}
+
+// Reset removes all holders and history.
+func (t *SYN2700Token) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.holders = make(map[string]uint64)
+	t.total = 0
+	t.history = nil
+}
+
+func cloneDividendResult(res DividendResult) DividendResult {
+	cp := make(map[string]uint64, len(res.Amounts))
+	for k, v := range res.Amounts {
+		cp[k] = v
+	}
+	res.Amounts = cp
+	return res
+}
+
+func cloneDividendRecord(rec DividendRecord) DividendRecord {
+	cloned := DividendRecord{
+		DividendResult: cloneDividendResult(rec.DividendResult),
+		Timestamp:      rec.Timestamp,
+	}
+	return cloned
 }

--- a/internal/tokens/syn2700_test.go
+++ b/internal/tokens/syn2700_test.go
@@ -1,7 +1,99 @@
 package tokens
 
-import "testing"
+import (
+	"sync"
+	"testing"
+	"time"
+)
 
-func TestSyn2700Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN2700Lifecycle(t *testing.T) {
+	tok := NewSYN2700Token()
+	if err := tok.AddHolder("alice", 0); err != ErrInvalidAmount {
+		t.Fatalf("expected ErrInvalidAmount, got %v", err)
+	}
+
+	if err := tok.AddHolder("alice", 40); err != nil {
+		t.Fatalf("add holder: %v", err)
+	}
+	if err := tok.AddHolder("bob", 60); err != nil {
+		t.Fatalf("add holder: %v", err)
+	}
+	if tok.TotalSupply() != 100 {
+		t.Fatalf("unexpected supply: %d", tok.TotalSupply())
+	}
+
+	if err := tok.UpdateHolder("alice", 25); err != nil {
+		t.Fatalf("update holder: %v", err)
+	}
+	if bal, ok := tok.HolderBalance("alice"); !ok || bal != 25 {
+		t.Fatalf("unexpected balance: %d %v", bal, ok)
+	}
+
+	if err := tok.RemoveHolder("carol"); err != ErrHolderNotFound {
+		t.Fatalf("expected ErrHolderNotFound, got %v", err)
+	}
+	if err := tok.RemoveHolder("alice"); err != nil {
+		t.Fatalf("remove holder: %v", err)
+	}
+	if _, ok := tok.HolderBalance("alice"); ok {
+		t.Fatal("alice should be removed")
+	}
+}
+
+func TestSYN2700DistributeDetailed(t *testing.T) {
+	tok := NewSYN2700Token()
+	must := func(err error) {
+		if err != nil {
+			t.Helper()
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	must(tok.AddHolder("alice", 10))
+	must(tok.AddHolder("bob", 10))
+	must(tok.AddHolder("carol", 10))
+
+	res, err := tok.DistributeDetailed(100)
+	if err != nil {
+		t.Fatalf("distribute detailed: %v", err)
+	}
+	if res.Unallocated != 0 || res.Distributed != 100 {
+		t.Fatalf("unexpected totals: %+v", res)
+	}
+	for _, addr := range []string{"alice", "bob", "carol"} {
+		if res.Amounts[addr] != 33 && res.Amounts[addr] != 34 {
+			t.Fatalf("unexpected allocation for %s: %d", addr, res.Amounts[addr])
+		}
+	}
+
+	history := tok.History(1)
+	if len(history) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(history))
+	}
+	if history[0].Distributed != 100 {
+		t.Fatalf("unexpected history distributed: %d", history[0].Distributed)
+	}
+}
+
+func TestSYN2700ConcurrentSnapshots(t *testing.T) {
+	tok := NewSYN2700Token()
+	must := func(err error) {
+		if err != nil {
+			t.Helper()
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	for i := 0; i < 10; i++ {
+		must(tok.AddHolder(time.Now().Add(time.Duration(i)*time.Millisecond).String(), 1))
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = tok.Snapshot()
+			_ = tok.TotalSupply()
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/tokens/syn2800_test.go
+++ b/internal/tokens/syn2800_test.go
@@ -1,7 +1,91 @@
 package tokens
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestSyn2800Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestLifePolicyRegistryLifecycle(t *testing.T) {
+	registry := NewLifePolicyRegistry()
+	start := time.Now().Add(2 * time.Hour)
+	end := start.Add(48 * time.Hour)
+
+	policy, err := registry.IssuePolicy("alice", "bob", 1_000, 100, start, end)
+	if err != nil {
+		t.Fatalf("issue policy: %v", err)
+	}
+	if policy.PolicyID == "" {
+		t.Fatalf("expected policy id")
+	}
+
+	if err := registry.PayPremium(policy.PolicyID, 0); err != ErrInvalidPremium {
+		t.Fatalf("expected ErrInvalidPremium, got %v", err)
+	}
+	if err := registry.PayPremium(policy.PolicyID, 200); err != nil {
+		t.Fatalf("pay premium: %v", err)
+	}
+
+	clone, ok := registry.GetPolicy(policy.PolicyID)
+	if !ok {
+		t.Fatalf("policy not retrievable")
+	}
+	if clone.PaidPremium != 200 {
+		t.Fatalf("expected paid premium 200, got %d", clone.PaidPremium)
+	}
+
+	if _, err := registry.FileClaim(policy.PolicyID, 2_000); err != ErrCoverageExceeded {
+		t.Fatalf("expected coverage exceeded, got %v", err)
+	}
+	claim, err := registry.FileClaim(policy.PolicyID, 400)
+	if err != nil {
+		t.Fatalf("file claim: %v", err)
+	}
+
+	if err := registry.SettleClaim(policy.PolicyID, claim.ClaimID); err != nil {
+		t.Fatalf("settle claim: %v", err)
+	}
+
+	// Settling the remaining coverage should deactivate the policy.
+	claim2, err := registry.FileClaim(policy.PolicyID, 600)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if err := registry.SettleClaim(policy.PolicyID, claim2.ClaimID); err != nil {
+		t.Fatalf("settle second claim: %v", err)
+	}
+	activePolicies := registry.ListActivePolicies(time.Now())
+	if len(activePolicies) != 0 {
+		t.Fatalf("expected policy to be inactive: %+v", activePolicies)
+	}
+
+	if err := registry.Deactivate(policy.PolicyID); err != nil {
+		t.Fatalf("deactivate policy: %v", err)
+	}
+	if err := registry.SettleClaim(policy.PolicyID, "unknown"); err != ErrClaimNotFound {
+		t.Fatalf("expected ErrClaimNotFound, got %v", err)
+	}
+}
+
+func TestLifePolicyGracePeriod(t *testing.T) {
+	registry := NewLifePolicyRegistry()
+	start := time.Now()
+	end := start.Add(24 * time.Hour)
+	registry.SetDefaultGrace(4 * time.Hour)
+	policy, err := registry.IssuePolicy("alice", "bob", 500, 50, start, end)
+	if err != nil {
+		t.Fatalf("issue policy: %v", err)
+	}
+
+	// No premium paid yet, still in grace period for 4 hours.
+	if !policy.InGracePeriod(start.Add(3 * time.Hour)) {
+		t.Fatalf("expected in grace period")
+	}
+
+	if err := registry.PayPremium(policy.PolicyID, 10); err != nil {
+		t.Fatalf("pay premium: %v", err)
+	}
+	updated, _ := registry.GetPolicy(policy.PolicyID)
+	if updated.LastPremium.Before(start) {
+		t.Fatalf("expected last premium to update")
+	}
 }

--- a/internal/tokens/syn2900_test.go
+++ b/internal/tokens/syn2900_test.go
@@ -1,7 +1,70 @@
 package tokens
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestSyn2900Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestInsuranceRegistryLifecycle(t *testing.T) {
+	registry := NewInsuranceRegistry()
+	start := time.Now().Add(time.Hour)
+	end := start.Add(72 * time.Hour)
+
+	policy, err := registry.IssuePolicy("alice", "property", 250, 5_000, 100, 10_000, start, end)
+	if err != nil {
+		t.Fatalf("issue policy: %v", err)
+	}
+	if policy.PolicyID == "" {
+		t.Fatalf("expected policy id")
+	}
+
+	if err := registry.PayPremium(policy.PolicyID, 0); err != ErrInsurancePremiumInvalid {
+		t.Fatalf("expected invalid premium error, got %v", err)
+	}
+	if err := registry.PayPremium(policy.PolicyID, 500); err != nil {
+		t.Fatalf("pay premium: %v", err)
+	}
+	clone, ok := registry.GetPolicy(policy.PolicyID)
+	if !ok {
+		t.Fatalf("policy not found")
+	}
+	if clone.PaidPremium != 500 {
+		t.Fatalf("expected paid premium 500, got %d", clone.PaidPremium)
+	}
+
+	if _, err := registry.FileClaim(policy.PolicyID, "fire", 20_000); err != ErrInsuranceLimitExceeded {
+		t.Fatalf("expected limit exceeded error, got %v", err)
+	}
+	claim, err := registry.FileClaim(policy.PolicyID, "fire", 4_000)
+	if err != nil {
+		t.Fatalf("file claim: %v", err)
+	}
+
+	exposure := registry.TotalExposure(time.Now())
+	if exposure != 6_000 {
+		t.Fatalf("expected exposure 6000, got %d", exposure)
+	}
+
+	if err := registry.SettleClaim(policy.PolicyID, claim.ClaimID); err != nil {
+		t.Fatalf("settle claim: %v", err)
+	}
+
+	claim2, err := registry.FileClaim(policy.PolicyID, "water", 6_000)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if err := registry.SettleClaim(policy.PolicyID, claim2.ClaimID); err != nil {
+		t.Fatalf("settle second claim: %v", err)
+	}
+	active := registry.ListActivePolicies(time.Now())
+	if len(active) != 0 {
+		t.Fatalf("policy should be inactive after settling limit")
+	}
+
+	if err := registry.Deactivate(policy.PolicyID); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	if err := registry.SettleClaim(policy.PolicyID, "unknown"); err != ErrInsuranceClaimNotFound {
+		t.Fatalf("expected claim not found error, got %v", err)
+	}
 }

--- a/internal/tokens/syn300_token_test.go
+++ b/internal/tokens/syn300_token_test.go
@@ -1,7 +1,68 @@
 package tokens
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestSyn300tokenPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN300TokenSupplyAndTransfer(t *testing.T) {
+	token := NewSYN300Token(map[string]uint64{"alice": 100})
+	if err := token.Mint("bob", 0); err != ErrInvalidAmount {
+		t.Fatalf("expected ErrInvalidAmount, got %v", err)
+	}
+	if err := token.Mint("bob", 50); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if token.TotalSupply() != 150 {
+		t.Fatalf("unexpected supply: %d", token.TotalSupply())
+	}
+	if err := token.Transfer("alice", "bob", 40); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if token.BalanceOf("alice") != 60 {
+		t.Fatalf("unexpected alice balance: %d", token.BalanceOf("alice"))
+	}
+	if err := token.Burn("bob", 10); err != nil {
+		t.Fatalf("burn: %v", err)
+	}
+	if token.TotalSupply() != 140 {
+		t.Fatalf("unexpected supply after burn: %d", token.TotalSupply())
+	}
+}
+
+func TestSYN300GovernanceLifecycle(t *testing.T) {
+	token := NewSYN300Token(map[string]uint64{"alice": 100})
+	if _, err := token.CreateProposalWithDeadline("carol", "unauthorised", time.Now().Add(time.Hour)); err != ErrNoVotingPower {
+		t.Fatalf("expected ErrNoVotingPower, got %v", err)
+	}
+	if _, err := token.CreateProposalWithDeadline("alice", "expired", time.Now().Add(-time.Hour)); err != ErrProposalExpired {
+		t.Fatalf("expected ErrProposalExpired, got %v", err)
+	}
+
+	id, err := token.CreateProposal("alice", "upgrade network")
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+	if err := token.Vote(id, "alice", true); err != nil {
+		t.Fatalf("vote: %v", err)
+	}
+	if err := token.Execute(id, 50); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if err := token.Vote(id, "alice", true); err != ErrProposalExecuted {
+		t.Fatalf("expected ErrProposalExecuted, got %v", err)
+	}
+
+	status, err := token.ProposalStatus(id)
+	if err != nil {
+		t.Fatalf("proposal status: %v", err)
+	}
+	if !status.Executed || status.ExecutedAt.IsZero() {
+		t.Fatalf("expected executed proposal")
+	}
+
+	proposals := token.ListProposals()
+	if len(proposals) != 1 || proposals[0].ID != id {
+		t.Fatalf("unexpected proposals list: %+v", proposals)
+	}
 }

--- a/internal/tokens/syn3200.go
+++ b/internal/tokens/syn3200.go
@@ -1,29 +1,86 @@
 package tokens
 
-import "sync"
+import (
+	"errors"
+	"math"
+	"math/big"
+	"sync"
+)
+
+var ErrInvalidRatio = errors.New("tokens: conversion ratio must be greater than zero")
 
 // SYN3200Token converts units using a configurable ratio. It can model
 // convertible assets such as wrapped tokens.
 type SYN3200Token struct {
 	mu    sync.RWMutex
-	ratio float64
+	ratio *big.Rat
 }
 
-// NewSYN3200Token creates a new converter with the given ratio.
+// NewSYN3200Token creates a new converter with the given ratio. If the ratio is
+// invalid the converter defaults to 1:1.
 func NewSYN3200Token(ratio float64) *SYN3200Token {
-	return &SYN3200Token{ratio: ratio}
+	tok := &SYN3200Token{ratio: big.NewRat(1, 1)}
+	_ = tok.SetRatio(ratio)
+	return tok
 }
 
-// Convert returns the amount multiplied by the current ratio.
+// Convert returns the amount multiplied by the current ratio rounded using
+// standard half-up rounding.
 func (t *SYN3200Token) Convert(amount uint64) uint64 {
+	exact := t.ConvertExact(amount)
+	num := new(big.Int).Set(exact.Num())
+	den := new(big.Int).Set(exact.Denom())
+	if den.Sign() == 0 {
+		return 0
+	}
+	quotient := new(big.Int)
+	remainder := new(big.Int)
+	quotient.QuoRem(num, den, remainder)
+	if remainder.Sign() != 0 {
+		doubled := new(big.Int).Lsh(remainder.Abs(remainder), 1)
+		if doubled.Cmp(den) >= 0 {
+			quotient.Add(quotient, big.NewInt(1))
+		}
+	}
+	return quotient.Uint64()
+}
+
+// ConvertExact returns the precise rational representation of the conversion.
+func (t *SYN3200Token) ConvertExact(amount uint64) *big.Rat {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return uint64(float64(amount) * t.ratio)
+	product := new(big.Rat).Mul(t.ratio, new(big.Rat).SetUint64(amount))
+	return new(big.Rat).Set(product)
 }
 
-// SetRatio updates the conversion ratio.
-func (t *SYN3200Token) SetRatio(r float64) {
+// Ratio returns a snapshot of the configured ratio.
+func (t *SYN3200Token) Ratio() *big.Rat {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return new(big.Rat).Set(t.ratio)
+}
+
+// SetRatio updates the conversion ratio using a floating point value.
+func (t *SYN3200Token) SetRatio(r float64) error {
+	if r <= 0 || math.IsNaN(r) || math.IsInf(r, 0) {
+		return ErrInvalidRatio
+	}
+	rat := new(big.Rat)
+	rat.SetFloat64(r)
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.ratio = r
+	t.ratio = rat
+	return nil
+}
+
+// SetRatioFraction updates the ratio using a numerator and denominator.
+func (t *SYN3200Token) SetRatioFraction(numerator, denominator uint64) error {
+	if denominator == 0 {
+		return ErrInvalidRatio
+	}
+	rat := new(big.Rat).SetFrac(new(big.Int).SetUint64(numerator), new(big.Int).SetUint64(denominator))
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ratio = rat
+	return nil
 }

--- a/internal/tokens/syn3200_test.go
+++ b/internal/tokens/syn3200_test.go
@@ -1,7 +1,38 @@
 package tokens
 
-import "testing"
+import (
+	"math/big"
+	"testing"
+)
 
-func TestSyn3200Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN3200Conversion(t *testing.T) {
+	tok := NewSYN3200Token(1.5)
+	if err := tok.SetRatio(2.0); err != nil {
+		t.Fatalf("set ratio: %v", err)
+	}
+	if v := tok.Convert(5); v != 10 {
+		t.Fatalf("unexpected conversion result: %d", v)
+	}
+	exact := tok.ConvertExact(3)
+	expected := big.NewRat(6, 1)
+	if exact.Cmp(expected) != 0 {
+		t.Fatalf("expected exact 6, got %s", exact)
+	}
+}
+
+func TestSYN3200SetRatioFraction(t *testing.T) {
+	tok := NewSYN3200Token(0)
+	if err := tok.SetRatioFraction(3, 2); err != nil {
+		t.Fatalf("set ratio fraction: %v", err)
+	}
+	if v := tok.Convert(4); v != 6 {
+		t.Fatalf("expected rounded result 6, got %d", v)
+	}
+	ratio := tok.Ratio()
+	if ratio.Cmp(big.NewRat(3, 2)) != 0 {
+		t.Fatalf("unexpected ratio %s", ratio)
+	}
+	if err := tok.SetRatioFraction(1, 0); err != ErrInvalidRatio {
+		t.Fatalf("expected ErrInvalidRatio, got %v", err)
+	}
 }

--- a/internal/tokens/syn3400.go
+++ b/internal/tokens/syn3400.go
@@ -3,11 +3,17 @@ package tokens
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
 
-// ForexMetadata defines pair specific information for SYN3400 tokens.
+var (
+	ErrForexPairNotFound = errors.New("tokens: forex pair not found")
+	ErrInvalidForexRate  = errors.New("tokens: forex rate must be positive")
+)
+
+// ForexPair defines pair specific information for SYN3400 tokens.
 type ForexPair struct {
 	PairID    string
 	Base      string
@@ -18,34 +24,55 @@ type ForexPair struct {
 
 // ForexRegistry tracks registered Forex pairs.
 type ForexRegistry struct {
-	mu      sync.RWMutex
-	pairs   map[string]*ForexPair
-	counter uint64
+	mu       sync.RWMutex
+	pairs    map[string]*ForexPair
+	bySymbol map[string]string
+	counter  uint64
 }
 
 // NewForexRegistry creates an empty registry.
 func NewForexRegistry() *ForexRegistry {
-	return &ForexRegistry{pairs: make(map[string]*ForexPair)}
+	return &ForexRegistry{pairs: make(map[string]*ForexPair), bySymbol: make(map[string]string)}
+}
+
+func key(base, quote string) string {
+	return fmt.Sprintf("%s-%s", base, quote)
 }
 
 // Register adds a new forex pair to the registry.
-func (r *ForexRegistry) Register(base, quote string, rate float64) *ForexPair {
+func (r *ForexRegistry) Register(base, quote string, rate float64) (*ForexPair, error) {
+	if base == "" || quote == "" {
+		return nil, errors.New("base and quote required")
+	}
+	if rate <= 0 {
+		return nil, ErrInvalidForexRate
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if existingID, ok := r.bySymbol[key(base, quote)]; ok {
+		pair := r.pairs[existingID]
+		pair.Rate = rate
+		pair.UpdatedAt = time.Now()
+		return cloneForexPair(pair), nil
+	}
 	r.counter++
 	id := fmt.Sprintf("FX-%d", r.counter)
 	p := &ForexPair{PairID: id, Base: base, Quote: quote, Rate: rate, UpdatedAt: time.Now()}
 	r.pairs[id] = p
-	return p
+	r.bySymbol[key(base, quote)] = id
+	return cloneForexPair(p), nil
 }
 
 // UpdateRate updates the exchange rate for a pair.
 func (r *ForexRegistry) UpdateRate(pairID string, rate float64) error {
+	if rate <= 0 {
+		return ErrInvalidForexRate
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	p, ok := r.pairs[pairID]
 	if !ok {
-		return errors.New("pair not found")
+		return ErrForexPairNotFound
 	}
 	p.Rate = rate
 	p.UpdatedAt = time.Now()
@@ -53,25 +80,53 @@ func (r *ForexRegistry) UpdateRate(pairID string, rate float64) error {
 }
 
 // Get retrieves a forex pair by ID.
-func (r *ForexRegistry) Get(pairID string) (*ForexPair, bool) {
+func (r *ForexRegistry) Get(pairID string) (*ForexPair, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	p, ok := r.pairs[pairID]
 	if !ok {
-		return nil, false
+		return nil, ErrForexPairNotFound
 	}
-	cp := *p
-	return &cp, true
+	return cloneForexPair(p), nil
 }
 
-// List returns all registered forex pairs.
+// GetBySymbol retrieves a pair by base and quote symbols.
+func (r *ForexRegistry) GetBySymbol(base, quote string) (*ForexPair, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	id, ok := r.bySymbol[key(base, quote)]
+	if !ok {
+		return nil, ErrForexPairNotFound
+	}
+	return cloneForexPair(r.pairs[id]), nil
+}
+
+// List returns all registered forex pairs sorted by identifier.
 func (r *ForexRegistry) List() []*ForexPair {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	res := make([]*ForexPair, 0, len(r.pairs))
 	for _, p := range r.pairs {
-		cp := *p
-		res = append(res, &cp)
+		res = append(res, cloneForexPair(p))
 	}
+	sort.Slice(res, func(i, j int) bool { return res[i].PairID < res[j].PairID })
 	return res
+}
+
+// Remove deletes a pair from the registry.
+func (r *ForexRegistry) Remove(pairID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.pairs[pairID]
+	if !ok {
+		return ErrForexPairNotFound
+	}
+	delete(r.pairs, pairID)
+	delete(r.bySymbol, key(p.Base, p.Quote))
+	return nil
+}
+
+func cloneForexPair(p *ForexPair) *ForexPair {
+	cp := *p
+	return &cp
 }

--- a/internal/tokens/syn3400_test.go
+++ b/internal/tokens/syn3400_test.go
@@ -1,7 +1,46 @@
 package tokens
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestSyn3400Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestForexRegistryLifecycle(t *testing.T) {
+	reg := NewForexRegistry()
+	pair, err := reg.Register("USD", "EUR", 0.9)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if _, err := reg.Register("", "EUR", 1); err == nil {
+		t.Fatalf("expected validation error for empty base")
+	}
+	fetched, err := reg.Get(pair.PairID)
+	if err != nil {
+		t.Fatalf("get pair: %v", err)
+	}
+	if fetched.Rate != 0.9 {
+		t.Fatalf("unexpected rate: %f", fetched.Rate)
+	}
+	if err := reg.UpdateRate(pair.PairID, 0); err != ErrInvalidForexRate {
+		t.Fatalf("expected invalid rate error, got %v", err)
+	}
+	if err := reg.UpdateRate(pair.PairID, 0.95); err != nil {
+		t.Fatalf("update rate: %v", err)
+	}
+	symbolPair, err := reg.GetBySymbol("USD", "EUR")
+	if err != nil {
+		t.Fatalf("get by symbol: %v", err)
+	}
+	if symbolPair.Rate != 0.95 {
+		t.Fatalf("unexpected symbol rate: %f", symbolPair.Rate)
+	}
+	list := reg.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(list))
+	}
+	if err := reg.Remove(pair.PairID); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := reg.Get(pair.PairID); err != ErrForexPairNotFound {
+		t.Fatalf("expected pair not found, got %v", err)
+	}
 }

--- a/internal/tokens/syn3500_token.go
+++ b/internal/tokens/syn3500_token.go
@@ -5,32 +5,43 @@ import (
 	"sync"
 )
 
+var ErrAccountFrozen = errors.New("tokens: account is frozen")
+
 // SYN3500Token represents a currency or stablecoin token.
 type SYN3500Token struct {
-	mu       sync.RWMutex
-	Name     string
-	Symbol   string
-	Issuer   string
-	Rate     float64
-	Balances map[string]uint64
+	mu         sync.RWMutex
+	Name       string
+	Symbol     string
+	Issuer     string
+	Rate       float64
+	Balances   map[string]uint64
+	allowances map[string]map[string]uint64
+	frozen     map[string]bool
+	total      uint64
 }
 
 // NewSYN3500Token creates a new currency token instance.
 func NewSYN3500Token(name, symbol, issuer string, rate float64) *SYN3500Token {
 	return &SYN3500Token{
-		Name:     name,
-		Symbol:   symbol,
-		Issuer:   issuer,
-		Rate:     rate,
-		Balances: make(map[string]uint64),
+		Name:       name,
+		Symbol:     symbol,
+		Issuer:     issuer,
+		Rate:       rate,
+		Balances:   make(map[string]uint64),
+		allowances: make(map[string]map[string]uint64),
+		frozen:     make(map[string]bool),
 	}
 }
 
 // SetRate updates the fiat exchange rate of the token.
-func (t *SYN3500Token) SetRate(rate float64) {
+func (t *SYN3500Token) SetRate(rate float64) error {
+	if rate <= 0 {
+		return ErrInvalidForexRate
+	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.Rate = rate
-	t.mu.Unlock()
+	return nil
 }
 
 // Info returns token symbol, issuer and current rate.
@@ -41,21 +52,97 @@ func (t *SYN3500Token) Info() (string, string, float64) {
 }
 
 // Mint creates new tokens for the specified address.
-func (t *SYN3500Token) Mint(to string, amt uint64) {
+func (t *SYN3500Token) Mint(to string, amt uint64) error {
+	if amt == 0 {
+		return ErrInvalidAmount
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.frozen[to] {
+		return ErrAccountFrozen
+	}
 	t.Balances[to] += amt
+	t.total += amt
+	return nil
 }
 
 // Redeem removes tokens from circulation for the given address.
 func (t *SYN3500Token) Redeem(from string, amt uint64) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.frozen[from] {
+		return ErrAccountFrozen
+	}
 	bal := t.Balances[from]
 	if bal < amt {
-		return errors.New("insufficient balance")
+		return ErrInsufficientBalance
 	}
 	t.Balances[from] = bal - amt
+	t.total -= amt
+	return nil
+}
+
+// Transfer moves tokens between accounts respecting freeze status.
+func (t *SYN3500Token) Transfer(from, to string, amt uint64) error {
+	if amt == 0 {
+		return ErrInvalidAmount
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.frozen[from] || t.frozen[to] {
+		return ErrAccountFrozen
+	}
+	bal := t.Balances[from]
+	if bal < amt {
+		return ErrInsufficientBalance
+	}
+	t.Balances[from] = bal - amt
+	t.Balances[to] += amt
+	return nil
+}
+
+// Approve allows the spender to transfer up to amt from the owner's account.
+func (t *SYN3500Token) Approve(owner, spender string, amt uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.frozen[owner] {
+		return ErrAccountFrozen
+	}
+	if _, ok := t.allowances[owner]; !ok {
+		t.allowances[owner] = make(map[string]uint64)
+	}
+	t.allowances[owner][spender] = amt
+	return nil
+}
+
+// Allowance returns the approved spending limit for a spender.
+func (t *SYN3500Token) Allowance(owner, spender string) uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.allowances[owner][spender]
+}
+
+// TransferFrom spends the allowance and moves funds to the recipient.
+func (t *SYN3500Token) TransferFrom(owner, spender, to string, amt uint64) error {
+	if amt == 0 {
+		return ErrInvalidAmount
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.frozen[owner] || t.frozen[to] {
+		return ErrAccountFrozen
+	}
+	allowed := t.allowances[owner][spender]
+	if allowed < amt {
+		return ErrInsufficientBalance
+	}
+	bal := t.Balances[owner]
+	if bal < amt {
+		return ErrInsufficientBalance
+	}
+	t.allowances[owner][spender] = allowed - amt
+	t.Balances[owner] = bal - amt
+	t.Balances[to] += amt
 	return nil
 }
 
@@ -64,4 +151,32 @@ func (t *SYN3500Token) BalanceOf(addr string) uint64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.Balances[addr]
+}
+
+// TotalSupply returns the total supply.
+func (t *SYN3500Token) TotalSupply() uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.total
+}
+
+// FreezeAccount prevents transfers to or from the address.
+func (t *SYN3500Token) FreezeAccount(addr string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.frozen[addr] = true
+}
+
+// UnfreezeAccount removes the freeze restriction.
+func (t *SYN3500Token) UnfreezeAccount(addr string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.frozen, addr)
+}
+
+// IsFrozen reports whether an account is currently frozen.
+func (t *SYN3500Token) IsFrozen(addr string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.frozen[addr]
 }

--- a/internal/tokens/syn3500_token_test.go
+++ b/internal/tokens/syn3500_token_test.go
@@ -2,6 +2,55 @@ package tokens
 
 import "testing"
 
-func TestSyn3500tokenPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN3500TokenLifecycle(t *testing.T) {
+	token := NewSYN3500Token("SynStable", "SYNUSD", "Synnergy", 1.0)
+	if err := token.Mint("alice", 0); err != ErrInvalidAmount {
+		t.Fatalf("expected ErrInvalidAmount, got %v", err)
+	}
+	if err := token.Mint("alice", 100); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if err := token.Transfer("alice", "bob", 50); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if token.BalanceOf("alice") != 50 || token.BalanceOf("bob") != 50 {
+		t.Fatalf("unexpected balances: alice %d bob %d", token.BalanceOf("alice"), token.BalanceOf("bob"))
+	}
+	if err := token.Approve("alice", "bob", 20); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if token.Allowance("alice", "bob") != 20 {
+		t.Fatalf("unexpected allowance: %d", token.Allowance("alice", "bob"))
+	}
+	if err := token.TransferFrom("alice", "bob", "carol", 15); err != nil {
+		t.Fatalf("transferFrom: %v", err)
+	}
+	if token.BalanceOf("carol") != 15 {
+		t.Fatalf("unexpected carol balance: %d", token.BalanceOf("carol"))
+	}
+	token.FreezeAccount("alice")
+	if err := token.Transfer("alice", "bob", 1); err != ErrAccountFrozen {
+		t.Fatalf("expected ErrAccountFrozen, got %v", err)
+	}
+	token.UnfreezeAccount("alice")
+	if err := token.Redeem("alice", 10); err != nil {
+		t.Fatalf("redeem: %v", err)
+	}
+	if token.TotalSupply() != 90 {
+		t.Fatalf("unexpected total supply: %d", token.TotalSupply())
+	}
+}
+
+func TestSYN3500SetRate(t *testing.T) {
+	token := NewSYN3500Token("SynStable", "SYNUSD", "Synnergy", 1.0)
+	if err := token.SetRate(0); err != ErrInvalidForexRate {
+		t.Fatalf("expected ErrInvalidForexRate, got %v", err)
+	}
+	if err := token.SetRate(1.05); err != nil {
+		t.Fatalf("set rate: %v", err)
+	}
+	_, _, rate := token.Info()
+	if rate != 1.05 {
+		t.Fatalf("unexpected rate %f", rate)
+	}
 }

--- a/internal/tokens/syn3600.go
+++ b/internal/tokens/syn3600.go
@@ -1,11 +1,18 @@
 package tokens
 
-import "sync"
+import (
+	"errors"
+	"sort"
+	"sync"
+)
+
+var ErrWeightTooLow = errors.New("tokens: weight would underflow")
 
 // SYN3600Token stores governance weights for addresses.
 type SYN3600Token struct {
 	mu      sync.RWMutex
 	weights map[string]uint64
+	total   uint64
 }
 
 // NewSYN3600Token creates an empty governance weight ledger.
@@ -17,7 +24,34 @@ func NewSYN3600Token() *SYN3600Token {
 func (t *SYN3600Token) SetWeight(addr string, w uint64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	prev := t.weights[addr]
 	t.weights[addr] = w
+	if w >= prev {
+		t.total += w - prev
+	} else {
+		t.total -= prev - w
+	}
+}
+
+// IncreaseWeight increments the weight for an address.
+func (t *SYN3600Token) IncreaseWeight(addr string, delta uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.weights[addr] += delta
+	t.total += delta
+}
+
+// DecreaseWeight reduces the weight for an address.
+func (t *SYN3600Token) DecreaseWeight(addr string, delta uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	current := t.weights[addr]
+	if current < delta {
+		return ErrWeightTooLow
+	}
+	t.weights[addr] = current - delta
+	t.total -= delta
+	return nil
 }
 
 // Weight returns the voting weight of an address.
@@ -25,4 +59,50 @@ func (t *SYN3600Token) Weight(addr string) uint64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.weights[addr]
+}
+
+// TotalWeight returns the sum of all weights.
+func (t *SYN3600Token) TotalWeight() uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.total
+}
+
+// Snapshot returns a copy of the weight map.
+func (t *SYN3600Token) Snapshot() map[string]uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	cp := make(map[string]uint64, len(t.weights))
+	for addr, w := range t.weights {
+		cp[addr] = w
+	}
+	return cp
+}
+
+// TopHolders returns the top n addresses by weight.
+func (t *SYN3600Token) TopHolders(n int) []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	type kv struct {
+		addr   string
+		weight uint64
+	}
+	arr := make([]kv, 0, len(t.weights))
+	for addr, w := range t.weights {
+		arr = append(arr, kv{addr: addr, weight: w})
+	}
+	sort.Slice(arr, func(i, j int) bool {
+		if arr[i].weight == arr[j].weight {
+			return arr[i].addr < arr[j].addr
+		}
+		return arr[i].weight > arr[j].weight
+	})
+	if n <= 0 || n > len(arr) {
+		n = len(arr)
+	}
+	res := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		res = append(res, arr[i].addr)
+	}
+	return res
 }

--- a/internal/tokens/syn3600_test.go
+++ b/internal/tokens/syn3600_test.go
@@ -2,6 +2,24 @@ package tokens
 
 import "testing"
 
-func TestSyn3600Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN3600Weights(t *testing.T) {
+	token := NewSYN3600Token()
+	token.SetWeight("alice", 10)
+	token.IncreaseWeight("bob", 20)
+	if err := token.DecreaseWeight("bob", 5); err != nil {
+		t.Fatalf("decrease weight: %v", err)
+	}
+	if err := token.DecreaseWeight("alice", 20); err != ErrWeightTooLow {
+		t.Fatalf("expected ErrWeightTooLow, got %v", err)
+	}
+	if token.Weight("bob") != 15 {
+		t.Fatalf("unexpected bob weight: %d", token.Weight("bob"))
+	}
+	if token.TotalWeight() != 25 {
+		t.Fatalf("unexpected total weight: %d", token.TotalWeight())
+	}
+	top := token.TopHolders(1)
+	if len(top) != 1 || top[0] != "bob" {
+		t.Fatalf("unexpected top holder: %v", top)
+	}
 }

--- a/internal/tokens/syn3700_token.go
+++ b/internal/tokens/syn3700_token.go
@@ -2,7 +2,13 @@ package tokens
 
 import (
 	"errors"
+	"sort"
 	"sync"
+)
+
+var (
+	ErrComponentNotFound = errors.New("tokens: component not found")
+	ErrMissingPrice      = errors.New("tokens: price missing for component")
 )
 
 // IndexComponent defines a single asset within an index token.
@@ -25,10 +31,30 @@ func NewSYN3700Token(name, symbol string) *SYN3700Token {
 }
 
 // AddComponent adds an asset and its weight to the index.
-func (t *SYN3700Token) AddComponent(token string, weight float64) {
+func (t *SYN3700Token) AddComponent(token string, weight float64) error {
+	if weight < 0 {
+		return ErrInvalidAmount
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.Components = append(t.Components, IndexComponent{Token: token, Weight: weight})
+	return nil
+}
+
+// UpdateComponent updates the weight for an existing component.
+func (t *SYN3700Token) UpdateComponent(token string, weight float64) error {
+	if weight < 0 {
+		return ErrInvalidAmount
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i, c := range t.Components {
+		if c.Token == token {
+			t.Components[i].Weight = weight
+			return nil
+		}
+	}
+	return ErrComponentNotFound
 }
 
 // RemoveComponent removes an asset from the index by token symbol.
@@ -41,7 +67,7 @@ func (t *SYN3700Token) RemoveComponent(token string) error {
 			return nil
 		}
 	}
-	return errors.New("component not found")
+	return ErrComponentNotFound
 }
 
 // ListComponents returns a snapshot of the current index components.
@@ -50,17 +76,61 @@ func (t *SYN3700Token) ListComponents() []IndexComponent {
 	defer t.mu.RUnlock()
 	comps := make([]IndexComponent, len(t.Components))
 	copy(comps, t.Components)
+	sort.Slice(comps, func(i, j int) bool { return comps[i].Token < comps[j].Token })
 	return comps
+}
+
+// NormalizeWeights scales the weights so that they sum to 1.
+func (t *SYN3700Token) NormalizeWeights() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var sum float64
+	for _, c := range t.Components {
+		sum += c.Weight
+	}
+	if sum == 0 {
+		return
+	}
+	for i := range t.Components {
+		t.Components[i].Weight = t.Components[i].Weight / sum
+	}
+}
+
+// ComponentWeight returns the weight for a token.
+func (t *SYN3700Token) ComponentWeight(token string) (float64, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for _, c := range t.Components {
+		if c.Token == token {
+			return c.Weight, nil
+		}
+	}
+	return 0, ErrComponentNotFound
 }
 
 // Value computes the weighted index value using the provided price map.
 func (t *SYN3700Token) Value(prices map[string]float64) float64 {
+	value, _, err := t.ValueDetailed(prices)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+// ValueDetailed returns the index value plus per-component contributions.
+func (t *SYN3700Token) ValueDetailed(prices map[string]float64) (float64, map[string]float64, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
+	contributions := make(map[string]float64, len(t.Components))
 	var sum float64
 	for _, c := range t.Components {
-		price := prices[c.Token]
-		sum += price * c.Weight
+		price, ok := prices[c.Token]
+		if !ok {
+			return 0, nil, ErrMissingPrice
+		}
+		contrib := price * c.Weight
+		contributions[c.Token] = contrib
+		sum += contrib
 	}
-	return sum
+	return sum, contributions, nil
 }

--- a/internal/tokens/syn3700_token_test.go
+++ b/internal/tokens/syn3700_token_test.go
@@ -2,6 +2,43 @@ package tokens
 
 import "testing"
 
-func TestSyn3700tokenPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN3700IndexOperations(t *testing.T) {
+	token := NewSYN3700Token("Syn Index", "SYNX")
+	if err := token.AddComponent("SYN", 0.5); err != nil {
+		t.Fatalf("add component: %v", err)
+	}
+	if err := token.AddComponent("BTC", 0.3); err != nil {
+		t.Fatalf("add component: %v", err)
+	}
+	if err := token.UpdateComponent("BTC", 0.4); err != nil {
+		t.Fatalf("update component: %v", err)
+	}
+	token.NormalizeWeights()
+	weight, err := token.ComponentWeight("BTC")
+	if err != nil {
+		t.Fatalf("component weight: %v", err)
+	}
+	if weight <= 0 {
+		t.Fatalf("expected positive weight")
+	}
+	prices := map[string]float64{"SYN": 2, "BTC": 10}
+	value, contributions, err := token.ValueDetailed(prices)
+	if err != nil {
+		t.Fatalf("value detailed: %v", err)
+	}
+	if value <= 0 {
+		t.Fatalf("expected positive value")
+	}
+	if _, ok := contributions["BTC"]; !ok {
+		t.Fatalf("expected BTC contribution")
+	}
+	if err := token.RemoveComponent("SYN"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := token.ComponentWeight("SYN"); err != ErrComponentNotFound {
+		t.Fatalf("expected ErrComponentNotFound, got %v", err)
+	}
+	if _, _, err := token.ValueDetailed(map[string]float64{"BTC": 10}); err != nil {
+		t.Fatalf("value detailed after removal: %v", err)
+	}
 }

--- a/internal/tokens/syn3800_test.go
+++ b/internal/tokens/syn3800_test.go
@@ -2,6 +2,33 @@ package tokens
 
 import "testing"
 
-func TestSyn3800Placeholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestSYN3800TokenLifecycle(t *testing.T) {
+	tok := NewSYN3800Token(100)
+	if err := tok.Mint(0); err != ErrInvalidAmount {
+		t.Fatalf("expected ErrInvalidAmount, got %v", err)
+	}
+	if err := tok.Mint(80); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if tok.Supply() != 80 || tok.Remaining() != 20 {
+		t.Fatalf("unexpected state supply %d remaining %d", tok.Supply(), tok.Remaining())
+	}
+	if err := tok.Mint(30); err != ErrCapExceeded {
+		t.Fatalf("expected ErrCapExceeded, got %v", err)
+	}
+	if err := tok.SetCap(60); err != ErrCapExceeded {
+		t.Fatalf("expected ErrCapExceeded on lowering cap, got %v", err)
+	}
+	if err := tok.SetCap(120); err != nil {
+		t.Fatalf("set cap: %v", err)
+	}
+	if err := tok.Burn(90); err != ErrInsufficientSupply {
+		t.Fatalf("expected ErrInsufficientSupply, got %v", err)
+	}
+	if err := tok.Burn(50); err != nil {
+		t.Fatalf("burn: %v", err)
+	}
+	if tok.Supply() != 30 {
+		t.Fatalf("unexpected supply %d", tok.Supply())
+	}
 }


### PR DESCRIPTION
## Summary
- Hardened the Stage 93 token modules by adding audited dividend tracking, life and insurance policy safety checks, governance mint/burn flows, rational converters, forex registry deduplication, fiat safeguards, weight accounting, and capped supply controls.【F:internal/tokens/syn2700.go†L11-L195】【F:internal/tokens/syn2800.go†L10-L176】【F:internal/tokens/syn300_token.go†L10-L200】【F:internal/tokens/syn3400.go†L11-L127】【F:internal/tokens/syn3500_token.go†L1-L122】【F:internal/tokens/syn3800.go†L1-L53】
- Expanded the accompanying test suite to cover lifecycle validation, settlement flows, governance execution, and other behavioural regressions introduced in the upgrade.【F:internal/tokens/syn2700_test.go†L1-L99】【F:internal/tokens/syn2800_test.go†L1-L91】【F:internal/tokens/syn300_token_test.go†L1-L68】
- Aligned the CLI forex commands with the new registry API and marked Stage 93 complete in the tracker with detailed status notes.【F:cli/syn3400.go†L11-L92】【F:docs/AGENTS.md†L5-L14】【F:docs/AGENTS.md†L2045-L2067】

## Testing
- `go test ./internal/tokens`
- `go test ./cli` *(fails: Stage 73 helper utilities referenced by other CLI suites remain undefined in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d09d9c683083209de6eb5c29c7cf34