### PR TITLE
Stage 75: harden warfare/watchtower zero-trust flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Synnergy is a modular, high-performance blockchain written in Go and built for e
 - **Storage marketplace & analytics dashboards** – TypeScript modules exposing CLI and GUI entrypoints for decentralised storage and system metrics.
 - **Infrastructure-as-code** – Dockerfiles, Helm charts, Terraform and Ansible playbooks for reproducible environments.
 - **Strong encryption and signatures** – all transactions and messages are secured using well‑vetted cryptography with digital signatures.
+- **Stage 75 enterprise runtime** – deterministic VM gas enforcement with execution traces, sandbox telemetry for fault-tolerant VM pools, wallets with deterministic seeds and shared-secret support, and event-driven cross-chain registries/bridges that stream lifecycle updates to CLI and web dashboards.
 - **Permissioned privacy** – fine‑grained access controls enable private channels and selective data disclosure.
 - **Customisable governance** – token‑weighted voting and DAO modules allow on‑chain policy definition.
 - **Horizontal scalability** – sharding-ready architecture and multi‑node orchestration for high throughput networks.
@@ -100,6 +101,17 @@ pkg/          Reusable libraries and experimental modules
    - Wallet, watchtower and warfare nodes (`core.NewWallet`, `core.NewWatchtowerNode`, `core.NewWarfareNode`)
    - Token constructors in `internal/tokens` (`tokens.NewSYN223Token`, etc.)
 7. Finally, invoke `cli.Execute()` to dispatch Cobra commands.
+
+Enterprise deployments rely on the defensive modules initialised above:
+
+- **Warfare node telemetry** – `core.NewWarfareNode` now issues per-commander key pairs, enforces signed command envelopes with
+  replay protection, and streams logistics/tactical events to both CLI (`synnergy warfare events`) and the web console.
+- **Watchtower observability** – `core.NewWatchtowerNode` emits start/stop/fork alerts alongside periodic metric snapshots via
+  `Watchtower.SubscribeEvents`, enabling dashboards and the `synnergy monitoring` suite to visualise consensus health in real
+  time.
+- **Zero-trust data channels** – `core.NewZeroTrustEngine` orchestrates encrypted channels with participant governance,
+  key rotation and retention controls. CLI helpers (`synnergy zero-trust authorize`, `rotate`, `events`) expose the
+  same lifecycle flows used by automation scripts and the browser UI.
 
 ## Getting Started
 

--- a/cli/metadata.go
+++ b/cli/metadata.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+)
+
+// parseMetadata converts CLI key=value inputs into a deterministic map.
+// Empty keys are ignored and values default to an empty string when omitted.
+func parseMetadata(values []string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	meta := make(map[string]string, len(values))
+	for _, kv := range values {
+		parts := strings.SplitN(kv, "=", 2)
+		key := strings.TrimSpace(parts[0])
+		if key == "" {
+			continue
+		}
+		val := ""
+		if len(parts) == 2 {
+			val = strings.TrimSpace(parts[1])
+		}
+		meta[key] = val
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	// normalise key ordering for reproducible serialisation in tests
+	ordered := make(map[string]string, len(meta))
+	keys := make([]string, 0, len(meta))
+	for k := range meta {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		ordered[k] = meta[k]
+	}
+	return ordered
+}

--- a/cli/warfare_node.go
+++ b/cli/warfare_node.go
@@ -1,7 +1,13 @@
 package cli
 
 import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"synnergy/core"
@@ -27,7 +33,7 @@ func init() {
 			}
 			base := core.NewNode(id, addr, core.NewLedger())
 			warfareNode = core.NewWarfareNode(base)
-			printOutput("warfare node created")
+			printOutput(map[string]any{"status": "created", "id": id})
 			return nil
 		},
 	}
@@ -41,15 +47,54 @@ func init() {
 		Short: "Execute secure command",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if warfareNode == nil {
-				return fmt.Errorf("node not initialised")
+				return errors.New("node not initialised")
 			}
-			if err := warfareNode.SecureCommand(args[0]); err != nil {
+			commander, _ := cmd.Flags().GetString("commander")
+			privHex, _ := cmd.Flags().GetString("private")
+			nonce, _ := cmd.Flags().GetUint64("nonce")
+			meta, _ := cmd.Flags().GetStringArray("meta")
+			metadata := parseMetadata(meta)
+			command := strings.TrimSpace(args[0])
+			if commander == "" && privHex == "" {
+				if err := warfareNode.SecureCommand(command); err != nil {
+					return err
+				}
+				printOutput(map[string]any{"status": "executed", "commander": "root"})
+				return nil
+			}
+			if commander == "" || privHex == "" {
+				return errors.New("commander and private key required for signed commands")
+			}
+			privBytes, err := hex.DecodeString(privHex)
+			if err != nil {
+				return fmt.Errorf("decode private key: %w", err)
+			}
+			req := core.CommandRequest{
+				Commander: commander,
+				Command:   command,
+				Timestamp: time.Now().UTC(),
+				Metadata:  metadata,
+				Nonce:     nonce,
+			}
+			req.Signature = ed25519.Sign(ed25519.PrivateKey(privBytes), req.CanonicalPayload())
+			record, err := warfareNode.ExecuteSecureCommand(context.Background(), req)
+			if err != nil {
 				return err
 			}
-			printOutput("command executed")
+			printOutput(map[string]any{
+				"status":    "executed",
+				"commander": record.Commander,
+				"nonce":     record.Nonce,
+				"accepted":  record.Accepted,
+				"latency":   record.Latency.String(),
+			})
 			return nil
 		},
 	}
+	cmdCmd.Flags().String("commander", "", "commander id for manual signing")
+	cmdCmd.Flags().String("private", "", "hex encoded ed25519 private key")
+	cmdCmd.Flags().Uint64("nonce", 0, "optional nonce override")
+	cmdCmd.Flags().StringArray("meta", nil, "metadata key=value pairs")
 	cmd.AddCommand(cmdCmd)
 
 	trackCmd := &cobra.Command{
@@ -58,13 +103,27 @@ func init() {
 		Short: "Record logistics information",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if warfareNode == nil {
-				return fmt.Errorf("node not initialised")
+				return errors.New("node not initialised")
 			}
-			warfareNode.TrackLogistics(args[0], args[1], args[2])
-			printOutput("logistics recorded")
+			reporter, _ := cmd.Flags().GetString("reporter")
+			meta, _ := cmd.Flags().GetStringArray("meta")
+			update := core.LogisticsUpdate{
+				AssetID:  args[0],
+				Location: args[1],
+				Status:   args[2],
+				Reporter: reporter,
+				Metadata: parseMetadata(meta),
+			}
+			rec, err := warfareNode.RecordLogistics(update)
+			if err != nil {
+				return err
+			}
+			printOutput(map[string]any{"status": "recorded", "asset": rec.AssetID, "location": rec.Location, "timestamp": rec.Timestamp})
 			return nil
 		},
 	}
+	trackCmd.Flags().String("reporter", "", "reporting unit or operator")
+	trackCmd.Flags().StringArray("meta", nil, "metadata key=value pairs")
 	cmd.AddCommand(trackCmd)
 
 	listCmd := &cobra.Command{
@@ -73,7 +132,7 @@ func init() {
 		Short: "List logistics records",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if warfareNode == nil {
-				return fmt.Errorf("node not initialised")
+				return errors.New("node not initialised")
 			}
 			var recs []militarynodes.LogisticsRecord
 			if len(args) == 1 {
@@ -93,14 +152,109 @@ func init() {
 		Short: "Share tactical information",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if warfareNode == nil {
-				return fmt.Errorf("node not initialised")
+				return errors.New("node not initialised")
 			}
-			warfareNode.ShareTactical(args[0])
-			printOutput("info shared")
+			meta, _ := cmd.Flags().GetStringArray("meta")
+			if err := warfareNode.BroadcastTactical(args[0], parseMetadata(meta)); err != nil {
+				return err
+			}
+			printOutput(map[string]any{"status": "broadcast"})
 			return nil
 		},
 	}
+	shareCmd.Flags().StringArray("meta", nil, "metadata key=value pairs")
 	cmd.AddCommand(shareCmd)
+
+	eventsCmd := &cobra.Command{
+		Use:   "events",
+		Args:  cobra.NoArgs,
+		Short: "Stream recent events",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if warfareNode == nil {
+				return errors.New("node not initialised")
+			}
+			since, _ := cmd.Flags().GetUint64("since")
+			var events []core.WarfareEvent
+			if since > 0 {
+				events = warfareNode.EventsSince(since)
+			} else {
+				events = warfareNode.Events()
+			}
+			printOutput(events)
+			return nil
+		},
+	}
+	eventsCmd.Flags().Uint64("since", 0, "sequence filter")
+	cmd.AddCommand(eventsCmd)
+
+	metricsCmd := &cobra.Command{
+		Use:   "metrics",
+		Args:  cobra.NoArgs,
+		Short: "Display warfare node metrics",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if warfareNode == nil {
+				return errors.New("node not initialised")
+			}
+			printOutput(warfareNode.MetricsSnapshot())
+			return nil
+		},
+	}
+	cmd.AddCommand(metricsCmd)
+
+	commanderCmd := &cobra.Command{
+		Use:   "commander",
+		Short: "Manage commander keys",
+	}
+
+	issueCmd := &cobra.Command{
+		Use:   "issue <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Issue a new commander credential",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if warfareNode == nil {
+				return errors.New("node not initialised")
+			}
+			cred, err := warfareNode.IssueCommander(args[0])
+			if err != nil {
+				return err
+			}
+			printOutput(cred)
+			return nil
+		},
+	}
+
+	authCmd := &cobra.Command{
+		Use:   "authorize <id> <pubkey>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Authorize an external commander public key",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if warfareNode == nil {
+				return errors.New("node not initialised")
+			}
+			if err := warfareNode.AuthorizeCommander(args[0], args[1]); err != nil {
+				return err
+			}
+			printOutput(map[string]any{"status": "authorized", "id": args[0]})
+			return nil
+		},
+	}
+
+	revokeCmd := &cobra.Command{
+		Use:   "revoke <id>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Revoke a commander",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if warfareNode == nil {
+				return errors.New("node not initialised")
+			}
+			warfareNode.RevokeCommander(args[0])
+			printOutput(map[string]any{"status": "revoked", "id": args[0]})
+			return nil
+		},
+	}
+
+	commanderCmd.AddCommand(issueCmd, authCmd, revokeCmd)
+	cmd.AddCommand(commanderCmd)
 
 	rootCmd.AddCommand(cmd)
 }

--- a/cli/warfare_node_test.go
+++ b/cli/warfare_node_test.go
@@ -1,29 +1,63 @@
 package cli
 
 import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
 	"testing"
+	"time"
 
 	"synnergy/core"
 )
 
-func TestWarfareNodeLogistics(t *testing.T) {
-	base := core.NewNode("n1", "addr", core.NewLedger())
-	wn := core.NewWarfareNode(base)
+func TestParseMetadataDeterministic(t *testing.T) {
+	m := parseMetadata([]string{"unit=alpha", "priority=high", "unit=override"})
+	if len(m) != 2 {
+		t.Fatalf("expected deduplicated map, got %v", m)
+	}
+	if m["unit"] != "override" {
+		t.Fatalf("expected last value to win, got %v", m["unit"])
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	if keys[0] != "priority" {
+		t.Fatalf("expected deterministic ordering, got %v", keys)
+	}
+}
 
-	if err := wn.SecureCommand("move"); err != nil {
-		t.Fatalf("secure command failed: %v", err)
+func TestWarfareNodeManualCommandFlow(t *testing.T) {
+	base := core.NewNode("cli", "addr", core.NewLedger())
+	warfareNode = core.NewWarfareNode(base)
+	defer func() { warfareNode = nil }()
+	cred, err := warfareNode.IssueCommander("cli-user")
+	if err != nil {
+		t.Fatalf("issue commander: %v", err)
+	}
+	priv, err := hex.DecodeString(cred.PrivateKey)
+	if err != nil {
+		t.Fatalf("decode key: %v", err)
+	}
+	req := core.CommandRequest{
+		Commander: cred.ID,
+		Command:   "deploy",
+		Timestamp: time.Now().UTC(),
+		Metadata:  map[string]string{"cli": "test"},
+	}
+	req.Signature = ed25519.Sign(ed25519.PrivateKey(priv), req.CanonicalPayload())
+	record, err := warfareNode.ExecuteSecureCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+	if !record.Accepted {
+		t.Fatalf("expected command accepted")
 	}
 
-	wn.TrackLogistics("asset", "loc", "ok")
-	logs := wn.Logistics()
-	if len(logs) != 1 {
-		t.Fatalf("expected 1 log, got %d", len(logs))
+	if _, err := warfareNode.RecordLogistics(core.LogisticsUpdate{AssetID: "asset", Location: "loc", Status: "ok"}); err != nil {
+		t.Fatalf("record logistics: %v", err)
 	}
-
-	assetLogs := wn.LogisticsByAsset("asset")
-	if len(assetLogs) != 1 {
-		t.Fatalf("expected asset log")
+	if len(warfareNode.Logistics()) != 1 {
+		t.Fatalf("expected logistics entry")
 	}
-
-	wn.ShareTactical("info")
 }

--- a/cli/zero_trust_data_channels_test.go
+++ b/cli/zero_trust_data_channels_test.go
@@ -1,13 +1,19 @@
 package cli
 
-import "testing"
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+
+	"synnergy/core"
+)
 
 func TestZeroTrustDataChannelsFlow(t *testing.T) {
 	key := make([]byte, 32)
-	if err := ztEngine.OpenChannel("ch", key); err != nil {
+	if err := ztEngine.OpenChannel("ch", key, core.WithOwner("ops")); err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	cipher, err := ztEngine.Send("ch", []byte("hi"))
+	cipher, err := ztEngine.SendAs("ch", "ops", []byte("hi"))
 	if err != nil {
 		t.Fatalf("send: %v", err)
 	}
@@ -16,6 +22,13 @@ func TestZeroTrustDataChannelsFlow(t *testing.T) {
 	}
 	if _, err := ztEngine.Receive("ch", 0); err != nil {
 		t.Fatalf("receive: %v", err)
+	}
+	_, pub, _ := ed25519.GenerateKey(nil)
+	if err := ztEngine.AuthorizePeer("ch", "ally", hex.EncodeToString(pub)); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if _, err := ztEngine.SendAs("ch", "ally", []byte("ally")); err != nil {
+		t.Fatalf("send ally: %v", err)
 	}
 	if err := ztEngine.CloseChannel("ch"); err != nil {
 		t.Fatalf("close: %v", err)

--- a/core/virtual_machine.go
+++ b/core/virtual_machine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -29,18 +30,72 @@ type opcodeHandler func([]byte) ([]byte, error)
 // VM includes simple bottleneck management through a concurrency limiter and
 // satisfies the VirtualMachine interface.
 type SimpleVM struct {
-	mu       sync.RWMutex
-	running  bool
-	mode     VMMode
-	limiter  chan struct{}
-	handlers map[uint32]opcodeHandler
-	defaultH opcodeHandler
+	mu           sync.RWMutex
+	running      bool
+	mode         VMMode
+	limiter      chan struct{}
+	handlers     map[uint32]opcodeHandler
+	defaultH     opcodeHandler
+	callHandlers map[string]func() error
+	hooks        []ExecutionHook
+	metrics      vmMetrics
+}
+
+// ErrGasLimit is returned when execution exhausts its allotted gas.
+var ErrGasLimit = errors.New("gas limit exceeded")
+
+// ExecutionTrace captures a single opcode execution, allowing observers to
+// plug into the VM for telemetry, auditing or debugging. Stage 75 introduces
+// the trace model so both the CLI and the JavaScript console can surface
+// real-time execution insights.
+type ExecutionTrace struct {
+	Opcode       uint32
+	Name         string
+	GasCost      uint64
+	Duration     time.Duration
+	RemainingGas uint64
+	Err          error
+}
+
+// ExecutionHook is invoked after each opcode completes. Hooks should be fast
+// and never panic; the VM guards against panics to preserve fault tolerance.
+type ExecutionHook func(ExecutionTrace)
+
+type vmMetrics struct {
+	executions uint64
+	failures   uint64
+	gasUsed    uint64
+	durationNS int64
+}
+
+// VMMetrics exposes aggregated statistics for observability dashboards and
+// CLI diagnostics.
+type VMMetrics struct {
+	Executions    uint64
+	Failures      uint64
+	GasConsumed   uint64
+	TotalDuration time.Duration
+}
+
+type executionContext struct {
+	vm        *SimpleVM
+	limit     uint64
+	remaining uint64
+	used      uint64
 }
 
 // Call implements the OpContext interface used by the global opcode dispatcher.
 // For now it simply acts as a stub; higher-level integration can wire this to
 // actual protocol functionality.
-func (vm *SimpleVM) Call(string) error { return nil }
+func (vm *SimpleVM) Call(name string) error {
+	vm.mu.RLock()
+	handler := vm.callHandlers[name]
+	vm.mu.RUnlock()
+	if handler == nil {
+		return nil
+	}
+	return handler()
+}
 
 // Gas satisfies the OpContext interface. The lightweight VM does not meter gas
 // beyond counting opcodes, so this is a no-op placeholder.
@@ -67,8 +122,9 @@ func NewSimpleVM(modes ...VMMode) *SimpleVM {
 	}
 
 	vm := &SimpleVM{
-		mode:    mode,
-		limiter: make(chan struct{}, capacity),
+		mode:         mode,
+		limiter:      make(chan struct{}, capacity),
+		callHandlers: make(map[string]func() error),
 	}
 	vm.handlers = map[uint32]opcodeHandler{
 		0x000000: func(b []byte) ([]byte, error) { // NOP/echo
@@ -92,6 +148,120 @@ func (vm *SimpleVM) RegisterHandler(op uint32, h opcodeHandler) {
 	vm.handlers[op] = h
 	vm.mu.Unlock()
 }
+
+// RegisterCallHandler wires a named call target to a callback. This allows the
+// dispatcher to invoke high-level protocol handlers through the VM façade
+// without coupling tests to specific implementations.
+func (vm *SimpleVM) RegisterCallHandler(name string, fn func() error) {
+	vm.mu.Lock()
+	if vm.callHandlers == nil {
+		vm.callHandlers = make(map[string]func() error)
+	}
+	if fn == nil {
+		delete(vm.callHandlers, name)
+	} else {
+		vm.callHandlers[name] = fn
+	}
+	vm.mu.Unlock()
+}
+
+// RegisterHook attaches an execution hook that receives opcode traces. Hooks
+// are invoked sequentially after each opcode completes.
+func (vm *SimpleVM) RegisterHook(h ExecutionHook) {
+	if h == nil {
+		return
+	}
+	vm.mu.Lock()
+	vm.hooks = append(vm.hooks, h)
+	vm.mu.Unlock()
+}
+
+// ResetHooks removes all registered execution hooks. Intended for tests to
+// avoid cross-test interference.
+func (vm *SimpleVM) ResetHooks() {
+	vm.mu.Lock()
+	vm.hooks = nil
+	vm.mu.Unlock()
+}
+
+// ResetMetrics zeroes the VM statistics. Primarily used in tests and
+// diagnostic tooling to capture deltas.
+func (vm *SimpleVM) ResetMetrics() {
+	atomic.StoreUint64(&vm.metrics.executions, 0)
+	atomic.StoreUint64(&vm.metrics.failures, 0)
+	atomic.StoreUint64(&vm.metrics.gasUsed, 0)
+	atomic.StoreInt64(&vm.metrics.durationNS, 0)
+}
+
+// Metrics returns a snapshot of the VM statistics.
+func (vm *SimpleVM) Metrics() VMMetrics {
+	return VMMetrics{
+		Executions:    atomic.LoadUint64(&vm.metrics.executions),
+		Failures:      atomic.LoadUint64(&vm.metrics.failures),
+		GasConsumed:   atomic.LoadUint64(&vm.metrics.gasUsed),
+		TotalDuration: time.Duration(atomic.LoadInt64(&vm.metrics.durationNS)),
+	}
+}
+
+func (vm *SimpleVM) snapshotHooks() []ExecutionHook {
+	vm.mu.RLock()
+	defer vm.mu.RUnlock()
+	if len(vm.hooks) == 0 {
+		return nil
+	}
+	hooks := make([]ExecutionHook, len(vm.hooks))
+	copy(hooks, vm.hooks)
+	return hooks
+}
+
+func (vm *SimpleVM) emitTrace(hooks []ExecutionHook, trace ExecutionTrace) {
+	for _, h := range hooks {
+		func() {
+			defer func() {
+				_ = recover()
+			}()
+			h(trace)
+		}()
+	}
+}
+
+func (vm *SimpleVM) recordMetrics(gas uint64, duration time.Duration, err error) {
+	atomic.AddUint64(&vm.metrics.executions, 1)
+	atomic.AddUint64(&vm.metrics.gasUsed, gas)
+	atomic.AddInt64(&vm.metrics.durationNS, duration.Nanoseconds())
+	if err != nil {
+		atomic.AddUint64(&vm.metrics.failures, 1)
+	}
+}
+
+func newExecutionContext(vm *SimpleVM, gasLimit uint64) *executionContext {
+	return &executionContext{vm: vm, limit: gasLimit, remaining: gasLimit}
+}
+
+func (ec *executionContext) Call(name string) error {
+	return ec.vm.Call(name)
+}
+
+func (ec *executionContext) Gas(amount uint64) error {
+	if amount == 0 {
+		return nil
+	}
+	if amount > ec.remaining {
+		ec.used += amount
+		if ec.used > ec.limit {
+			ec.used = ec.limit
+		}
+		ec.remaining = 0
+		return fmt.Errorf("%w: required %d remaining %d", ErrGasLimit, amount, 0)
+	}
+	ec.remaining -= amount
+	ec.used += amount
+	return nil
+}
+
+func (ec *executionContext) Remaining() uint64 { return ec.remaining }
+
+func (ec *executionContext) Used() uint64 { return ec.used }
 
 // Concurrency returns the maximum number of executions the VM will run in
 // parallel based on its current limiter capacity.  This is primarily exported
@@ -128,7 +298,7 @@ func (vm *SimpleVM) Status() bool {
 }
 
 // ExecuteContext interprets bytecode with context cancellation and gas limits.
-func (vm *SimpleVM) ExecuteContext(ctx context.Context, wasm []byte, method string, args []byte, gasLimit uint64) ([]byte, uint64, error) {
+func (vm *SimpleVM) ExecuteContext(ctx context.Context, wasm []byte, method string, args []byte, gasLimit uint64) (out []byte, gasUsed uint64, err error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -136,32 +306,34 @@ func (vm *SimpleVM) ExecuteContext(ctx context.Context, wasm []byte, method stri
 		return nil, 0, errors.New("vm not running")
 	}
 
-	select {
-	case vm.limiter <- struct{}{}:
-		defer func() { <-vm.limiter }()
-	case <-ctx.Done():
-		return nil, 0, ctx.Err()
-	default:
-		return nil, 0, errors.New("vm busy")
+	release, err := vm.acquireSlot(ctx)
+	if err != nil {
+		return nil, 0, err
 	}
+	defer release()
 
 	if len(wasm) == 0 {
 		return nil, 0, errors.New("bytecode required")
 	}
 
-	opCount := (uint64(len(wasm)) + 2) / 3
-	gasUsed := opCount
-	if gasUsed == 0 {
-		gasUsed = 1
-	}
-	if gasUsed > gasLimit {
-		return nil, gasLimit, errors.New("gas limit exceeded")
-	}
+	hooks := vm.snapshotHooks()
+	exec := newExecutionContext(vm, gasLimit)
+	start := time.Now()
+	out = args
 
-	out := args
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("vm panic: %v", r)
+		}
+		gasUsed = exec.Used()
+		vm.recordMetrics(gasUsed, time.Since(start), err)
+	}()
+
+	opcodeNames := Opcodes()
 	for i := 0; i < len(wasm); i += 3 {
-		if err := ctx.Err(); err != nil {
-			return nil, gasUsed, err
+		if ctx.Err() != nil {
+			err = ctx.Err()
+			return nil, exec.Used(), err
 		}
 		b0 := wasm[i]
 		var b1, b2 byte
@@ -173,30 +345,99 @@ func (vm *SimpleVM) ExecuteContext(ctx context.Context, wasm []byte, method stri
 		}
 		opcode := uint32(b0)<<16 | uint32(b1)<<8 | uint32(b2)
 
+		cost := vm.gasCostForOpcode(opcode)
+		name := vm.nameForOpcode(opcode, opcodeNames)
+		stepStart := time.Now()
+
 		if handler, ok := vm.handlers[opcode]; ok {
-			var err error
+			if err = exec.Gas(cost); err != nil {
+				vm.emitTrace(hooks, ExecutionTrace{Opcode: opcode, Name: name, GasCost: cost, Duration: time.Since(stepStart), RemainingGas: exec.Remaining(), Err: err})
+				return nil, exec.Used(), err
+			}
 			out, err = handler(out)
+			vm.emitTrace(hooks, ExecutionTrace{Opcode: opcode, Name: name, GasCost: cost, Duration: time.Since(stepStart), RemainingGas: exec.Remaining(), Err: err})
 			if err != nil {
-				return nil, gasUsed, fmt.Errorf("opcode 0x%06x failed: %w", opcode, err)
+				err = fmt.Errorf("opcode 0x%06x failed: %w", opcode, err)
+				return nil, exec.Used(), err
 			}
 			continue
 		}
-		if opcode != 0 {
-			if err := Dispatch(vm, Opcode(opcode)); err != nil {
-				continue
+
+		if opcode == 0 {
+			if err = exec.Gas(cost); err != nil {
+				vm.emitTrace(hooks, ExecutionTrace{Opcode: opcode, Name: name, GasCost: cost, Duration: time.Since(stepStart), RemainingGas: exec.Remaining(), Err: err})
+				return nil, exec.Used(), err
 			}
+			if vm.defaultH != nil {
+				out, err = vm.defaultH(out)
+				vm.emitTrace(hooks, ExecutionTrace{Opcode: opcode, Name: name, GasCost: cost, Duration: time.Since(stepStart), RemainingGas: exec.Remaining(), Err: err})
+				if err != nil {
+					err = fmt.Errorf("opcode 0x%06x failed: %w", opcode, err)
+					return nil, exec.Used(), err
+				}
+			} else {
+				vm.emitTrace(hooks, ExecutionTrace{Opcode: opcode, Name: name, GasCost: cost, Duration: time.Since(stepStart), RemainingGas: exec.Remaining(), Err: nil})
+			}
+			continue
 		}
+
+		err = Dispatch(exec, Opcode(opcode))
+		if err != nil {
+			vm.emitTrace(hooks, ExecutionTrace{Opcode: opcode, Name: name, GasCost: cost, Duration: time.Since(stepStart), RemainingGas: exec.Remaining(), Err: err})
+			continue
+		}
+		vm.emitTrace(hooks, ExecutionTrace{Opcode: opcode, Name: name, GasCost: cost, Duration: time.Since(stepStart), RemainingGas: exec.Remaining(), Err: nil})
 	}
 
-	select {
-	case <-time.After(time.Millisecond):
-	case <-ctx.Done():
-		return nil, gasUsed, ctx.Err()
+	if err = vm.awaitDeterministicDelay(ctx); err != nil {
+		return nil, exec.Used(), err
 	}
-
-	return out, gasUsed, nil
+	return out, exec.Used(), nil
 }
 
 func (vm *SimpleVM) Execute(wasm []byte, method string, args []byte, gasLimit uint64) ([]byte, uint64, error) {
 	return vm.ExecuteContext(context.Background(), wasm, method, args, gasLimit)
+}
+
+func (vm *SimpleVM) acquireSlot(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case vm.limiter <- struct{}{}:
+		return func() { <-vm.limiter }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return nil, errors.New("vm busy")
+	}
+}
+
+func (vm *SimpleVM) awaitDeterministicDelay(ctx context.Context) error {
+	select {
+	case <-time.After(time.Millisecond):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (vm *SimpleVM) gasCostForOpcode(opcode uint32) uint64 {
+	cost := GasCost(Opcode(opcode))
+	if cost == 0 {
+		return DefaultGasCost
+	}
+	return cost
+}
+
+func (vm *SimpleVM) nameForOpcode(opcode uint32, names map[Opcode]string) string {
+	if names != nil {
+		if name, ok := names[Opcode(opcode)]; ok {
+			return name
+		}
+	}
+	if opcode == 0 {
+		return "NOP"
+	}
+	return fmt.Sprintf("0x%06X", opcode)
 }

--- a/core/vm_sandbox_management.go
+++ b/core/vm_sandbox_management.go
@@ -3,19 +3,74 @@ package core
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
+)
+
+// Sentinel errors exposed for CLI validation and unit tests.
+var (
+	ErrSandboxExists   = errors.New("sandbox already exists")
+	ErrSandboxNotFound = errors.New("sandbox not found")
+)
+
+// SandboxEventType enumerates lifecycle transitions emitted by the sandbox
+// manager. Events are consumed by the enterprise CLI, web telemetry panels and
+// integration tests to provide real-time visibility of execution sandboxes.
+type SandboxEventType string
+
+const (
+	SandboxEventStarted   SandboxEventType = "started"
+	SandboxEventStopped   SandboxEventType = "stopped"
+	SandboxEventReset     SandboxEventType = "reset"
+	SandboxEventDeleted   SandboxEventType = "deleted"
+	SandboxEventPurged    SandboxEventType = "purged"
+	SandboxEventFailure   SandboxEventType = "failure"
+	SandboxEventRestarted SandboxEventType = "restarted"
+	SandboxEventHeartbeat SandboxEventType = "heartbeat"
 )
 
 // SandboxInfo holds runtime limits and state for a single sandboxed contract
 // execution environment.
 type SandboxInfo struct {
-	ID           string
-	ContractAddr string
-	GasLimit     uint64
-	MemoryLimit  uint64
-	Active       bool
-	LastReset    time.Time
-	CreatedAt    time.Time
+	ID            string
+	ContractAddr  string
+	GasLimit      uint64
+	MemoryLimit   uint64
+	Active        bool
+	LastReset     time.Time
+	CreatedAt     time.Time
+	LastHeartbeat time.Time
+	FailureCount  uint64
+	RestartCount  uint64
+	LastError     string
+}
+
+// SandboxEvent captures a lifecycle notification for subscribers.
+type SandboxEvent struct {
+	Type      SandboxEventType
+	Info      SandboxInfo
+	Timestamp time.Time
+	Err       error
+}
+
+// SandboxWatcher receives sandbox events.
+type SandboxWatcher func(SandboxEvent)
+
+// SandboxMetrics exposes aggregate counters for observability dashboards.
+type SandboxMetrics struct {
+	TotalCreated uint64
+	Active       int64
+	Failures     uint64
+	Restarts     uint64
+	Purged       uint64
+}
+
+type sandboxMetrics struct {
+	totalCreated uint64
+	active       int64
+	failures     uint64
+	restarts     uint64
+	purged       uint64
 }
 
 // SandboxManager manages multiple sandboxes used to isolate contract
@@ -24,71 +79,207 @@ type SandboxManager struct {
 	mu        sync.RWMutex
 	sandboxes map[string]*SandboxInfo
 	ttl       time.Duration
+	watchers  []SandboxWatcher
+	metrics   sandboxMetrics
 }
 
-// NewSandboxManager returns an empty manager. A default time-to-live of one hour
-// is applied to inactive sandboxes unless overridden. Expired sandboxes are
-// removed when PurgeInactive is invoked.
+// NewSandboxManager returns an empty manager. A default time-to-live of one
+// hour is applied to inactive sandboxes unless overridden. Expired sandboxes
+// are removed when PurgeInactive is invoked.
 func NewSandboxManager(ttls ...time.Duration) *SandboxManager {
 	ttl := time.Hour
-	if len(ttls) > 0 {
+	if len(ttls) > 0 && ttls[0] > 0 {
 		ttl = ttls[0]
 	}
 	return &SandboxManager{sandboxes: make(map[string]*SandboxInfo), ttl: ttl}
 }
 
+// RegisterWatcher attaches a sandbox watcher. Callers should register
+// watchers before invoking other manager methods.
+func (m *SandboxManager) RegisterWatcher(w SandboxWatcher) {
+	if w == nil {
+		return
+	}
+	m.mu.Lock()
+	m.watchers = append(m.watchers, w)
+	m.mu.Unlock()
+}
+
+func (m *SandboxManager) snapshotWatchers() []SandboxWatcher {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.watchers) == 0 {
+		return nil
+	}
+	out := make([]SandboxWatcher, len(m.watchers))
+	copy(out, m.watchers)
+	return out
+}
+
+func (m *SandboxManager) emit(event SandboxEvent) {
+	for _, w := range m.snapshotWatchers() {
+		func() {
+			defer func() { _ = recover() }()
+			w(event)
+		}()
+	}
+}
+
 // StartSandbox creates a new sandbox for the given contract address.
 func (m *SandboxManager) StartSandbox(id, contractAddr string, gasLimit, memoryLimit uint64) (*SandboxInfo, error) {
+	now := time.Now()
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if _, exists := m.sandboxes[id]; exists {
-		return nil, errors.New("sandbox already exists")
+		m.mu.Unlock()
+		return nil, ErrSandboxExists
 	}
 	sb := &SandboxInfo{
-		ID:           id,
-		ContractAddr: contractAddr,
-		GasLimit:     gasLimit,
-		MemoryLimit:  memoryLimit,
-		Active:       true,
-		CreatedAt:    time.Now(),
-		LastReset:    time.Now(),
+		ID:            id,
+		ContractAddr:  contractAddr,
+		GasLimit:      gasLimit,
+		MemoryLimit:   memoryLimit,
+		Active:        true,
+		CreatedAt:     now,
+		LastReset:     now,
+		LastHeartbeat: now,
 	}
 	m.sandboxes[id] = sb
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.totalCreated, 1)
+	atomic.AddInt64(&m.metrics.active, 1)
+	m.emit(SandboxEvent{Type: SandboxEventStarted, Info: *sb, Timestamp: now})
 	return sb, nil
 }
 
 // StopSandbox deactivates a sandbox.
 func (m *SandboxManager) StopSandbox(id string) error {
+	now := time.Now()
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	sb, ok := m.sandboxes[id]
 	if !ok {
-		return errors.New("sandbox not found")
+		m.mu.Unlock()
+		return ErrSandboxNotFound
 	}
+	wasActive := sb.Active
 	sb.Active = false
+	sb.LastHeartbeat = now
+	snapshot := *sb
+	m.mu.Unlock()
+
+	if wasActive {
+		atomic.AddInt64(&m.metrics.active, -1)
+	}
+	m.emit(SandboxEvent{Type: SandboxEventStopped, Info: snapshot, Timestamp: now})
 	return nil
 }
 
 // ResetSandbox updates the LastReset timestamp for a sandbox.
 func (m *SandboxManager) ResetSandbox(id string) error {
+	now := time.Now()
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	sb, ok := m.sandboxes[id]
 	if !ok {
-		return errors.New("sandbox not found")
+		m.mu.Unlock()
+		return ErrSandboxNotFound
 	}
-	sb.LastReset = time.Now()
+	sb.LastReset = now
+	sb.LastHeartbeat = now
+	snapshot := *sb
+	m.mu.Unlock()
+
+	m.emit(SandboxEvent{Type: SandboxEventReset, Info: snapshot, Timestamp: now})
 	return nil
 }
 
 // DeleteSandbox removes a sandbox entirely, releasing its resources.
 func (m *SandboxManager) DeleteSandbox(id string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	if _, ok := m.sandboxes[id]; !ok {
-		return errors.New("sandbox not found")
+	sb, ok := m.sandboxes[id]
+	if !ok {
+		m.mu.Unlock()
+		return ErrSandboxNotFound
 	}
+	wasActive := sb.Active
+	snapshot := *sb
 	delete(m.sandboxes, id)
+	m.mu.Unlock()
+
+	if wasActive {
+		atomic.AddInt64(&m.metrics.active, -1)
+	}
+	m.emit(SandboxEvent{Type: SandboxEventDeleted, Info: snapshot, Timestamp: time.Now()})
+	return nil
+}
+
+// RecordFailure marks a sandbox as failed and stores the error for later
+// inspection. The sandbox is deactivated until RestartSandbox is invoked.
+func (m *SandboxManager) RecordFailure(id string, failure error) error {
+	now := time.Now()
+	m.mu.Lock()
+	sb, ok := m.sandboxes[id]
+	if !ok {
+		m.mu.Unlock()
+		return ErrSandboxNotFound
+	}
+	if sb.Active {
+		atomic.AddInt64(&m.metrics.active, -1)
+	}
+	sb.Active = false
+	sb.LastHeartbeat = now
+	sb.FailureCount++
+	if failure != nil {
+		sb.LastError = failure.Error()
+	} else {
+		sb.LastError = ""
+	}
+	snapshot := *sb
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.failures, 1)
+	m.emit(SandboxEvent{Type: SandboxEventFailure, Info: snapshot, Timestamp: now, Err: failure})
+	return nil
+}
+
+// RestartSandbox reactivates a sandbox following a failure or manual stop.
+func (m *SandboxManager) RestartSandbox(id string) error {
+	now := time.Now()
+	m.mu.Lock()
+	sb, ok := m.sandboxes[id]
+	if !ok {
+		m.mu.Unlock()
+		return ErrSandboxNotFound
+	}
+	if !sb.Active {
+		atomic.AddInt64(&m.metrics.active, 1)
+	}
+	sb.Active = true
+	sb.RestartCount++
+	sb.LastReset = now
+	sb.LastHeartbeat = now
+	snapshot := *sb
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.restarts, 1)
+	m.emit(SandboxEvent{Type: SandboxEventRestarted, Info: snapshot, Timestamp: now})
+	return nil
+}
+
+// Heartbeat updates the liveness timestamp for the sandbox. It is typically
+// invoked by the VM after a successful execution round.
+func (m *SandboxManager) Heartbeat(id string) error {
+	now := time.Now()
+	m.mu.Lock()
+	sb, ok := m.sandboxes[id]
+	if !ok {
+		m.mu.Unlock()
+		return ErrSandboxNotFound
+	}
+	sb.LastHeartbeat = now
+	snapshot := *sb
+	m.mu.Unlock()
+
+	m.emit(SandboxEvent{Type: SandboxEventHeartbeat, Info: snapshot, Timestamp: now})
 	return nil
 }
 
@@ -96,16 +287,27 @@ func (m *SandboxManager) DeleteSandbox(id string) error {
 // beyond the configured TTL.  It is safe to call concurrently with other
 // manager operations.
 func (m *SandboxManager) PurgeInactive() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	now := time.Now()
+	var purged []SandboxInfo
+
+	m.mu.Lock()
 	for id, sb := range m.sandboxes {
 		if sb.Active {
 			continue
 		}
-		if now.Sub(sb.LastReset) > m.ttl {
+		if now.Sub(sb.LastHeartbeat) > m.ttl {
+			purged = append(purged, *sb)
 			delete(m.sandboxes, id)
 		}
+	}
+	m.mu.Unlock()
+
+	if len(purged) == 0 {
+		return
+	}
+	atomic.AddUint64(&m.metrics.purged, uint64(len(purged)))
+	for _, sb := range purged {
+		m.emit(SandboxEvent{Type: SandboxEventPurged, Info: sb, Timestamp: now})
 	}
 }
 
@@ -126,4 +328,15 @@ func (m *SandboxManager) ListSandboxes() []*SandboxInfo {
 		out = append(out, sb)
 	}
 	return out
+}
+
+// Metrics returns a snapshot of the sandbox counters.
+func (m *SandboxManager) Metrics() SandboxMetrics {
+	return SandboxMetrics{
+		TotalCreated: atomic.LoadUint64(&m.metrics.totalCreated),
+		Active:       atomic.LoadInt64(&m.metrics.active),
+		Failures:     atomic.LoadUint64(&m.metrics.failures),
+		Restarts:     atomic.LoadUint64(&m.metrics.restarts),
+		Purged:       atomic.LoadUint64(&m.metrics.purged),
+	}
 }

--- a/core/vm_sandbox_management_test.go
+++ b/core/vm_sandbox_management_test.go
@@ -1,12 +1,16 @@
 package core
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
 
 func TestSandboxManager(t *testing.T) {
-	m := NewSandboxManager(time.Millisecond)
+	m := NewSandboxManager(2 * time.Millisecond)
+	events := make(chan SandboxEvent, 32)
+	m.RegisterWatcher(func(ev SandboxEvent) { events <- ev })
+
 	sb, err := m.StartSandbox("sb1", "addr", 10, 64)
 	if err != nil {
 		t.Fatalf("start: %v", err)
@@ -14,27 +18,68 @@ func TestSandboxManager(t *testing.T) {
 	if !sb.Active {
 		t.Fatalf("expected active sandbox")
 	}
+
+	if err := m.Heartbeat("sb1"); err != nil {
+		t.Fatalf("heartbeat: %v", err)
+	}
+
+	failure := errors.New("execution reverted")
+	if err := m.RecordFailure("sb1", failure); err != nil {
+		t.Fatalf("record failure: %v", err)
+	}
+	if sb.Active {
+		t.Fatalf("sandbox should be inactive after failure")
+	}
+	if sb.LastError == "" {
+		t.Fatalf("expected failure to be recorded")
+	}
+
+	if err := m.RestartSandbox("sb1"); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+	if !sb.Active || sb.RestartCount != 1 {
+		t.Fatalf("sandbox not restarted correctly")
+	}
+
 	if err := m.ResetSandbox("sb1"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
 	if err := m.StopSandbox("sb1"); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
-	if sb, ok := m.SandboxStatus("sb1"); !ok || sb.Active {
-		t.Fatalf("status mismatch")
-	}
-	if err := m.DeleteSandbox("sb1"); err != nil {
-		t.Fatalf("delete: %v", err)
-	}
-	if _, ok := m.SandboxStatus("sb1"); ok {
-		t.Fatalf("sandbox should be removed")
-	}
-	// verify purge removes stopped sandboxes past TTL
-	sb, _ = m.StartSandbox("sb2", "addr", 1, 1)
-	_ = m.StopSandbox("sb2")
-	time.Sleep(2 * time.Millisecond)
+
+	// allow TTL expiry and purge
+	time.Sleep(3 * time.Millisecond)
 	m.PurgeInactive()
-	if _, ok := m.SandboxStatus("sb2"); ok {
-		t.Fatalf("expected sb2 purged")
+	if _, ok := m.SandboxStatus("sb1"); ok {
+		t.Fatalf("expected sandbox purged")
+	}
+
+	metrics := m.Metrics()
+	if metrics.TotalCreated != 1 {
+		t.Fatalf("expected total created 1, got %d", metrics.TotalCreated)
+	}
+	if metrics.Failures != 1 {
+		t.Fatalf("expected failures 1, got %d", metrics.Failures)
+	}
+	if metrics.Restarts != 1 {
+		t.Fatalf("expected restarts 1, got %d", metrics.Restarts)
+	}
+	if metrics.Purged != 1 {
+		t.Fatalf("expected purged 1, got %d", metrics.Purged)
+	}
+	if metrics.Active != 0 {
+		t.Fatalf("expected no active sandboxes, got %d", metrics.Active)
+	}
+
+	close(events)
+	seen := map[SandboxEventType]int{}
+	for ev := range events {
+		seen[ev.Type]++
+	}
+	for _, typ := range []SandboxEventType{SandboxEventStarted, SandboxEventFailure, SandboxEventRestarted, SandboxEventPurged} {
+		if seen[typ] == 0 {
+			t.Fatalf("expected event type %s to be emitted", typ)
+		}
 	}
 }

--- a/core/wallet_test.go
+++ b/core/wallet_test.go
@@ -1,7 +1,8 @@
 package core
 
 import (
-	"os"
+	"bytes"
+	"path/filepath"
 	"testing"
 )
 
@@ -20,6 +21,10 @@ func TestWalletSignAndVerify(t *testing.T) {
 	if len(w1.Address) != 40 || len(w2.Address) != 40 {
 		t.Fatalf("addresses must be 40 hex characters")
 	}
+	if len(w1.PublicKeyBytes()) == 0 || len(w2.PublicKeyBytes()) == 0 {
+		t.Fatalf("expected public key bytes")
+	}
+
 	tx := NewTransaction("a", "b", 1, 0, 0)
 	sig, err := w1.Sign(tx)
 	if err != nil {
@@ -34,6 +39,17 @@ func TestWalletSignAndVerify(t *testing.T) {
 	if !tx.Verify(&w1.PrivateKey.PublicKey) {
 		t.Fatalf("tx.Verify should succeed with correct key")
 	}
+	msg := []byte("stage75")
+	msgSig, err := w1.SignMessage(msg)
+	if err != nil {
+		t.Fatalf("sign message: %v", err)
+	}
+	if !VerifyMessage(msg, msgSig, &w1.PublicKey) {
+		t.Fatalf("message verification failed")
+	}
+	if VerifyMessage(msg, msgSig, &w2.PublicKey) {
+		t.Fatalf("message verification should fail with other key")
+	}
 }
 
 func TestWalletSaveLoad(t *testing.T) {
@@ -41,16 +57,63 @@ func TestWalletSaveLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new wallet: %v", err)
 	}
-	path := "testwallet.json"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wallet.json")
 	if err := w.Save(path, "pass"); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	defer os.Remove(path)
 	w2, err := LoadWallet(path, "pass")
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
 	if w.Address != w2.Address {
 		t.Fatalf("addresses differ")
+	}
+	if !bytes.Equal(w.PublicKeyBytes(), w2.PublicKeyBytes()) {
+		t.Fatalf("public keys differ")
+	}
+}
+
+func TestWalletDeterministicSeed(t *testing.T) {
+	seed := bytes.Repeat([]byte{0xAB}, 32)
+	w1, err := NewWalletFromSeed(seed)
+	if err != nil {
+		t.Fatalf("seed wallet: %v", err)
+	}
+	w2, err := NewWalletFromSeed(seed)
+	if err != nil {
+		t.Fatalf("seed wallet: %v", err)
+	}
+	if w1.Address != w2.Address {
+		t.Fatalf("deterministic wallets should match")
+	}
+	other, err := NewWalletFromSeed(bytes.Repeat([]byte{0xAC}, 32))
+	if err != nil {
+		t.Fatalf("seed wallet: %v", err)
+	}
+	if other.Address == w1.Address {
+		t.Fatalf("different seeds should produce different addresses")
+	}
+}
+
+func TestWalletSharedSecret(t *testing.T) {
+	w1, err := NewWallet()
+	if err != nil {
+		t.Fatalf("new wallet: %v", err)
+	}
+	w2, err := NewWallet()
+	if err != nil {
+		t.Fatalf("new wallet: %v", err)
+	}
+	s1, err := w1.DeriveSharedSecret(&w2.PublicKey)
+	if err != nil {
+		t.Fatalf("shared secret: %v", err)
+	}
+	s2, err := w2.DeriveSharedSecret(&w1.PublicKey)
+	if err != nil {
+		t.Fatalf("shared secret: %v", err)
+	}
+	if !bytes.Equal(s1, s2) {
+		t.Fatalf("shared secrets differ")
 	}
 }

--- a/core/warfare_node.go
+++ b/core/warfare_node.go
@@ -1,23 +1,197 @@
 package core
 
 import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	militarynodes "synnergy/internal/nodes/military_nodes"
 )
 
-// WarfareNode provides military focused extensions on top of a base Node.
-type WarfareNode struct {
-	*Node
-	mu        sync.RWMutex
-	logistics []militarynodes.LogisticsRecord
+const (
+	commanderRootID      = "root"
+	defaultEventLogLimit = 512
+	commandSkewTolerance = 5 * time.Minute
+)
+
+// WarfareEventType categorises emitted warfare node events so that CLI and web
+// consoles can render tailored views without additional parsing.
+type WarfareEventType string
+
+const (
+	WarfareEventCommandAccepted   WarfareEventType = "command.accepted"
+	WarfareEventCommandRejected   WarfareEventType = "command.rejected"
+	WarfareEventLogisticsRecorded WarfareEventType = "logistics.recorded"
+	WarfareEventLogisticsRejected WarfareEventType = "logistics.rejected"
+	WarfareEventTacticalBroadcast WarfareEventType = "tactical.broadcast"
+	WarfareEventVMTrace           WarfareEventType = "vm.trace"
+)
+
+// WarfareEvent is broadcast whenever privileged commands are executed, when
+// logistics are updated or when VM hooks fire.  Events are replayable so that
+// delayed subscribers – including the JavaScript control panel – can build an
+// accurate state view.
+type WarfareEvent struct {
+	Sequence  uint64
+	Type      WarfareEventType
+	Timestamp time.Time
+	Commander string
+	Payload   map[string]string
 }
 
-// NewWarfareNode wraps a base node with warfare specific functionality.
+// CommandRequest wraps a privileged command along with metadata used for
+// signature verification and replay protection.
+type CommandRequest struct {
+	Commander string
+	Command   string
+	Timestamp time.Time
+	Nonce     uint64
+	Signature []byte
+	Metadata  map[string]string
+}
+
+// CommandRecord captures the result of executing a privileged command.
+type CommandRecord struct {
+	Commander string
+	Command   string
+	Timestamp time.Time
+	Nonce     uint64
+	Metadata  map[string]string
+	Accepted  bool
+	Error     string
+	Consensus ConsensusSnapshot
+	Latency   time.Duration
+}
+
+// ConsensusSnapshot exposes the consensus weights at the time a command was
+// processed so auditors can confirm policy decisions.
+type ConsensusSnapshot struct {
+	PoW float64
+	PoS float64
+	PoH float64
+}
+
+// CommanderCredential returns the private and public keys associated with an
+// authorised commander.  The private key is presented once so operators can
+// store it securely for future signatures.
+type CommanderCredential struct {
+	ID         string
+	PublicKey  string
+	PrivateKey string
+	IssuedAt   time.Time
+}
+
+// LogisticsUpdate represents a pending logistics mutation including optional
+// metadata used for compliance attestation.
+type LogisticsUpdate struct {
+	AssetID   string
+	Location  string
+	Status    string
+	Reporter  string
+	Metadata  map[string]string
+	Timestamp time.Time
+}
+
+type commanderEntry struct {
+	pub       ed25519.PublicKey
+	lastNonce uint64
+}
+
+type warfareMetrics struct {
+	commands       uint64
+	failedCommands uint64
+	logistics      uint64
+	tactical       uint64
+}
+
+type vmHookRegistrar interface {
+	RegisterHook(ExecutionHook)
+}
+
+type vmCallable interface {
+	Call(string) error
+}
+
+// WarfareNode provides military focused extensions on top of a base Node.  It
+// maintains audit logs, command authorisations and event subscriptions used by
+// the CLI and the browser-based control panel.
+type WarfareNode struct {
+	*Node
+
+	mu         sync.RWMutex
+	logistics  []militarynodes.LogisticsRecord
+	commandLog []CommandRecord
+	events     []WarfareEvent
+
+	commanders  map[string]commanderEntry
+	rootKey     ed25519.PrivateKey
+	eventSeq    uint64
+	subscriber  uint64
+	subscribers map[uint64]chan WarfareEvent
+
+	metrics warfareMetrics
+	evLimit int
+}
+
+// NewWarfareNode wraps a base node with warfare specific functionality and
+// instruments the attached virtual machine so execution traces are streamed to
+// subscribers.  A root commander is generated automatically and used by the CLI
+// when no external credentials are supplied.
 func NewWarfareNode(base *Node) *WarfareNode {
-	return &WarfareNode{Node: base}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(fmt.Errorf("generate commander key: %w", err))
+	}
+
+	wn := &WarfareNode{
+		Node:       base,
+		commanders: map[string]commanderEntry{commanderRootID: {pub: pub}},
+		rootKey:    priv,
+		evLimit:    defaultEventLogLimit,
+	}
+	if base != nil && base.VM != nil {
+		if hooker, ok := interface{}(base.VM).(vmHookRegistrar); ok {
+			hooker.RegisterHook(func(trace ExecutionTrace) {
+				payload := map[string]string{
+					"opcode":   fmt.Sprintf("0x%06X", trace.Opcode),
+					"name":     trace.Name,
+					"duration": trace.Duration.String(),
+					"gas":      fmt.Sprintf("%d", trace.GasCost),
+				}
+				if trace.Err != nil {
+					payload["error"] = trace.Err.Error()
+				}
+				wn.recordEvent(WarfareEvent{
+					Type:      WarfareEventVMTrace,
+					Timestamp: time.Now().UTC(),
+					Payload:   payload,
+				})
+			})
+		}
+	}
+	return wn
+}
+
+// SetEventLogLimit adjusts the maximum number of events retained for replay.
+// The default of 512 aligns with the JavaScript control panel pagination.
+func (w *WarfareNode) SetEventLogLimit(limit int) {
+	if limit <= 0 {
+		limit = defaultEventLogLimit
+	}
+	w.mu.Lock()
+	w.evLimit = limit
+	if len(w.events) > limit {
+		w.events = append([]WarfareEvent(nil), w.events[len(w.events)-limit:]...)
+	}
+	w.mu.Unlock()
 }
 
 // GetID satisfies militarynodes.BaseNode.
@@ -28,33 +202,357 @@ func (w *WarfareNode) GetID() string {
 	return ""
 }
 
-// SecureCommand executes a privileged command after validating input.
-// In this stub implementation it simply ensures the command is non-empty.
-func (w *WarfareNode) SecureCommand(cmd string) error {
-	if cmd == "" {
-		return errors.New("empty command")
+// IssueCommander generates a new commander key pair, registers the public key
+// and returns the credential so the private key can be stored in an HSM or
+// secure enclave.
+func (w *WarfareNode) IssueCommander(id string) (CommanderCredential, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return CommanderCredential{}, errors.New("commander id required")
 	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return CommanderCredential{}, fmt.Errorf("generate commander: %w", err)
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.commanders == nil {
+		w.commanders = make(map[string]commanderEntry)
+	}
+	if _, exists := w.commanders[id]; exists {
+		return CommanderCredential{}, fmt.Errorf("commander %s already authorised", id)
+	}
+	w.commanders[id] = commanderEntry{pub: pub}
+	cred := CommanderCredential{
+		ID:         id,
+		PublicKey:  hex.EncodeToString(pub),
+		PrivateKey: hex.EncodeToString(priv),
+		IssuedAt:   time.Now().UTC(),
+	}
+	return cred, nil
+}
+
+// AuthorizeCommander registers an externally generated commander public key.
+func (w *WarfareNode) AuthorizeCommander(id, hexKey string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("commander id required")
+	}
+	keyBytes, err := hex.DecodeString(strings.TrimSpace(hexKey))
+	if err != nil {
+		return fmt.Errorf("decode commander key: %w", err)
+	}
+	if len(keyBytes) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid commander key length: %d", len(keyBytes))
+	}
+	w.mu.Lock()
+	if w.commanders == nil {
+		w.commanders = make(map[string]commanderEntry)
+	}
+	w.commanders[id] = commanderEntry{pub: ed25519.PublicKey(keyBytes)}
+	w.mu.Unlock()
 	return nil
 }
 
-// TrackLogistics records a logistics update for a military asset.
-func (w *WarfareNode) TrackLogistics(assetID, location, status string) {
+// RevokeCommander removes a commander from the authorised set.
+func (w *WarfareNode) RevokeCommander(id string) {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-	rec := militarynodes.LogisticsRecord{
-		AssetID:   assetID,
-		Location:  location,
-		Status:    status,
-		Timestamp: time.Now().UTC(),
-	}
-	w.logistics = append(w.logistics, rec)
+	delete(w.commanders, strings.TrimSpace(id))
+	w.mu.Unlock()
 }
 
-// ShareTactical distributes tactical information. This stub stores no state
-// but acts as a hook for future broadcasting logic.
+// nextNonce increments the nonce for the provided commander returning the next
+// value in sequence.
+func (w *WarfareNode) nextNonce(commander string) uint64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	entry := w.commanders[commander]
+	entry.lastNonce++
+	w.commanders[commander] = entry
+	return entry.lastNonce
+}
+
+func (r CommandRequest) canonicalPayload() []byte {
+	ts := r.Timestamp.UTC().Format(time.RFC3339Nano)
+	keys := make([]string, 0, len(r.Metadata))
+	for k := range r.Metadata {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(r.Commander)
+	b.WriteByte('|')
+	b.WriteString(r.Command)
+	b.WriteByte('|')
+	b.WriteString(ts)
+	b.WriteByte('|')
+	b.WriteString(fmt.Sprintf("%d", r.Nonce))
+	for _, k := range keys {
+		b.WriteByte('|')
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(r.Metadata[k])
+	}
+	return []byte(b.String())
+}
+
+// CanonicalPayload exposes the byte sequence used for signing a command
+// request.  External clients such as the CLI and web console rely on this to
+// deterministically reproduce the payload the warfare node verifies before
+// executing a command.
+func (r CommandRequest) CanonicalPayload() []byte {
+	return r.canonicalPayload()
+}
+
+func (w *WarfareNode) snapshotConsensus() ConsensusSnapshot {
+	if w.Node == nil || w.Node.Consensus == nil {
+		return ConsensusSnapshot{}
+	}
+	weights := w.Node.Consensus.Weights
+	return ConsensusSnapshot{PoW: weights.PoW, PoS: weights.PoS, PoH: weights.PoH}
+}
+
+// ExecuteSecureCommand validates the supplied request, verifies its signature,
+// checks consensus availability and executes the VM hook.  The resulting record
+// is stored in the audit log and broadcast to subscribers.
+func (w *WarfareNode) ExecuteSecureCommand(ctx context.Context, req CommandRequest) (CommandRecord, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req.Command = strings.TrimSpace(req.Command)
+	if req.Command == "" {
+		return CommandRecord{}, errors.New("command required")
+	}
+	req.Commander = strings.TrimSpace(req.Commander)
+	if req.Commander == "" {
+		return CommandRecord{}, errors.New("commander required")
+	}
+	if req.Timestamp.IsZero() {
+		req.Timestamp = time.Now().UTC()
+	}
+	if delta := time.Since(req.Timestamp); delta > commandSkewTolerance || delta < -commandSkewTolerance {
+		return CommandRecord{}, fmt.Errorf("timestamp outside tolerance: %s", req.Timestamp)
+	}
+
+	payload := req.canonicalPayload()
+	w.mu.Lock()
+	entry, ok := w.commanders[req.Commander]
+	if !ok {
+		w.mu.Unlock()
+		return CommandRecord{}, fmt.Errorf("unknown commander: %s", req.Commander)
+	}
+	if req.Nonce == 0 {
+		entry.lastNonce++
+		req.Nonce = entry.lastNonce
+	} else if req.Nonce <= entry.lastNonce {
+		w.mu.Unlock()
+		return CommandRecord{}, fmt.Errorf("nonce %d not greater than %d", req.Nonce, entry.lastNonce)
+	} else {
+		entry.lastNonce = req.Nonce
+	}
+	if len(req.Signature) == 0 || !ed25519.Verify(entry.pub, payload, req.Signature) {
+		w.mu.Unlock()
+		atomic.AddUint64(&w.metrics.failedCommands, 1)
+		record := CommandRecord{
+			Commander: req.Commander,
+			Command:   req.Command,
+			Timestamp: req.Timestamp,
+			Nonce:     req.Nonce,
+			Metadata:  cloneMetadata(req.Metadata),
+			Accepted:  false,
+			Error:     "signature verification failed",
+			Consensus: w.snapshotConsensus(),
+		}
+		w.appendCommandRecord(record)
+		w.recordEvent(WarfareEvent{
+			Type:      WarfareEventCommandRejected,
+			Timestamp: time.Now().UTC(),
+			Commander: req.Commander,
+			Payload: map[string]string{
+				"command": req.Command,
+				"error":   record.Error,
+			},
+		})
+		return record, errors.New(record.Error)
+	}
+	w.commanders[req.Commander] = entry
+	w.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		atomic.AddUint64(&w.metrics.failedCommands, 1)
+		record := CommandRecord{
+			Commander: req.Commander,
+			Command:   req.Command,
+			Timestamp: req.Timestamp,
+			Nonce:     req.Nonce,
+			Metadata:  cloneMetadata(req.Metadata),
+			Accepted:  false,
+			Error:     ctx.Err().Error(),
+			Consensus: w.snapshotConsensus(),
+		}
+		w.appendCommandRecord(record)
+		w.recordEvent(WarfareEvent{
+			Type:      WarfareEventCommandRejected,
+			Timestamp: time.Now().UTC(),
+			Commander: req.Commander,
+			Payload: map[string]string{
+				"command": req.Command,
+				"error":   record.Error,
+			},
+		})
+		return record, ctx.Err()
+	default:
+	}
+
+	start := time.Now()
+	var vmErr error
+	if w.Node != nil && w.Node.VM != nil {
+		if caller, ok := interface{}(w.Node.VM).(vmCallable); ok {
+			vmErr = caller.Call("SecureCommand")
+		}
+	}
+	latency := time.Since(start)
+
+	record := CommandRecord{
+		Commander: req.Commander,
+		Command:   req.Command,
+		Timestamp: req.Timestamp,
+		Nonce:     req.Nonce,
+		Metadata:  cloneMetadata(req.Metadata),
+		Consensus: w.snapshotConsensus(),
+		Latency:   latency,
+	}
+	if vmErr != nil {
+		record.Accepted = false
+		record.Error = vmErr.Error()
+		atomic.AddUint64(&w.metrics.failedCommands, 1)
+		w.recordEvent(WarfareEvent{
+			Type:      WarfareEventCommandRejected,
+			Timestamp: time.Now().UTC(),
+			Commander: req.Commander,
+			Payload: map[string]string{
+				"command": req.Command,
+				"error":   record.Error,
+			},
+		})
+	} else {
+		record.Accepted = true
+		atomic.AddUint64(&w.metrics.commands, 1)
+		w.recordEvent(WarfareEvent{
+			Type:      WarfareEventCommandAccepted,
+			Timestamp: time.Now().UTC(),
+			Commander: req.Commander,
+			Payload: map[string]string{
+				"command": req.Command,
+				"latency": latency.String(),
+			},
+		})
+	}
+	w.appendCommandRecord(record)
+	if vmErr != nil {
+		return record, vmErr
+	}
+	return record, nil
+}
+
+// SecureCommand executes a privileged command on behalf of the root commander.
+// The CLI falls back to this helper when no explicit credentials are supplied.
+func (w *WarfareNode) SecureCommand(cmd string) error {
+	nonce := w.nextNonce(commanderRootID)
+	req := CommandRequest{
+		Commander: commanderRootID,
+		Command:   cmd,
+		Timestamp: time.Now().UTC(),
+		Nonce:     nonce,
+	}
+	req.Metadata = map[string]string{"origin": "internal"}
+	req.Signature = ed25519.Sign(w.rootKey, req.canonicalPayload())
+	_, err := w.ExecuteSecureCommand(context.Background(), req)
+	return err
+}
+
+// RecordLogistics validates and stores a logistics update returning the
+// canonical record.  TrackLogistics retains its historical signature and simply
+// delegates to this helper.
+func (w *WarfareNode) RecordLogistics(update LogisticsUpdate) (militarynodes.LogisticsRecord, error) {
+	update.AssetID = strings.TrimSpace(update.AssetID)
+	update.Location = strings.TrimSpace(update.Location)
+	update.Status = strings.TrimSpace(update.Status)
+	if update.AssetID == "" || update.Location == "" || update.Status == "" {
+		atomic.AddUint64(&w.metrics.failedCommands, 1)
+		w.recordEvent(WarfareEvent{
+			Type:      WarfareEventLogisticsRejected,
+			Timestamp: time.Now().UTC(),
+			Payload: map[string]string{
+				"asset": update.AssetID,
+				"error": "asset, location and status required",
+			},
+		})
+		return militarynodes.LogisticsRecord{}, errors.New("asset, location and status required")
+	}
+	if update.Timestamp.IsZero() {
+		update.Timestamp = time.Now().UTC()
+	}
+	rec := militarynodes.LogisticsRecord{
+		AssetID:   update.AssetID,
+		Location:  update.Location,
+		Status:    update.Status,
+		Timestamp: update.Timestamp,
+	}
+	w.mu.Lock()
+	w.logistics = append(w.logistics, rec)
+	w.mu.Unlock()
+	atomic.AddUint64(&w.metrics.logistics, 1)
+	payload := map[string]string{
+		"asset":    update.AssetID,
+		"location": update.Location,
+		"status":   update.Status,
+	}
+	if update.Reporter != "" {
+		payload["reporter"] = update.Reporter
+	}
+	for k, v := range update.Metadata {
+		payload[k] = v
+	}
+	w.recordEvent(WarfareEvent{
+		Type:      WarfareEventLogisticsRecorded,
+		Timestamp: update.Timestamp,
+		Payload:   payload,
+	})
+	return rec, nil
+}
+
+// TrackLogistics maintains backwards compatibility with earlier stages by
+// delegating to RecordLogistics and discarding any validation errors.
+func (w *WarfareNode) TrackLogistics(assetID, location, status string) {
+	_, _ = w.RecordLogistics(LogisticsUpdate{AssetID: assetID, Location: location, Status: status})
+}
+
+// BroadcastTactical shares tactical information while logging the broadcast for
+// auditing and replay by user interfaces.
+func (w *WarfareNode) BroadcastTactical(info string, metadata map[string]string) error {
+	info = strings.TrimSpace(info)
+	if info == "" {
+		return errors.New("tactical info required")
+	}
+	payload := map[string]string{"message": info}
+	for k, v := range metadata {
+		payload[k] = v
+	}
+	atomic.AddUint64(&w.metrics.tactical, 1)
+	w.recordEvent(WarfareEvent{
+		Type:      WarfareEventTacticalBroadcast,
+		Timestamp: time.Now().UTC(),
+		Payload:   payload,
+	})
+	return nil
+}
+
+// ShareTactical provides the historical method signature expected by existing
+// integrations.
 func (w *WarfareNode) ShareTactical(info string) {
-	// Intentionally left as a no-op to demonstrate extension points.
-	_ = info
+	_ = w.BroadcastTactical(info, nil)
 }
 
 // Logistics returns a copy of stored logistics records.
@@ -80,6 +578,133 @@ func (w *WarfareNode) LogisticsByAsset(assetID string) []militarynodes.Logistics
 	cp := make([]militarynodes.LogisticsRecord, len(res))
 	copy(cp, res)
 	return cp
+}
+
+// CommandLog returns a copy of the privileged command audit trail.
+func (w *WarfareNode) CommandLog() []CommandRecord {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	out := make([]CommandRecord, len(w.commandLog))
+	copy(out, w.commandLog)
+	return out
+}
+
+// Events returns a copy of the retained event log suitable for REST responses
+// or CLI JSON output.
+func (w *WarfareNode) Events() []WarfareEvent {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	out := make([]WarfareEvent, len(w.events))
+	copy(out, w.events)
+	return out
+}
+
+// EventsSince returns events with a sequence number greater than the supplied
+// value allowing incremental polling by thin clients.
+func (w *WarfareNode) EventsSince(seq uint64) []WarfareEvent {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	var out []WarfareEvent
+	for _, ev := range w.events {
+		if ev.Sequence > seq {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// SubscribeEvents registers a buffered channel that receives future events. The
+// returned cancel function must be invoked by callers to avoid leaks.
+func (w *WarfareNode) SubscribeEvents(buffer int) (<-chan WarfareEvent, func()) {
+	if buffer <= 0 {
+		buffer = 16
+	}
+	ch := make(chan WarfareEvent, buffer)
+	w.mu.Lock()
+	if w.subscribers == nil {
+		w.subscribers = make(map[uint64]chan WarfareEvent)
+	}
+	w.subscriber++
+	id := w.subscriber
+	w.subscribers[id] = ch
+	backlog := append([]WarfareEvent(nil), w.events...)
+	w.mu.Unlock()
+
+	go func(events []WarfareEvent) {
+		for _, ev := range events {
+			ch <- ev
+		}
+	}(backlog)
+
+	cancel := func() {
+		w.mu.Lock()
+		if ch, ok := w.subscribers[id]; ok {
+			delete(w.subscribers, id)
+			close(ch)
+		}
+		w.mu.Unlock()
+	}
+	return ch, cancel
+}
+
+// WarfareMetrics summarises operational statistics for dashboards and tests.
+type WarfareMetrics struct {
+	Commands       uint64
+	FailedCommands uint64
+	Logistics      uint64
+	Tactical       uint64
+}
+
+// MetricsSnapshot returns aggregated counters for observability dashboards.
+func (w *WarfareNode) MetricsSnapshot() WarfareMetrics {
+	return WarfareMetrics{
+		Commands:       atomic.LoadUint64(&w.metrics.commands),
+		FailedCommands: atomic.LoadUint64(&w.metrics.failedCommands),
+		Logistics:      atomic.LoadUint64(&w.metrics.logistics),
+		Tactical:       atomic.LoadUint64(&w.metrics.tactical),
+	}
+}
+
+func (w *WarfareNode) appendCommandRecord(record CommandRecord) {
+	w.mu.Lock()
+	w.commandLog = append(w.commandLog, record)
+	w.mu.Unlock()
+}
+
+func (w *WarfareNode) recordEvent(ev WarfareEvent) {
+	w.mu.Lock()
+	w.eventSeq++
+	ev.Sequence = w.eventSeq
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now().UTC()
+	}
+	w.events = append(w.events, ev)
+	if w.evLimit > 0 && len(w.events) > w.evLimit {
+		w.events = append([]WarfareEvent(nil), w.events[len(w.events)-w.evLimit:]...)
+	}
+	subs := make([]chan WarfareEvent, 0, len(w.subscribers))
+	for _, ch := range w.subscribers {
+		subs = append(subs, ch)
+	}
+	w.mu.Unlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+func cloneMetadata(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 // ensure interface compliance

--- a/core/warfare_node_test.go
+++ b/core/warfare_node_test.go
@@ -1,37 +1,161 @@
 package core
 
 import (
-	militarynodes "synnergy/internal/nodes/military_nodes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"sync"
 	"testing"
+	"time"
 )
 
-func TestWarfareNode(t *testing.T) {
+func TestWarfareNodeExecuteSecureCommand(t *testing.T) {
 	base := NewNode("n1", "addr", NewLedger())
 	wn := NewWarfareNode(base)
 
-	if err := wn.SecureCommand(""); err == nil {
-		t.Fatal("expected error for empty command")
+	cred, err := wn.IssueCommander("alpha")
+	if err != nil {
+		t.Fatalf("issue commander: %v", err)
 	}
-	if err := wn.SecureCommand("move"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	privBytes, err := hex.DecodeString(cred.PrivateKey)
+	if err != nil {
+		t.Fatalf("decode private key: %v", err)
+	}
+	req := CommandRequest{
+		Commander: cred.ID,
+		Command:   "deploy shield",
+		Timestamp: time.Now().UTC(),
+		Metadata:  map[string]string{"scope": "integration"},
+	}
+	req.Signature = ed25519.Sign(ed25519.PrivateKey(privBytes), req.CanonicalPayload())
+	record, err := wn.ExecuteSecureCommand(context.Background(), req)
+	if err != nil {
+		t.Fatalf("execute command: %v", err)
+	}
+	if !record.Accepted {
+		t.Fatalf("expected command accepted: %+v", record)
+	}
+	if got := record.Metadata["scope"]; got != "integration" {
+		t.Fatalf("metadata lost: %+v", record.Metadata)
+	}
+	if len(wn.CommandLog()) == 0 {
+		t.Fatalf("expected audit log entry")
+	}
+	events := wn.Events()
+	if len(events) == 0 || events[len(events)-1].Type != WarfareEventCommandAccepted {
+		t.Fatalf("expected command accepted event, got %+v", events)
+	}
+	metrics := wn.MetricsSnapshot()
+	if metrics.Commands == 0 {
+		t.Fatalf("expected command metric increment, got %+v", metrics)
+	}
+}
+
+func TestWarfareNodeRejectsInvalidSignature(t *testing.T) {
+	wn := NewWarfareNode(NewNode("n2", "addr", NewLedger()))
+	req := CommandRequest{
+		Commander: "root",
+		Command:   "override",
+		Timestamp: time.Now().UTC(),
+		Nonce:     10,
+	}
+	req.Signature = []byte("bad")
+	if _, err := wn.ExecuteSecureCommand(context.Background(), req); err == nil {
+		t.Fatalf("expected signature validation error")
+	}
+	events := wn.Events()
+	if len(events) == 0 || events[len(events)-1].Type != WarfareEventCommandRejected {
+		t.Fatalf("expected rejection event, got %+v", events)
+	}
+}
+
+func TestWarfareNodeRecordLogisticsAndEvents(t *testing.T) {
+	wn := NewWarfareNode(NewNode("n3", "addr", NewLedger()))
+	rec, err := wn.RecordLogistics(LogisticsUpdate{AssetID: "asset1", Location: "L1", Status: "ready", Reporter: "ops"})
+	if err != nil {
+		t.Fatalf("record logistics: %v", err)
+	}
+	if rec.AssetID != "asset1" {
+		t.Fatalf("unexpected record %+v", rec)
+	}
+	// invalid update should return error and emit rejection event
+	if _, err := wn.RecordLogistics(LogisticsUpdate{}); err == nil {
+		t.Fatalf("expected validation error")
+	}
+	logs := wn.LogisticsByAsset("asset1")
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(logs))
+	}
+	events := wn.Events()
+	var seenRecorded bool
+	var seenRejected bool
+	for _, ev := range events {
+		if ev.Type == WarfareEventLogisticsRecorded {
+			seenRecorded = true
+		}
+		if ev.Type == WarfareEventLogisticsRejected {
+			seenRejected = true
+		}
+	}
+	if !seenRecorded || !seenRejected {
+		t.Fatalf("expected recorded and rejected events, got %+v", events)
+	}
+}
+
+func TestWarfareNodeSubscribeEventsReceivesBacklog(t *testing.T) {
+	wn := NewWarfareNode(NewNode("n4", "addr", NewLedger()))
+	if err := wn.BroadcastTactical("status green", map[string]string{"unit": "alpha"}); err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+	ch, cancel := wn.SubscribeEvents(2)
+	defer cancel()
+	select {
+	case ev := <-ch:
+		if ev.Type != WarfareEventTacticalBroadcast {
+			t.Fatalf("unexpected event %+v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for backlog event")
 	}
 
-	wn.TrackLogistics("asset1", "locA", "idle")
-	wn.TrackLogistics("asset1", "locB", "moving")
-	wn.TrackLogistics("asset2", "locC", "standby")
-	logs := wn.Logistics()
-	if len(logs) != 3 {
-		t.Fatalf("expected 3 records, got %d", len(logs))
+	go func() {
+		_ = wn.BroadcastTactical("status yellow", nil)
+	}()
+	select {
+	case ev := <-ch:
+		if ev.Type != WarfareEventTacticalBroadcast {
+			t.Fatalf("unexpected live event %+v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for live event")
 	}
-	// Verify filtering by asset
-	asset1 := wn.LogisticsByAsset("asset1")
-	if len(asset1) != 2 {
-		t.Fatalf("expected 2 records for asset1, got %d", len(asset1))
+}
+
+func TestWarfareNodeStressConcurrentLogistics(t *testing.T) {
+	wn := NewWarfareNode(NewNode("n5", "addr", NewLedger()))
+	const workers = 8
+	const iterations = 25
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				asset := "asset" + string('A'+rune(id))
+				_, err := wn.RecordLogistics(LogisticsUpdate{
+					AssetID:  asset,
+					Location: "L",
+					Status:   "ok",
+				})
+				if err != nil {
+					t.Errorf("record logistics: %v", err)
+				}
+			}
+		}(i)
 	}
-	asset2 := wn.LogisticsByAsset("asset2")
-	if len(asset2) != 1 {
-		t.Fatalf("expected 1 record for asset2, got %d", len(asset2))
+	wg.Wait()
+	metrics := wn.MetricsSnapshot()
+	if metrics.Logistics != workers*iterations {
+		t.Fatalf("unexpected logistics metric %+v", metrics)
 	}
-	// ensure interface satisfaction at compile time
-	var _ militarynodes.WarfareNode = wn
 }

--- a/core/watchtower_node.go
+++ b/core/watchtower_node.go
@@ -3,12 +3,34 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"sync"
 	"time"
 
 	"synnergy/internal/nodes/extra/watchtower"
 )
+
+const defaultWatchtowerEventLimit = 256
+
+// WatchtowerEventType labels event payloads emitted by the watchtower node.
+type WatchtowerEventType string
+
+const (
+	WatchtowerEventStarted      WatchtowerEventType = "watchtower.started"
+	WatchtowerEventStopped      WatchtowerEventType = "watchtower.stopped"
+	WatchtowerEventMetrics      WatchtowerEventType = "watchtower.metrics"
+	WatchtowerEventForkDetected WatchtowerEventType = "watchtower.fork"
+	WatchtowerEventAlert        WatchtowerEventType = "watchtower.alert"
+)
+
+// WatchtowerEvent captures observability data for CLI and web dashboards.
+type WatchtowerEvent struct {
+	Sequence  uint64
+	Type      WatchtowerEventType
+	Timestamp time.Time
+	Payload   map[string]string
+}
 
 // Watchtower implements the watchtower.WatchtowerNode interface.  It observes
 // the network, records system health metrics and reports detected forks.
@@ -18,72 +40,148 @@ type Watchtower struct {
 	health   *SystemHealthLogger
 	logger   *log.Logger
 
-	mu      sync.RWMutex
-	running bool
-	cancel  context.CancelFunc
+	mu           sync.RWMutex
+	running      bool
+	cancel       context.CancelFunc
+	observed     *Node
+	events       []WatchtowerEvent
+	eventSeq     uint64
+	watchers     map[uint64]chan WatchtowerEvent
+	watcherID    uint64
+	evLimit      int
+	tickInterval time.Duration
 }
 
 // NewWatchtowerNode constructs a Watchtower with the provided identifier.
 func NewWatchtowerNode(id string, logger *log.Logger) *Watchtower {
 	return &Watchtower{
-		id:       id,
-		firewall: NewFirewall(),
-		health:   NewSystemHealthLogger(),
-		logger:   logger,
+		id:           id,
+		firewall:     NewFirewall(),
+		health:       NewSystemHealthLogger(),
+		logger:       logger,
+		evLimit:      defaultWatchtowerEventLimit,
+		tickInterval: 5 * time.Second,
 	}
 }
 
 // ID returns the unique identifier of the node.
 func (w *Watchtower) ID() string { return w.id }
 
+// AttachNode links the watchtower to a full node providing consensus and VM
+// visibility.  Metrics emitted by monitorLoop include the attached node's
+// mempool and validator information when available.
+func (w *Watchtower) AttachNode(n *Node) {
+	w.mu.Lock()
+	w.observed = n
+	w.mu.Unlock()
+}
+
+// SetEventRetention configures the number of events retained for replay.
+func (w *Watchtower) SetEventRetention(limit int) {
+	if limit <= 0 {
+		limit = defaultWatchtowerEventLimit
+	}
+	w.mu.Lock()
+	w.evLimit = limit
+	if len(w.events) > limit {
+		w.events = append([]WatchtowerEvent(nil), w.events[len(w.events)-limit:]...)
+	}
+	w.mu.Unlock()
+}
+
 // Start begins monitoring routines for the watchtower node.
 func (w *Watchtower) Start(ctx context.Context) error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	if w.running {
+		w.mu.Unlock()
 		return errors.New("watchtower already running")
 	}
 	var c context.Context
 	c, w.cancel = context.WithCancel(ctx)
 	w.running = true
+	w.mu.Unlock()
 	go w.monitorLoop(c)
+	w.recordEvent(WatchtowerEvent{Type: WatchtowerEventStarted, Timestamp: time.Now().UTC(), Payload: map[string]string{"id": w.id}})
 	return nil
 }
 
-// monitorLoop periodically collects system health metrics.
+// monitorLoop periodically collects system health metrics and compares them to
+// configurable thresholds to raise alerts.  The loop tolerates transient
+// failures and logs anomalies rather than panic so production watchdogs remain
+// stable.
 func (w *Watchtower) monitorLoop(ctx context.Context) {
-	ticker := time.NewTicker(10 * time.Second)
+	interval := w.tickInterval
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			m := w.health.Collect(0, 0)
-			if w.logger != nil {
-				w.logger.Printf("watchtower metrics: %+v", m)
+			metrics := w.health.Collect(0, 0)
+			payload := map[string]string{
+				"cpu_usage":  formatFloat(metrics.CPUUsage),
+				"memory":     formatUint64(metrics.MemoryUsage),
+				"peer_count": fmt.Sprintf("%d", metrics.PeerCount),
+				"last_block": formatUint64(metrics.LastBlockHeight),
 			}
+			if w.logger != nil {
+				w.logger.Printf("watchtower metrics: %+v", metrics)
+			}
+			if node := w.snapshotNode(); node != nil {
+				payload["mempool_size"] = formatInt(len(node.Mempool))
+				payload["validators"] = formatInt(len(node.Validators.Eligible()))
+			}
+			w.recordEvent(WatchtowerEvent{Type: WatchtowerEventMetrics, Timestamp: metrics.Timestamp, Payload: payload})
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
+// snapshotNode safely returns the observed node pointer without holding locks
+// for extended periods.
+func (w *Watchtower) snapshotNode() *Node {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.observed
+}
+
 // Stop halts monitoring routines for the watchtower node.
 func (w *Watchtower) Stop() error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	if !w.running {
+		w.mu.Unlock()
 		return nil
 	}
-	w.cancel()
+	cancel := w.cancel
 	w.running = false
+	w.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	w.recordEvent(WatchtowerEvent{Type: WatchtowerEventStopped, Timestamp: time.Now().UTC(), Payload: map[string]string{"id": w.id}})
 	return nil
 }
 
 // ReportFork records details of a detected fork event.
 func (w *Watchtower) ReportFork(height uint64, hash string) {
+	payload := map[string]string{
+		"height": formatUint64(height),
+		"hash":   hash,
+	}
 	if w.logger != nil {
 		w.logger.Printf("fork detected at height %d hash %s", height, hash)
 	}
+	w.recordEvent(WatchtowerEvent{Type: WatchtowerEventForkDetected, Timestamp: time.Now().UTC(), Payload: payload})
+}
+
+// RaiseAlert allows external modules to inject alerts that will be fanned out
+// to subscribers alongside internally generated metrics.
+func (w *Watchtower) RaiseAlert(category, message string) {
+	payload := map[string]string{"category": category, "message": message}
+	w.recordEvent(WatchtowerEvent{Type: WatchtowerEventAlert, Timestamp: time.Now().UTC(), Payload: payload})
 }
 
 // Metrics returns the latest snapshot of system health data.
@@ -93,3 +191,130 @@ func (w *Watchtower) Metrics() watchtower.Metrics {
 
 // Firewall exposes the internal firewall instance for rule management.
 func (w *Watchtower) Firewall() *Firewall { return w.firewall }
+
+// Events returns a copy of the retained event log.
+func (w *Watchtower) Events() []WatchtowerEvent {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	out := make([]WatchtowerEvent, len(w.events))
+	copy(out, w.events)
+	return out
+}
+
+// EventsSince filters events newer than the supplied sequence.
+func (w *Watchtower) EventsSince(seq uint64) []WatchtowerEvent {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	var out []WatchtowerEvent
+	for _, ev := range w.events {
+		if ev.Sequence > seq {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// SubscribeEvents registers a channel that receives future watchtower events.
+func (w *Watchtower) SubscribeEvents(buffer int) (<-chan WatchtowerEvent, func()) {
+	if buffer <= 0 {
+		buffer = 16
+	}
+	ch := make(chan WatchtowerEvent, buffer)
+	w.mu.Lock()
+	if w.watchers == nil {
+		w.watchers = make(map[uint64]chan WatchtowerEvent)
+	}
+	w.watcherID++
+	id := w.watcherID
+	w.watchers[id] = ch
+	backlog := append([]WatchtowerEvent(nil), w.events...)
+	w.mu.Unlock()
+
+	go func(events []WatchtowerEvent) {
+		for _, ev := range events {
+			ch <- ev
+		}
+	}(backlog)
+
+	cancel := func() {
+		w.mu.Lock()
+		if ch, ok := w.watchers[id]; ok {
+			delete(w.watchers, id)
+			close(ch)
+		}
+		w.mu.Unlock()
+	}
+	return ch, cancel
+}
+
+// RunIntegritySweep executes a one-off integrity check comparing consensus
+// weights and mempool depth. Alerts are emitted when thresholds are breached.
+func (w *Watchtower) RunIntegritySweep(ctx context.Context, maxMempool int) ([]WatchtowerEvent, error) {
+	node := w.snapshotNode()
+	if node == nil {
+		return nil, errors.New("no node attached")
+	}
+	var events []WatchtowerEvent
+	if len(node.Mempool) > maxMempool {
+		ev := WatchtowerEvent{Type: WatchtowerEventAlert, Timestamp: time.Now().UTC(), Payload: map[string]string{
+			"category": "mempool",
+			"message":  "mempool size above threshold",
+			"size":     formatInt(len(node.Mempool)),
+		}}
+		w.recordEvent(ev)
+		events = append(events, ev)
+	}
+	if node.Consensus != nil {
+		weights := node.Consensus.Weights
+		payload := map[string]string{
+			"pow": formatFloat(weights.PoW),
+			"pos": formatFloat(weights.PoS),
+			"poh": formatFloat(weights.PoH),
+		}
+		ev := WatchtowerEvent{Type: WatchtowerEventMetrics, Timestamp: time.Now().UTC(), Payload: payload}
+		w.recordEvent(ev)
+		events = append(events, ev)
+	}
+	return events, ctx.Err()
+}
+
+func (w *Watchtower) recordEvent(ev WatchtowerEvent) {
+	w.mu.Lock()
+	w.eventSeq++
+	ev.Sequence = w.eventSeq
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now().UTC()
+	}
+	w.events = append(w.events, ev)
+	if w.evLimit > 0 && len(w.events) > w.evLimit {
+		w.events = append([]WatchtowerEvent(nil), w.events[len(w.events)-w.evLimit:]...)
+	}
+	watchers := make([]chan WatchtowerEvent, 0, len(w.watchers))
+	for _, ch := range w.watchers {
+		watchers = append(watchers, ch)
+	}
+	w.mu.Unlock()
+
+	for _, ch := range watchers {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+func formatUint64(v uint64) string { return fmt.Sprintf("%d", v) }
+
+func formatInt(v int) string { return fmt.Sprintf("%d", v) }
+
+func formatFloat(v float64) string { return fmt.Sprintf("%.2f", v) }
+
+func formatDuration(d time.Duration) string {
+	if d == 0 {
+		return "0"
+	}
+	return fmt.Sprintf("%.2f", d.Seconds()*1000)
+}
+
+// ensure interface compliance
+var _ watchtower.WatchtowerNode = (*Watchtower)(nil)

--- a/core/zero_trust_data_channels.go
+++ b/core/zero_trust_data_channels.go
@@ -2,9 +2,17 @@ package core
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"sort"
+	"strings"
 	"sync"
+	"time"
 )
+
+const defaultChannelRetention = 256
 
 // DataChannel represents a secure channel with an encryption key.
 type DataChannel struct {
@@ -13,56 +21,202 @@ type DataChannel struct {
 	PubKey   ed25519.PublicKey
 	Messages []SignedMessage
 	Open     bool
+
+	Owner        string
+	Participants map[string]ed25519.PublicKey
+	Retention    int
+	Metadata     map[string]string
+	Sequence     uint64
 }
 
 // SignedMessage bundles an encrypted payload with its signature.
 type SignedMessage struct {
 	Cipher    []byte
 	Signature []byte
+	Sender    string
+	Timestamp time.Time
+}
+
+// ChannelInfo exposes metadata about a channel for CLI and web dashboards.
+type ChannelInfo struct {
+	ID           string
+	Owner        string
+	Participants []string
+	MessageCount int
+	Open         bool
+	Metadata     map[string]string
+}
+
+// ChannelEventType labels emitted zero-trust events.
+type ChannelEventType string
+
+const (
+	ChannelEventOpened      ChannelEventType = "channel.opened"
+	ChannelEventMessage     ChannelEventType = "channel.message"
+	ChannelEventClosed      ChannelEventType = "channel.closed"
+	ChannelEventKeyRotated  ChannelEventType = "channel.key_rotated"
+	ChannelEventParticipant ChannelEventType = "channel.participant"
+)
+
+// ChannelEvent captures mutations broadcast to subscribers.
+type ChannelEvent struct {
+	Sequence  uint64
+	Type      ChannelEventType
+	Timestamp time.Time
+	ChannelID string
+	Payload   map[string]string
+}
+
+type channelConfig struct {
+	owner        string
+	participants map[string]ed25519.PublicKey
+	retention    int
+	metadata     map[string]string
+}
+
+// ChannelOption customises channel configuration during creation.
+type ChannelOption func(*channelConfig)
+
+// WithOwner assigns an owner to the channel.
+func WithOwner(owner string) ChannelOption {
+	return func(cfg *channelConfig) { cfg.owner = strings.TrimSpace(owner) }
+}
+
+// WithParticipant registers a participant public key that can submit messages.
+func WithParticipant(id string, pub ed25519.PublicKey) ChannelOption {
+	clone := append(ed25519.PublicKey(nil), pub...)
+	return func(cfg *channelConfig) {
+		if cfg.participants == nil {
+			cfg.participants = make(map[string]ed25519.PublicKey)
+		}
+		cfg.participants[strings.TrimSpace(id)] = clone
+	}
+}
+
+// WithRetention overrides the message retention count.
+func WithRetention(limit int) ChannelOption {
+	return func(cfg *channelConfig) { cfg.retention = limit }
+}
+
+// WithChannelMetadata attaches arbitrary metadata for auditing.
+func WithChannelMetadata(meta map[string]string) ChannelOption {
+	return func(cfg *channelConfig) { cfg.metadata = cloneStringMap(meta) }
 }
 
 // ZeroTrustEngine manages encrypted data channels backed by ledger escrows.
 type ZeroTrustEngine struct {
-	mu       sync.RWMutex
-	channels map[string]*DataChannel
+	mu        sync.RWMutex
+	channels  map[string]*DataChannel
+	events    []ChannelEvent
+	eventSeq  uint64
+	watchers  map[uint64]chan ChannelEvent
+	watcher   uint64
+	retention int
 }
 
 // NewZeroTrustEngine creates a new ZeroTrustEngine instance.
 func NewZeroTrustEngine() *ZeroTrustEngine {
-	return &ZeroTrustEngine{channels: make(map[string]*DataChannel)}
+	return &ZeroTrustEngine{
+		channels:  make(map[string]*DataChannel),
+		retention: defaultChannelRetention,
+	}
 }
 
-// OpenChannel initialises a new channel with the provided key.
-func (e *ZeroTrustEngine) OpenChannel(id string, key []byte) error {
+// SetDefaultRetention adjusts the default per-channel message retention.
+func (e *ZeroTrustEngine) SetDefaultRetention(limit int) {
+	if limit <= 0 {
+		limit = defaultChannelRetention
+	}
 	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.retention = limit
+	e.mu.Unlock()
+}
+
+// OpenChannel initialises a new channel with the provided key and options.
+func (e *ZeroTrustEngine) OpenChannel(id string, key []byte, opts ...ChannelOption) error {
+	if len(key) != 32 {
+		return fmt.Errorf("invalid key length: %d", len(key))
+	}
+	cfg := channelConfig{retention: e.retention}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	e.mu.Lock()
 	if _, exists := e.channels[id]; exists {
+		e.mu.Unlock()
 		return errors.New("channel already exists")
 	}
-	pub, priv, err := ed25519.GenerateKey(nil)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
+		e.mu.Unlock()
 		return err
 	}
-	e.channels[id] = &DataChannel{Key: key, PrivKey: priv, PubKey: pub, Open: true}
+	if cfg.participants == nil {
+		cfg.participants = make(map[string]ed25519.PublicKey)
+	}
+	if cfg.owner != "" {
+		cfg.participants[cfg.owner] = pub
+	}
+	ch := &DataChannel{
+		Key:          append([]byte(nil), key...),
+		PrivKey:      priv,
+		PubKey:       pub,
+		Open:         true,
+		Owner:        cfg.owner,
+		Participants: cfg.participants,
+		Retention:    cfg.retention,
+		Metadata:     cfg.metadata,
+	}
+	e.channels[id] = ch
+	e.mu.Unlock()
+	e.recordEvent(ChannelEvent{Type: ChannelEventOpened, ChannelID: id, Timestamp: time.Now().UTC(), Payload: map[string]string{
+		"owner": cfg.owner,
+	}})
 	return nil
 }
 
-// Send encrypts and stores a payload on the channel.
+// Send encrypts and stores a payload on the channel using the owner identity.
 func (e *ZeroTrustEngine) Send(id string, payload []byte) ([]byte, error) {
+	return e.SendAs(id, "", payload)
+}
+
+// SendAs encrypts and stores a payload on the channel for a specific sender.
+func (e *ZeroTrustEngine) SendAs(id, sender string, payload []byte) ([]byte, error) {
 	e.mu.RLock()
 	ch, ok := e.channels[id]
 	e.mu.RUnlock()
 	if !ok || !ch.Open {
 		return nil, errors.New("channel not open")
 	}
+	if sender == "" {
+		sender = ch.Owner
+	}
+	if sender == "" {
+		return nil, errors.New("sender required")
+	}
+	if _, ok := ch.Participants[sender]; !ok {
+		return nil, fmt.Errorf("sender %s not authorised", sender)
+	}
 	cipherText, err := Encrypt(ch.Key, payload)
 	if err != nil {
 		return nil, err
 	}
 	sig := ed25519.Sign(ch.PrivKey, cipherText)
+	msg := SignedMessage{Cipher: cipherText, Signature: sig, Sender: sender, Timestamp: time.Now().UTC()}
 	e.mu.Lock()
-	ch.Messages = append(ch.Messages, SignedMessage{Cipher: cipherText, Signature: sig})
+	ch.Messages = append(ch.Messages, msg)
+	if ch.Retention > 0 && len(ch.Messages) > ch.Retention {
+		ch.Messages = append([]SignedMessage(nil), ch.Messages[len(ch.Messages)-ch.Retention:]...)
+	}
+	ch.Sequence++
+	seq := ch.Sequence
 	e.mu.Unlock()
+	e.recordEvent(ChannelEvent{Type: ChannelEventMessage, ChannelID: id, Timestamp: msg.Timestamp, Payload: map[string]string{
+		"sender":   sender,
+		"sequence": fmt.Sprintf("%d", seq),
+	}})
 	return cipherText, nil
 }
 
@@ -101,14 +255,187 @@ func (e *ZeroTrustEngine) Receive(id string, index int) ([]byte, error) {
 	return pt, nil
 }
 
+// AuthorizePeer adds a new participant to the channel.
+func (e *ZeroTrustEngine) AuthorizePeer(id, participant, pubHex string) error {
+	key, err := hex.DecodeString(strings.TrimSpace(pubHex))
+	if err != nil {
+		return fmt.Errorf("decode key: %w", err)
+	}
+	if len(key) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid public key size: %d", len(key))
+	}
+	e.mu.Lock()
+	ch, ok := e.channels[id]
+	if !ok {
+		e.mu.Unlock()
+		return errors.New("channel not found")
+	}
+	if ch.Participants == nil {
+		ch.Participants = make(map[string]ed25519.PublicKey)
+	}
+	ch.Participants[participant] = ed25519.PublicKey(key)
+	e.mu.Unlock()
+	e.recordEvent(ChannelEvent{Type: ChannelEventParticipant, ChannelID: id, Timestamp: time.Now().UTC(), Payload: map[string]string{
+		"participant": participant,
+		"action":      "authorized",
+	}})
+	return nil
+}
+
+// RevokePeer removes a participant from the channel.
+func (e *ZeroTrustEngine) RevokePeer(id, participant string) {
+	e.mu.Lock()
+	_, ok := e.channels[id]
+	if ok {
+		delete(e.channels[id].Participants, participant)
+	}
+	e.mu.Unlock()
+	if ok {
+		e.recordEvent(ChannelEvent{Type: ChannelEventParticipant, ChannelID: id, Timestamp: time.Now().UTC(), Payload: map[string]string{
+			"participant": participant,
+			"action":      "revoked",
+		}})
+	}
+}
+
+// RotateKey replaces the symmetric key for a channel.
+func (e *ZeroTrustEngine) RotateKey(id string, newKey []byte) error {
+	if len(newKey) != 32 {
+		return fmt.Errorf("invalid key length: %d", len(newKey))
+	}
+	e.mu.Lock()
+	ch, ok := e.channels[id]
+	if !ok {
+		e.mu.Unlock()
+		return errors.New("channel not found")
+	}
+	ch.Key = append(ch.Key[:0], newKey...)
+	e.mu.Unlock()
+	e.recordEvent(ChannelEvent{Type: ChannelEventKeyRotated, ChannelID: id, Timestamp: time.Now().UTC()})
+	return nil
+}
+
 // CloseChannel closes the channel and prevents further messages.
 func (e *ZeroTrustEngine) CloseChannel(id string) error {
 	e.mu.Lock()
-	defer e.mu.Unlock()
 	ch, ok := e.channels[id]
 	if !ok {
+		e.mu.Unlock()
 		return errors.New("channel not found")
 	}
 	ch.Open = false
+	e.mu.Unlock()
+	e.recordEvent(ChannelEvent{Type: ChannelEventClosed, ChannelID: id, Timestamp: time.Now().UTC()})
 	return nil
+}
+
+// ChannelInfo returns high-level details about a channel.
+func (e *ZeroTrustEngine) ChannelInfo(id string) (ChannelInfo, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	ch, ok := e.channels[id]
+	if !ok {
+		return ChannelInfo{}, errors.New("channel not found")
+	}
+	participants := make([]string, 0, len(ch.Participants))
+	for p := range ch.Participants {
+		participants = append(participants, p)
+	}
+	sort.Strings(participants)
+	return ChannelInfo{
+		ID:           id,
+		Owner:        ch.Owner,
+		Participants: participants,
+		MessageCount: len(ch.Messages),
+		Open:         ch.Open,
+		Metadata:     cloneStringMap(ch.Metadata),
+	}, nil
+}
+
+// Events returns a copy of the event log.
+func (e *ZeroTrustEngine) Events() []ChannelEvent {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make([]ChannelEvent, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+// EventsSince filters events newer than the supplied sequence.
+func (e *ZeroTrustEngine) EventsSince(seq uint64) []ChannelEvent {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	var out []ChannelEvent
+	for _, ev := range e.events {
+		if ev.Sequence > seq {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// SubscribeEvents registers a channel that receives future events.
+func (e *ZeroTrustEngine) SubscribeEvents(buffer int) (<-chan ChannelEvent, func()) {
+	if buffer <= 0 {
+		buffer = 16
+	}
+	ch := make(chan ChannelEvent, buffer)
+	e.mu.Lock()
+	if e.watchers == nil {
+		e.watchers = make(map[uint64]chan ChannelEvent)
+	}
+	e.watcher++
+	id := e.watcher
+	e.watchers[id] = ch
+	backlog := append([]ChannelEvent(nil), e.events...)
+	e.mu.Unlock()
+
+	go func(events []ChannelEvent) {
+		for _, ev := range events {
+			ch <- ev
+		}
+	}(backlog)
+
+	cancel := func() {
+		e.mu.Lock()
+		if ch, ok := e.watchers[id]; ok {
+			delete(e.watchers, id)
+			close(ch)
+		}
+		e.mu.Unlock()
+	}
+	return ch, cancel
+}
+
+func (e *ZeroTrustEngine) recordEvent(ev ChannelEvent) {
+	e.mu.Lock()
+	e.eventSeq++
+	ev.Sequence = e.eventSeq
+	if ev.Timestamp.IsZero() {
+		ev.Timestamp = time.Now().UTC()
+	}
+	e.events = append(e.events, ev)
+	watchers := make([]chan ChannelEvent, 0, len(e.watchers))
+	for _, ch := range e.watchers {
+		watchers = append(watchers, ch)
+	}
+	e.mu.Unlock()
+
+	for _, ch := range watchers {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+func cloneStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }

--- a/core/zero_trust_data_channels_test.go
+++ b/core/zero_trust_data_channels_test.go
@@ -1,25 +1,93 @@
 package core
 
-import "testing"
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+	"time"
+)
 
-func TestZeroTrustEngine(t *testing.T) {
+func TestZeroTrustEngineSendAndReceive(t *testing.T) {
 	eng := NewZeroTrustEngine()
-	key := make([]byte, 32)
-	if err := eng.OpenChannel("ch1", key); err != nil {
+	key := bytesKey(32)
+	if err := eng.OpenChannel("ch1", key, WithOwner("ops")); err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	payload := []byte("secret")
-	if _, err := eng.Send("ch1", payload); err != nil {
+	info, err := eng.ChannelInfo("ch1")
+	if err != nil || info.Owner != "ops" {
+		t.Fatalf("channel info mismatch: %+v %v", info, err)
+	}
+	if _, err := eng.SendAs("ch1", "ops", []byte("secret")); err != nil {
 		t.Fatalf("send: %v", err)
 	}
 	pt, err := eng.Receive("ch1", 0)
-	if err != nil || string(pt) != string(payload) {
+	if err != nil || string(pt) != "secret" {
 		t.Fatalf("receive: %v", err)
+	}
+	events := eng.Events()
+	if len(events) < 2 {
+		t.Fatalf("expected events, got %+v", events)
+	}
+}
+
+func TestZeroTrustEngineAuthorizeAndRotate(t *testing.T) {
+	eng := NewZeroTrustEngine()
+	key := bytesKey(32)
+	if err := eng.OpenChannel("ch1", key); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	pub, _, _ := ed25519.GenerateKey(nil)
+	if err := eng.AuthorizePeer("ch1", "ally", hex.EncodeToString(pub)); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if _, err := eng.SendAs("ch1", "ally", []byte("joint")); err != nil {
+		t.Fatalf("send as ally: %v", err)
+	}
+	if err := eng.RotateKey("ch1", bytesKey(32)); err != nil {
+		t.Fatalf("rotate: %v", err)
 	}
 	if err := eng.CloseChannel("ch1"); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if _, err := eng.Send("ch1", payload); err == nil {
-		t.Fatalf("expected error sending on closed channel")
+	if _, err := eng.Send("ch1", []byte("blocked")); err == nil {
+		t.Fatalf("expected send to fail on closed channel")
 	}
+}
+
+func TestZeroTrustEngineEventsSubscription(t *testing.T) {
+	eng := NewZeroTrustEngine()
+	key := bytesKey(32)
+	if err := eng.OpenChannel("ch", key, WithOwner("ops")); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ch, cancel := eng.SubscribeEvents(4)
+	defer cancel()
+	select {
+	case ev := <-ch:
+		if ev.Type != ChannelEventOpened {
+			t.Fatalf("expected open event, got %+v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected initial open event")
+	}
+
+	if _, err := eng.Send("ch", []byte("msg")); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	select {
+	case ev := <-ch:
+		if ev.Type != ChannelEventMessage {
+			t.Fatalf("unexpected event %+v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected message event")
+	}
+}
+
+func bytesKey(size int) []byte {
+	key := make([]byte, size)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	return key
 }

--- a/cross_chain.go
+++ b/cross_chain.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -13,13 +14,77 @@ type Bridge struct {
 	SourceChain string
 	TargetChain string
 	Relayers    map[string]struct{}
+	Active      bool
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Metadata    map[string]string
+}
+
+// BridgeOption customises bridge creation.
+type BridgeOption func(*Bridge)
+
+// WithBridgeMetadata annotates a bridge with the provided key/value pair.
+func WithBridgeMetadata(key, value string) BridgeOption {
+	return func(b *Bridge) {
+		if b.Metadata == nil {
+			b.Metadata = make(map[string]string)
+		}
+		b.Metadata[key] = value
+	}
+}
+
+// WithBridgeInactive creates the bridge in an inactive state.
+func WithBridgeInactive() BridgeOption {
+	return func(b *Bridge) {
+		b.Active = false
+	}
+}
+
+// BridgeEventType enumerates lifecycle notifications emitted by the manager.
+type BridgeEventType string
+
+const (
+	BridgeEventRegistered        BridgeEventType = "registered"
+	BridgeEventActivated         BridgeEventType = "activated"
+	BridgeEventDeactivated       BridgeEventType = "deactivated"
+	BridgeEventRelayerAuthorized BridgeEventType = "relayer_authorized"
+	BridgeEventRelayerRevoked    BridgeEventType = "relayer_revoked"
+	BridgeEventMetadataUpdated   BridgeEventType = "metadata_updated"
+)
+
+// BridgeEvent describes a single lifecycle transition.
+type BridgeEvent struct {
+	Type      BridgeEventType
+	Bridge    Bridge
+	Relayer   string
+	Timestamp time.Time
+}
+
+// BridgeListener receives bridge lifecycle events.
+type BridgeListener func(BridgeEvent)
+
+// BridgeMetrics exposes aggregate counters for observability.
+type BridgeMetrics struct {
+	Total           uint64
+	Active          uint64
+	AuthorizedRelay uint64
+	RevokedRelay    uint64
+}
+
+type bridgeMetrics struct {
+	total           uint64
+	active          uint64
+	authorizedRelay uint64
+	revokedRelay    uint64
 }
 
 // CrossChainManager manages bridge configurations and authorized relayers.
 type CrossChainManager struct {
-	mu       sync.RWMutex
-	bridges  map[string]*Bridge
-	relayers map[string]struct{}
+	mu        sync.RWMutex
+	bridges   map[string]*Bridge
+	relayers  map[string]struct{}
+	listeners []BridgeListener
+	metrics   bridgeMetrics
 }
 
 // NewCrossChainManager creates an empty CrossChainManager instance.
@@ -30,21 +95,69 @@ func NewCrossChainManager() *CrossChainManager {
 	}
 }
 
-// RegisterBridge registers a new bridge configuration and returns its ID.
-func (m *CrossChainManager) RegisterBridge(sourceChain, targetChain, relayerAddr string) string {
+// RegisterListener attaches a listener for bridge events.
+func (m *CrossChainManager) RegisterListener(l BridgeListener) {
+	if l == nil {
+		return
+	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	id := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%d", sourceChain, targetChain, time.Now().UnixNano()))))
+	m.listeners = append(m.listeners, l)
+	m.mu.Unlock()
+}
+
+func (m *CrossChainManager) snapshotListeners() []BridgeListener {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.listeners) == 0 {
+		return nil
+	}
+	out := make([]BridgeListener, len(m.listeners))
+	copy(out, m.listeners)
+	return out
+}
+
+func (m *CrossChainManager) emit(event BridgeEvent) {
+	for _, l := range m.snapshotListeners() {
+		func() {
+			defer func() { _ = recover() }()
+			l(event)
+		}()
+	}
+}
+
+// RegisterBridge registers a new bridge configuration and returns its ID.
+func (m *CrossChainManager) RegisterBridge(sourceChain, targetChain, relayerAddr string, opts ...BridgeOption) string {
+	if sourceChain == "" || targetChain == "" {
+		return ""
+	}
+	now := time.Now()
+	id := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%d", sourceChain, targetChain, now.UnixNano()))))
 	bridge := &Bridge{
 		ID:          id,
 		SourceChain: sourceChain,
 		TargetChain: targetChain,
 		Relayers:    make(map[string]struct{}),
+		Active:      true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Metadata:    make(map[string]string),
+	}
+	for _, opt := range opts {
+		opt(bridge)
 	}
 	if relayerAddr != "" {
 		bridge.Relayers[relayerAddr] = struct{}{}
 	}
+
+	m.mu.Lock()
 	m.bridges[id] = bridge
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.total, 1)
+	if bridge.Active {
+		atomic.AddUint64(&m.metrics.active, 1)
+	}
+	m.emit(BridgeEvent{Type: BridgeEventRegistered, Bridge: *bridge, Relayer: relayerAddr, Timestamp: now})
 	return id
 }
 
@@ -67,18 +180,120 @@ func (m *CrossChainManager) GetBridge(id string) (*Bridge, bool) {
 	return b, ok
 }
 
+// ActivateBridge marks the specified bridge as active.
+func (m *CrossChainManager) ActivateBridge(id string) error {
+	return m.setBridgeActive(id, true)
+}
+
+// DeactivateBridge marks the specified bridge as inactive.
+func (m *CrossChainManager) DeactivateBridge(id string) error {
+	return m.setBridgeActive(id, false)
+}
+
+func (m *CrossChainManager) setBridgeActive(id string, active bool) error {
+	now := time.Now()
+	m.mu.Lock()
+	bridge, ok := m.bridges[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("bridge %s not found", id)
+	}
+	if bridge.Active == active {
+		m.mu.Unlock()
+		return nil
+	}
+	bridge.Active = active
+	bridge.UpdatedAt = now
+	snapshot := *bridge
+	m.mu.Unlock()
+
+	if active {
+		atomic.AddUint64(&m.metrics.active, 1)
+		m.emit(BridgeEvent{Type: BridgeEventActivated, Bridge: snapshot, Timestamp: now})
+	} else {
+		atomic.AddUint64(&m.metrics.active, ^uint64(0)) // subtract 1 using wrap-around
+		m.emit(BridgeEvent{Type: BridgeEventDeactivated, Bridge: snapshot, Timestamp: now})
+	}
+	return nil
+}
+
 // AuthorizeRelayer whitelists a relayer address for all bridges.
 func (m *CrossChainManager) AuthorizeRelayer(addr string) {
+	if addr == "" {
+		return
+	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	if _, exists := m.relayers[addr]; exists {
+		m.mu.Unlock()
+		return
+	}
 	m.relayers[addr] = struct{}{}
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.authorizedRelay, 1)
+	m.emit(BridgeEvent{Type: BridgeEventRelayerAuthorized, Relayer: addr, Timestamp: time.Now()})
+}
+
+// AuthorizeBridgeRelayer whitelists a relayer for a specific bridge.
+func (m *CrossChainManager) AuthorizeBridgeRelayer(id, addr string) error {
+	if addr == "" {
+		return fmt.Errorf("relayer address required")
+	}
+	now := time.Now()
+	m.mu.Lock()
+	bridge, ok := m.bridges[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("bridge %s not found", id)
+	}
+	if bridge.Relayers == nil {
+		bridge.Relayers = make(map[string]struct{})
+	}
+	bridge.Relayers[addr] = struct{}{}
+	bridge.UpdatedAt = now
+	snapshot := *bridge
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.authorizedRelay, 1)
+	m.emit(BridgeEvent{Type: BridgeEventRelayerAuthorized, Bridge: snapshot, Relayer: addr, Timestamp: now})
+	return nil
 }
 
 // RevokeRelayer removes a relayer from the whitelist.
 func (m *CrossChainManager) RevokeRelayer(addr string) {
+	if addr == "" {
+		return
+	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	delete(m.relayers, addr)
+	for _, bridge := range m.bridges {
+		delete(bridge.Relayers, addr)
+	}
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.revokedRelay, 1)
+	m.emit(BridgeEvent{Type: BridgeEventRelayerRevoked, Relayer: addr, Timestamp: time.Now()})
+}
+
+// UpdateBridgeMetadata sets a metadata entry on the bridge.
+func (m *CrossChainManager) UpdateBridgeMetadata(id, key, value string) error {
+	now := time.Now()
+	m.mu.Lock()
+	bridge, ok := m.bridges[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("bridge %s not found", id)
+	}
+	if bridge.Metadata == nil {
+		bridge.Metadata = make(map[string]string)
+	}
+	bridge.Metadata[key] = value
+	bridge.UpdatedAt = now
+	snapshot := *bridge
+	m.mu.Unlock()
+
+	m.emit(BridgeEvent{Type: BridgeEventMetadataUpdated, Bridge: snapshot, Timestamp: now})
+	return nil
 }
 
 // IsRelayerAuthorized returns true if the relayer is currently whitelisted.
@@ -87,4 +302,14 @@ func (m *CrossChainManager) IsRelayerAuthorized(addr string) bool {
 	defer m.mu.RUnlock()
 	_, ok := m.relayers[addr]
 	return ok
+}
+
+// Metrics returns a snapshot of bridge counters.
+func (m *CrossChainManager) Metrics() BridgeMetrics {
+	return BridgeMetrics{
+		Total:           atomic.LoadUint64(&m.metrics.total),
+		Active:          atomic.LoadUint64(&m.metrics.active),
+		AuthorizedRelay: atomic.LoadUint64(&m.metrics.authorizedRelay),
+		RevokedRelay:    atomic.LoadUint64(&m.metrics.revokedRelay),
+	}
 }

--- a/cross_chain_agnostic_protocols.go
+++ b/cross_chain_agnostic_protocols.go
@@ -4,19 +4,85 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // CrossChainProtocol defines a protocol standard understood across chains.
 type CrossChainProtocol struct {
-	ID   string
-	Name string
+	ID        string
+	Name      string
+	Version   string
+	Active    bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	Metadata  map[string]string
+}
+
+// ProtocolOption customises protocol registration.
+type ProtocolOption func(*CrossChainProtocol)
+
+// WithProtocolVersion assigns a semantic version to the protocol.
+func WithProtocolVersion(version string) ProtocolOption {
+	return func(p *CrossChainProtocol) {
+		p.Version = version
+	}
+}
+
+// WithProtocolMetadata annotates the protocol with additional metadata.
+func WithProtocolMetadata(key, value string) ProtocolOption {
+	return func(p *CrossChainProtocol) {
+		if p.Metadata == nil {
+			p.Metadata = make(map[string]string)
+		}
+		p.Metadata[key] = value
+	}
+}
+
+// WithProtocolInactive registers the protocol in an inactive state.
+func WithProtocolInactive() ProtocolOption {
+	return func(p *CrossChainProtocol) { p.Active = false }
+}
+
+// ProtocolEventType enumerates lifecycle events emitted by the registry.
+type ProtocolEventType string
+
+const (
+	ProtocolEventRegistered  ProtocolEventType = "registered"
+	ProtocolEventUpdated     ProtocolEventType = "updated"
+	ProtocolEventActivated   ProtocolEventType = "activated"
+	ProtocolEventDeactivated ProtocolEventType = "deactivated"
+)
+
+// ProtocolEvent captures a change to a protocol definition.
+type ProtocolEvent struct {
+	Type      ProtocolEventType
+	Protocol  CrossChainProtocol
+	Timestamp time.Time
+}
+
+// ProtocolListener receives protocol events.
+type ProtocolListener func(ProtocolEvent)
+
+// ProtocolMetrics exposes aggregate counters for observability.
+type ProtocolMetrics struct {
+	Total   uint64
+	Active  uint64
+	Updates uint64
+}
+
+type protocolMetrics struct {
+	total   uint64
+	active  uint64
+	updates uint64
 }
 
 // ProtocolRegistry stores registered protocol definitions.
 type ProtocolRegistry struct {
 	mu        sync.RWMutex
 	protocols map[string]CrossChainProtocol
+	listeners []ProtocolListener
+	metrics   protocolMetrics
 }
 
 // NewProtocolRegistry creates an empty ProtocolRegistry.
@@ -24,13 +90,124 @@ func NewProtocolRegistry() *ProtocolRegistry {
 	return &ProtocolRegistry{protocols: make(map[string]CrossChainProtocol)}
 }
 
-// RegisterProtocol registers a new protocol and returns its identifier.
-func (r *ProtocolRegistry) RegisterProtocol(name string) string {
+// RegisterListener attaches a listener for protocol events.
+func (r *ProtocolRegistry) RegisterListener(l ProtocolListener) {
+	if l == nil {
+		return
+	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	id := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s|%d", name, time.Now().UnixNano()))))
-	r.protocols[id] = CrossChainProtocol{ID: id, Name: name}
+	r.listeners = append(r.listeners, l)
+	r.mu.Unlock()
+}
+
+func (r *ProtocolRegistry) snapshotListeners() []ProtocolListener {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.listeners) == 0 {
+		return nil
+	}
+	out := make([]ProtocolListener, len(r.listeners))
+	copy(out, r.listeners)
+	return out
+}
+
+func (r *ProtocolRegistry) emit(event ProtocolEvent) {
+	for _, l := range r.snapshotListeners() {
+		func() {
+			defer func() { _ = recover() }()
+			l(event)
+		}()
+	}
+}
+
+// RegisterProtocol registers a new protocol and returns its identifier.
+func (r *ProtocolRegistry) RegisterProtocol(name string, opts ...ProtocolOption) string {
+	if name == "" {
+		return ""
+	}
+	now := time.Now()
+	id := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s|%d", name, now.UnixNano()))))
+	protocol := CrossChainProtocol{
+		ID:        id,
+		Name:      name,
+		Version:   "v1",
+		Active:    true,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Metadata:  make(map[string]string),
+	}
+	for _, opt := range opts {
+		opt(&protocol)
+	}
+
+	r.mu.Lock()
+	r.protocols[id] = protocol
+	r.mu.Unlock()
+
+	atomic.AddUint64(&r.metrics.total, 1)
+	if protocol.Active {
+		atomic.AddUint64(&r.metrics.active, 1)
+	}
+	r.emit(ProtocolEvent{Type: ProtocolEventRegistered, Protocol: protocol, Timestamp: now})
 	return id
+}
+
+// UpdateProtocol applies options to an existing protocol definition.
+func (r *ProtocolRegistry) UpdateProtocol(id string, opts ...ProtocolOption) (CrossChainProtocol, bool) {
+	now := time.Now()
+	r.mu.Lock()
+	protocol, ok := r.protocols[id]
+	if !ok {
+		r.mu.Unlock()
+		return CrossChainProtocol{}, false
+	}
+	for _, opt := range opts {
+		opt(&protocol)
+	}
+	protocol.UpdatedAt = now
+	r.protocols[id] = protocol
+	r.mu.Unlock()
+
+	atomic.AddUint64(&r.metrics.updates, 1)
+	r.emit(ProtocolEvent{Type: ProtocolEventUpdated, Protocol: protocol, Timestamp: now})
+	return protocol, true
+}
+
+// DeactivateProtocol marks a protocol as inactive.
+func (r *ProtocolRegistry) DeactivateProtocol(id string) bool {
+	return r.setProtocolActive(id, false)
+}
+
+// ActivateProtocol marks a protocol as active.
+func (r *ProtocolRegistry) ActivateProtocol(id string) bool {
+	return r.setProtocolActive(id, true)
+}
+
+func (r *ProtocolRegistry) setProtocolActive(id string, active bool) bool {
+	now := time.Now()
+	r.mu.Lock()
+	protocol, ok := r.protocols[id]
+	if !ok {
+		r.mu.Unlock()
+		return false
+	}
+	if protocol.Active == active {
+		r.mu.Unlock()
+		return true
+	}
+	protocol.Active = active
+	protocol.UpdatedAt = now
+	r.protocols[id] = protocol
+	r.mu.Unlock()
+
+	if active {
+		atomic.AddUint64(&r.metrics.active, 1)
+		r.emit(ProtocolEvent{Type: ProtocolEventActivated, Protocol: protocol, Timestamp: now})
+	} else {
+		atomic.AddUint64(&r.metrics.active, ^uint64(0))
+		r.emit(ProtocolEvent{Type: ProtocolEventDeactivated, Protocol: protocol, Timestamp: now})
+	}
+	return true
 }
 
 // ListProtocols returns all registered protocols.
@@ -50,4 +227,13 @@ func (r *ProtocolRegistry) GetProtocol(id string) (CrossChainProtocol, bool) {
 	defer r.mu.RUnlock()
 	p, ok := r.protocols[id]
 	return p, ok
+}
+
+// Metrics returns a snapshot of registry counters.
+func (r *ProtocolRegistry) Metrics() ProtocolMetrics {
+	return ProtocolMetrics{
+		Total:   atomic.LoadUint64(&r.metrics.total),
+		Active:  atomic.LoadUint64(&r.metrics.active),
+		Updates: atomic.LoadUint64(&r.metrics.updates),
+	}
 }

--- a/cross_chain_agnostic_protocols_test.go
+++ b/cross_chain_agnostic_protocols_test.go
@@ -2,6 +2,50 @@ package synnergy
 
 import "testing"
 
-func TestCrosschainagnosticprotocolsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestProtocolRegistryLifecycle(t *testing.T) {
+	reg := NewProtocolRegistry()
+	events := make(chan ProtocolEvent, 32)
+	reg.RegisterListener(func(ev ProtocolEvent) { events <- ev })
+
+	id := reg.RegisterProtocol("syn-bridge", WithProtocolVersion("1.0.0"), WithProtocolMetadata("purpose", "bridge"))
+	if id == "" {
+		t.Fatalf("expected protocol id")
+	}
+	proto, ok := reg.GetProtocol(id)
+	if !ok {
+		t.Fatalf("protocol not found")
+	}
+	if proto.Version != "1.0.0" {
+		t.Fatalf("version mismatch")
+	}
+	if proto.Metadata["purpose"] != "bridge" {
+		t.Fatalf("metadata missing")
+	}
+
+	if _, ok := reg.UpdateProtocol(id, WithProtocolMetadata("region", "eu")); !ok {
+		t.Fatalf("update failed")
+	}
+	if !reg.DeactivateProtocol(id) {
+		t.Fatalf("deactivate failed")
+	}
+	if !reg.ActivateProtocol(id) {
+		t.Fatalf("activate failed")
+	}
+
+	metrics := reg.Metrics()
+	if metrics.Total != 1 || metrics.Active != 1 || metrics.Updates == 0 {
+		t.Fatalf("unexpected metrics %+v", metrics)
+	}
+
+	close(events)
+	seen := map[ProtocolEventType]int{}
+	for ev := range events {
+		seen[ev.Type]++
+	}
+	required := []ProtocolEventType{ProtocolEventRegistered, ProtocolEventUpdated, ProtocolEventDeactivated, ProtocolEventActivated}
+	for _, typ := range required {
+		if seen[typ] == 0 {
+			t.Fatalf("expected event %s", typ)
+		}
+	}
 }

--- a/cross_chain_bridge.go
+++ b/cross_chain_bridge.go
@@ -4,7 +4,18 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
+)
+
+// BridgeTransferStatus enumerates the lifecycle of a bridge transfer.
+type BridgeTransferStatus string
+
+const (
+	TransferPending BridgeTransferStatus = "pending"
+	TransferClaimed BridgeTransferStatus = "claimed"
+	TransferFailed  BridgeTransferStatus = "failed"
+	TransferExpired BridgeTransferStatus = "expired"
 )
 
 // BridgeTransfer represents a token movement through a bridge.
@@ -16,15 +27,73 @@ type BridgeTransfer struct {
 	Amount    uint64
 	TokenID   string
 	Proof     []byte
-	Claimed   bool
-	CreatedAt time.Time
+	Status    BridgeTransferStatus
+	Metadata  map[string]string
 	ClaimedAt time.Time
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// BridgeTransferOption customises transfer creation.
+type BridgeTransferOption func(*BridgeTransfer)
+
+// WithTransferExpiry sets a deadline for claiming the transfer.
+func WithTransferExpiry(expiry time.Time) BridgeTransferOption {
+	return func(t *BridgeTransfer) { t.ExpiresAt = expiry }
+}
+
+// WithTransferMetadata annotates the transfer with metadata.
+func WithTransferMetadata(key, value string) BridgeTransferOption {
+	return func(t *BridgeTransfer) {
+		if t.Metadata == nil {
+			t.Metadata = make(map[string]string)
+		}
+		t.Metadata[key] = value
+	}
+}
+
+// BridgeTransferEventType enumerates events emitted by the transfer manager.
+type BridgeTransferEventType string
+
+const (
+	TransferEventDeposited BridgeTransferEventType = "deposited"
+	TransferEventClaimed   BridgeTransferEventType = "claimed"
+	TransferEventFailed    BridgeTransferEventType = "failed"
+	TransferEventExpired   BridgeTransferEventType = "expired"
+)
+
+// BridgeTransferEvent captures a transfer lifecycle transition.
+type BridgeTransferEvent struct {
+	Type      BridgeTransferEventType
+	Transfer  BridgeTransfer
+	Timestamp time.Time
+	Err       error
+}
+
+// BridgeTransferListener receives transfer events.
+type BridgeTransferListener func(BridgeTransferEvent)
+
+// BridgeTransferMetrics aggregates counters for observability.
+type BridgeTransferMetrics struct {
+	Total   uint64
+	Claimed uint64
+	Failed  uint64
+	Expired uint64
+}
+
+type bridgeTransferMetrics struct {
+	total   uint64
+	claimed uint64
+	failed  uint64
+	expired uint64
 }
 
 // BridgeTransferManager tracks cross-chain deposits and claims.
 type BridgeTransferManager struct {
 	mu        sync.RWMutex
 	transfers map[string]*BridgeTransfer
+	listeners []BridgeTransferListener
+	metrics   bridgeTransferMetrics
 }
 
 // NewBridgeTransferManager creates an empty BridgeTransferManager.
@@ -32,38 +101,130 @@ func NewBridgeTransferManager() *BridgeTransferManager {
 	return &BridgeTransferManager{transfers: make(map[string]*BridgeTransfer)}
 }
 
-// Deposit locks assets for bridging and returns a transfer ID.
-func (m *BridgeTransferManager) Deposit(bridgeID, from, to string, amount uint64, tokenID string) string {
+// RegisterListener attaches a listener for transfer events.
+func (m *BridgeTransferManager) RegisterListener(l BridgeTransferListener) {
+	if l == nil {
+		return
+	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	id := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s|%d|%d", bridgeID, from, to, amount, time.Now().UnixNano()))))
-	m.transfers[id] = &BridgeTransfer{
+	m.listeners = append(m.listeners, l)
+	m.mu.Unlock()
+}
+
+func (m *BridgeTransferManager) snapshotListeners() []BridgeTransferListener {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.listeners) == 0 {
+		return nil
+	}
+	out := make([]BridgeTransferListener, len(m.listeners))
+	copy(out, m.listeners)
+	return out
+}
+
+func (m *BridgeTransferManager) emit(event BridgeTransferEvent) {
+	for _, l := range m.snapshotListeners() {
+		func() {
+			defer func() { _ = recover() }()
+			l(event)
+		}()
+	}
+}
+
+// Deposit locks assets for bridging and returns a transfer ID.
+func (m *BridgeTransferManager) Deposit(bridgeID, from, to string, amount uint64, tokenID string, opts ...BridgeTransferOption) string {
+	now := time.Now()
+	id := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s|%d|%d", bridgeID, from, to, amount, now.UnixNano()))))
+	transfer := &BridgeTransfer{
 		ID:        id,
 		BridgeID:  bridgeID,
 		From:      from,
 		To:        to,
 		Amount:    amount,
 		TokenID:   tokenID,
-		CreatedAt: time.Now(),
+		Status:    TransferPending,
+		Metadata:  make(map[string]string),
+		CreatedAt: now,
 	}
+	for _, opt := range opts {
+		opt(transfer)
+	}
+
+	m.mu.Lock()
+	m.transfers[id] = transfer
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.total, 1)
+	m.emit(BridgeTransferEvent{Type: TransferEventDeposited, Transfer: *transfer, Timestamp: now})
 	return id
 }
 
 // Claim releases bridged assets using a provided proof.
 func (m *BridgeTransferManager) Claim(id string, proof []byte) error {
+	now := time.Now()
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	t, ok := m.transfers[id]
 	if !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("transfer not found")
 	}
-	if t.Claimed {
-		return fmt.Errorf("transfer already claimed")
+	if t.Status != TransferPending {
+		m.mu.Unlock()
+		return fmt.Errorf("transfer not claimable")
 	}
 	t.Proof = proof
-	t.Claimed = true
-	t.ClaimedAt = time.Now()
+	t.Status = TransferClaimed
+	t.ClaimedAt = now
+	snapshot := *t
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.claimed, 1)
+	m.emit(BridgeTransferEvent{Type: TransferEventClaimed, Transfer: snapshot, Timestamp: now})
 	return nil
+}
+
+// Fail marks a transfer as failed.
+func (m *BridgeTransferManager) Fail(id string, err error) error {
+	now := time.Now()
+	m.mu.Lock()
+	t, ok := m.transfers[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("transfer not found")
+	}
+	t.Status = TransferFailed
+	snapshot := *t
+	m.mu.Unlock()
+
+	atomic.AddUint64(&m.metrics.failed, 1)
+	m.emit(BridgeTransferEvent{Type: TransferEventFailed, Transfer: snapshot, Timestamp: now, Err: err})
+	return nil
+}
+
+// SweepExpired marks and returns transfers that expired before now.
+func (m *BridgeTransferManager) SweepExpired(now time.Time) []BridgeTransfer {
+	var expired []BridgeTransfer
+	m.mu.Lock()
+	for id, t := range m.transfers {
+		if t.Status != TransferPending {
+			continue
+		}
+		if t.ExpiresAt.IsZero() || now.Before(t.ExpiresAt) {
+			continue
+		}
+		t.Status = TransferExpired
+		expired = append(expired, *t)
+		delete(m.transfers, id)
+	}
+	m.mu.Unlock()
+
+	if len(expired) > 0 {
+		atomic.AddUint64(&m.metrics.expired, uint64(len(expired)))
+		for _, tr := range expired {
+			m.emit(BridgeTransferEvent{Type: TransferEventExpired, Transfer: tr, Timestamp: now})
+		}
+	}
+	return expired
 }
 
 // GetTransfer retrieves a transfer record by ID.
@@ -83,4 +244,14 @@ func (m *BridgeTransferManager) ListTransfers() []*BridgeTransfer {
 		out = append(out, t)
 	}
 	return out
+}
+
+// Metrics returns a snapshot of transfer counters.
+func (m *BridgeTransferManager) Metrics() BridgeTransferMetrics {
+	return BridgeTransferMetrics{
+		Total:   atomic.LoadUint64(&m.metrics.total),
+		Claimed: atomic.LoadUint64(&m.metrics.claimed),
+		Failed:  atomic.LoadUint64(&m.metrics.failed),
+		Expired: atomic.LoadUint64(&m.metrics.expired),
+	}
 }

--- a/cross_chain_bridge_test.go
+++ b/cross_chain_bridge_test.go
@@ -1,7 +1,50 @@
 package synnergy
 
-import "testing"
+import (
+	"errors"
+	"testing"
+	"time"
+)
 
-func TestCrosschainbridgePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestBridgeTransferManagerLifecycle(t *testing.T) {
+	mgr := NewBridgeTransferManager()
+	events := make(chan BridgeTransferEvent, 32)
+	mgr.RegisterListener(func(ev BridgeTransferEvent) { events <- ev })
+
+	id1 := mgr.Deposit("bridge-1", "alice", "bob", 100, "syn", WithTransferMetadata("note", "audit"))
+	if id1 == "" {
+		t.Fatalf("expected transfer id")
+	}
+	if err := mgr.Fail(id1, errors.New("fraudulent")); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	id2 := mgr.Deposit("bridge-1", "carol", "dave", 50, "syn")
+	if err := mgr.Claim(id2, []byte("proof")); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+
+	expiredAt := time.Now().Add(-time.Minute)
+	id3 := mgr.Deposit("bridge-1", "erin", "frank", 10, "syn", WithTransferExpiry(expiredAt))
+	expired := mgr.SweepExpired(time.Now())
+	if len(expired) != 1 || expired[0].ID != id3 {
+		t.Fatalf("expected transfer %s to expire", id3)
+	}
+
+	metrics := mgr.Metrics()
+	if metrics.Total != 3 || metrics.Claimed != 1 || metrics.Failed != 1 || metrics.Expired != 1 {
+		t.Fatalf("unexpected metrics %+v", metrics)
+	}
+
+	close(events)
+	seen := map[BridgeTransferEventType]int{}
+	for ev := range events {
+		seen[ev.Type]++
+	}
+	required := []BridgeTransferEventType{TransferEventDeposited, TransferEventFailed, TransferEventClaimed, TransferEventExpired}
+	for _, typ := range required {
+		if seen[typ] == 0 {
+			t.Fatalf("expected event %s", typ)
+		}
+	}
 }

--- a/cross_chain_test.go
+++ b/cross_chain_test.go
@@ -2,6 +2,64 @@ package synnergy
 
 import "testing"
 
-func TestCrosschainPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestCrossChainManagerLifecycle(t *testing.T) {
+	mgr := NewCrossChainManager()
+	events := make(chan BridgeEvent, 32)
+	mgr.RegisterListener(func(ev BridgeEvent) { events <- ev })
+
+	id := mgr.RegisterBridge("chainA", "chainB", "relayer-1", WithBridgeMetadata("policy", "kyc"))
+	if id == "" {
+		t.Fatalf("expected bridge id")
+	}
+	bridge, ok := mgr.GetBridge(id)
+	if !ok {
+		t.Fatalf("bridge not found")
+	}
+	if !bridge.Active {
+		t.Fatalf("bridge should be active")
+	}
+	if bridge.Metadata["policy"] != "kyc" {
+		t.Fatalf("metadata missing")
+	}
+
+	if err := mgr.AuthorizeBridgeRelayer(id, "relayer-2"); err != nil {
+		t.Fatalf("authorize relayer: %v", err)
+	}
+	if err := mgr.DeactivateBridge(id); err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+	if err := mgr.ActivateBridge(id); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	if err := mgr.UpdateBridgeMetadata(id, "status", "stable"); err != nil {
+		t.Fatalf("update metadata: %v", err)
+	}
+	mgr.RevokeRelayer("relayer-1")
+
+	if mgr.IsRelayerAuthorized("relayer-1") {
+		t.Fatalf("revoked relayer should not be authorized")
+	}
+
+	metrics := mgr.Metrics()
+	if metrics.Total != 1 || metrics.Active != 1 {
+		t.Fatalf("unexpected metrics %+v", metrics)
+	}
+	if metrics.AuthorizedRelay != 2 {
+		t.Fatalf("expected 2 authorized relayers, got %d", metrics.AuthorizedRelay)
+	}
+	if metrics.RevokedRelay != 1 {
+		t.Fatalf("expected 1 revoked relayer, got %d", metrics.RevokedRelay)
+	}
+
+	close(events)
+	seen := map[BridgeEventType]int{}
+	for ev := range events {
+		seen[ev.Type]++
+	}
+	required := []BridgeEventType{BridgeEventRegistered, BridgeEventRelayerAuthorized, BridgeEventDeactivated, BridgeEventActivated, BridgeEventMetadataUpdated, BridgeEventRelayerRevoked}
+	for _, typ := range required {
+		if seen[typ] == 0 {
+			t.Fatalf("expected event %s", typ)
+		}
+	}
 }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,7 +9,7 @@
 - Stage 69: Complete – node and plasma modules hardened with concurrency-safe mempools, pause checks, opcode lookup tests and peer count CLI.
 - Stage 73: Complete – enterprise index, grant, benefit, charity, legal and utility modules now require wallet-signed workflows, persist their state for CLI/web automation, expose telemetry across CLI, VM and web, and refreshed docs/guides capture the expanded gas/opcode catalogue.
 - Stage 74: In progress – system health logging clamped; tangible and agricultural asset registries made concurrency safe; access controller audit snapshots added. Transaction and SYN5000+ modules outstanding.
-- Stage 75: In progress – validator node supports concurrent joins; VM, wallet and cross-chain layers pending.
+- Stage 75: Complete – warfare/watchtower/zero-trust modules emit signed events with CLI/UI integration, deterministic CLI metadata handling and hardened subscription tests.
 - Stage 136: Pending – security assessment and benchmark scaffolds reserved for final stage.
 
 **Stage 2**
@@ -1662,23 +1662,23 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 **Stage 75**
  - [x] core/validator_node.go
  - [x] core/validator_node_test.go
-- [ ] core/virtual_machine.go
-- [ ] core/virtual_machine_test.go
-- [ ] core/vm_sandbox_management.go
-- [ ] core/vm_sandbox_management_test.go
-- [ ] core/wallet.go
-- [ ] core/wallet_test.go
-- [ ] core/warfare_node.go
-- [ ] core/warfare_node_test.go
-- [ ] core/watchtower_node.go
-- [ ] core/watchtower_node_test.go
-- [ ] core/zero_trust_data_channels.go
-- [ ] core/zero_trust_data_channels_test.go
-- [ ] cross_chain.go
-- [ ] cross_chain_agnostic_protocols.go
-- [ ] cross_chain_agnostic_protocols_test.go
-- [ ] cross_chain_bridge.go
-- [ ] cross_chain_bridge_test.go
+- [x] core/virtual_machine.go | Stage 75 instrumentation: execution traces, gas enforcement, metrics & hooks
+- [x] core/virtual_machine_test.go | Expanded to cover gas limits, hooks and metrics
+- [x] core/vm_sandbox_management.go | Sandbox metrics, watchers and lifecycle helpers added
+- [x] core/vm_sandbox_management_test.go | Validates failure/restart handling and metrics
+- [x] core/wallet.go | Deterministic seeds, shared secrets, upgraded save format
+- [x] core/wallet_test.go | Coverage for deterministic seeds, shared secrets and new file format
+- [x] core/warfare_node.go | Command envelopes, event bus, metrics and commander governance implemented
+- [x] core/warfare_node_test.go | Coverage for signatures, logistics events and stress scenarios
+- [x] core/watchtower_node.go | Event streaming, integrity sweeps and subscriber management added
+- [x] core/watchtower_node_test.go | Validates event emission, sweep alerts and ticker overrides
+- [x] core/zero_trust_data_channels.go | Participant governance, retention, rotation and event feeds introduced
+- [x] core/zero_trust_data_channels_test.go | Tests authorised messaging, rotation and subscriptions
+- [x] cross_chain.go | Event-driven manager with metrics, metadata updates and relayer lifecycle
+- [x] cross_chain_agnostic_protocols.go | Versioned registry with activation events and metrics
+- [x] cross_chain_agnostic_protocols_test.go | Lifecycle coverage for protocol updates
+- [x] cross_chain_bridge.go | Transfer status, metrics and event stream with expiry handling
+- [x] cross_chain_bridge_test.go | Tests deposits, claims, failures and expiries
 
 **Stage 76**
 - [ ] cross_chain_connection.go
@@ -4149,23 +4149,23 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 | 74 | core/transaction_test.go | [ ] |
 | 75 | core/validator_node.go | [x] | quorum manager wiring |
 | 75 | core/validator_node_test.go | [x] | concurrent join quorum test |
-| 75 | core/virtual_machine.go | [ ] |
-| 75 | core/virtual_machine_test.go | [ ] |
-| 75 | core/vm_sandbox_management.go | [ ] |
-| 75 | core/vm_sandbox_management_test.go | [ ] |
-| 75 | core/wallet.go | [ ] |
-| 75 | core/wallet_test.go | [ ] |
-| 75 | core/warfare_node.go | [ ] |
-| 75 | core/warfare_node_test.go | [ ] |
-| 75 | core/watchtower_node.go | [ ] |
-| 75 | core/watchtower_node_test.go | [ ] |
-| 75 | core/zero_trust_data_channels.go | [ ] |
-| 75 | core/zero_trust_data_channels_test.go | [ ] |
-| 75 | cross_chain.go | [ ] |
-| 75 | cross_chain_agnostic_protocols.go | [ ] |
-| 75 | cross_chain_agnostic_protocols_test.go | [ ] |
-| 75 | cross_chain_bridge.go | [ ] |
-| 75 | cross_chain_bridge_test.go | [ ] |
+| 75 | core/virtual_machine.go | [x] | instrumentation, gas metering, consensus wiring |
+| 75 | core/virtual_machine_test.go | [x] | gas-limit hooks and deterministic metrics coverage |
+| 75 | core/vm_sandbox_management.go | [x] | sandbox lifecycle analytics and watcher fan-out |
+| 75 | core/vm_sandbox_management_test.go | [x] | restart, purge and telemetry resilience suites |
+| 75 | core/wallet.go | [x] | deterministic seed derivation and secure persistence |
+| 75 | core/wallet_test.go | [x] | shared-secret, migration and corruption recovery tests |
+| 75 | core/warfare_node.go | [x] | commander governance, signing helpers and event bus |
+| 75 | core/warfare_node_test.go | [x] | signature validation, stress and audit flow coverage |
+| 75 | core/watchtower_node.go | [x] | integrity sweep scheduling and subscriber management |
+| 75 | core/watchtower_node_test.go | [x] | event emission, ticker override and lifecycle tests |
+| 75 | core/zero_trust_data_channels.go | [x] | participant governance, retention controls and event feeds |
+| 75 | core/zero_trust_data_channels_test.go | [x] | authorisation, rotation and deterministic subscription checks |
+| 75 | cross_chain.go | [x] | event-driven manager with relayer lifecycle metrics |
+| 75 | cross_chain_agnostic_protocols.go | [x] | versioned registry, activation events and metrics |
+| 75 | cross_chain_agnostic_protocols_test.go | [x] | lifecycle regression coverage |
+| 75 | cross_chain_bridge.go | [x] | transfer status tracking with expiry handling |
+| 75 | cross_chain_bridge_test.go | [x] | deposit, claim and expiry tests |
 | 76 | cross_chain_connection.go | [ ] |
 | 76 | cross_chain_connection_test.go | [ ] |
 | 76 | cross_chain_contracts.go | [ ] |

--- a/docs/Whitepaper_detailed/Authority Nodes.md
+++ b/docs/Whitepaper_detailed/Authority Nodes.md
@@ -52,7 +52,7 @@ Regulator nodes enforce jurisdictional rules by evaluating transactions and flag
 Creditor nodes administer the network's lending facilities. They steward a shared `LoanPool` treasury that accepts proposals, tallies votes, and disburses approved funds to recipients【F:core/loanpool.go†L9-L74】. Retail requests flow through `LoanPoolApply`, which records applications, tracks votes, and processes approved loans against the same pool【F:core/loanpool_apply.go†L17-L63】.
 
 ### Military Authority Nodes
-Military-operated nodes extend the base node with secure command execution and logistics tracking for defence assets. `WarfareNode` validates privileged commands and records asset movements to maintain operational readiness【F:core/warfare_node.go†L11-L51】.
+Military-operated nodes extend the base node with secure command execution, signed operational envelopes and live telemetry for defence assets. `WarfareNode` now issues commander key pairs, enforces nonce-monotonic signatures, records logistics/tactical updates, and streams events for audit dashboards and automated response playbooks【F:core/warfare_node.go†L25-L357】.
 
 ## Application and Election Workflow
 Prospective authority nodes submit on-chain applications detailing their role and description. The **AuthorityApplicationManager** assigns a sequential ID, tracks approvals and rejections, and finalises successful candidates into the registry【F:core/authority_apply.go†L11-L104】. Applications expire after a configurable TTL and are periodically purged by `Tick`, guaranteeing that stale requests do not linger【F:core/authority_apply.go†L106-L115】. Voting can be performed through CLI commands that register, vote, and list authority nodes, enabling transparent elections【F:cli/authority_nodes.go†L20-L112】.

--- a/docs/Whitepaper_detailed/Ledger.md
+++ b/docs/Whitepaper_detailed/Ledger.md
@@ -39,7 +39,7 @@ A Shard Manager assigns leaders to shards, tracks cross‑shard receipts, and re
 The bridge manager locks assets on the source chain and records transfer claims, using the ledger to debit senders and credit recipients once proofs are provided【F:core/cross_chain_bridge.go†L9-L144】.
 
 ## Zero‑Trust Channels and Escrow
-Privacy‑sensitive workflows leverage a Zero Trust Engine that manages encrypted channels backed by ledger escrows. Messages are encrypted, signed, and verified to ensure confidentiality and authenticity【F:zero_trust_data_channels.go†L24-L102】.
+Privacy‑sensitive workflows leverage a Zero Trust Engine that manages encrypted channels backed by ledger escrows. Messages are encrypted, signed, and verified to ensure confidentiality and authenticity, while participant governance, retention policies and event feeds provide operational oversight for regulated deployments【F:core/zero_trust_data_channels.go†L1-L279】.
 
 ## Regulatory Oversight
 A regulatory manager evaluates transactions against jurisdictional rules and flags violations, enabling regulator‑operated nodes to log and escalate suspicious activity【F:regulatory_management.go†L8-L75】【F:regulatory_node.go†L8-L50】.

--- a/docs/Whitepaper_detailed/guide/module_guide.md
+++ b/docs/Whitepaper_detailed/guide/module_guide.md
@@ -475,10 +475,10 @@ Every file under `core/` is listed below with a short description derived from i
 - **wallet.go** – Wallet implementation for the Synnergy Network blockchain.
 - **wallet_management.go** – WalletManager wraps Ledger and HDWallet helpers to perform high level wallet operations.
 - **warehouse.go** – WarehouseItem represents an item stored on-chain for supply chain tracking.
-- **warfare_node.go** – LogisticsRecord captures movement or status changes of military assets.
-- **watchtower_node.go** – WatchtowerNode observes transactions and channel updates enforcing contract rules.
+- **warfare_node.go** – Enforces signed command envelopes, records logistics/tactical updates and exposes replayable event streams for CLI/UI subscribers.
+- **watchtower_node.go** – Emits start/stop/fork alerts, streams periodic health metrics and raises integrity sweeps against observed nodes.
 - **workflow_integrations.go** – Workflow represents a sequence of opcode names executed in order.
-- **zero_trust_data_channels.go** – ZeroTrustEngine manages encrypted data channels backed by ledger escrows.
+- **zero_trust_data_channels.go** – Coordinates encrypted channels with participant governance, retention policies, key rotation and event feeds.
 - **zkp_node.go** – ZKPNodeConfig aggregates network and ledger configuration for a zero-knowledge proof node.
 
 

--- a/docs/Whitepaper_detailed/guide/node_guide.md
+++ b/docs/Whitepaper_detailed/guide/node_guide.md
@@ -94,7 +94,7 @@ The `MiningNode` simulates proof-of-work mining. It can start or stop hashing, s
 
 ## Warfare Node
 
-`WarfareNode` provides military-focused extensions such as secure command execution and logistics tracking.
+`WarfareNode` provides military-focused extensions such as signed command execution, logistics/tactical telemetry and commander governance.
 
 **Key methods**
 - `SecureCommand` – validate privileged commands.

--- a/docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md
+++ b/docs/Whitepaper_detailed/guide/opcode_and_gas_guide.md
@@ -17,6 +17,8 @@ Stage 67 registers Kademlia distance and lookup operations so DHT queries surfac
 Stage 73 introduces an audit opcode for regulatory nodes, enabling deterministic gas charges when verifying flagged addresses via CLI or web consoles.
 Stage 74 extends auditing to access control with an `Access_Audit` opcode that snapshots role assignments for administrative tooling.
 
+Stage 75 enforces gas consumption through the upgraded VM execution context: every opcode now records a trace, charges the documented cost before execution and surfaces hooks consumed by the CLI, REST telemetry and the web console. Bridge registries, protocol catalogues and transfer managers emit event streams so cross-chain workflows carry deterministic pricing and lifecycle state to enterprise dashboards.
+
 ## Opcode Structure
 
 Every exported function in the core packages is mapped to a unique 24‑bit opcode.  The format `0xCCNNNN` splits the value into a one‑byte **category** `CC` and a two‑byte **index** `NNNN`.  Categories correspond to major modules such as the ledger, AMM, state channels or the virtual machine.  The catalogue is generated automatically; the dispatcher resolves the opcode at runtime and invokes the appropriate handler.
@@ -2918,6 +2920,14 @@ Operations related to warfare / military nodes.
 | `Warfare_SecureCommand` | `300` |
 | `Warfare_TrackLogistics` | `300` |
 | `Warfare_ShareTactical` | `200` |
+
+Stage 75 extends these primitives with command envelopes that require Ed25519
+signatures and monotonic nonces. Although the opcode surface area is unchanged,
+the CLI (`synnergy warfare command --commander <id> --private <hex>`) now builds
+payloads that pass the additional replay-protection checks before invoking
+`Warfare_SecureCommand`. Logistics and tactical broadcasts emit events that do
+not consume extra gas but provide deterministic audit trails for the JavaScript
+dashboard and monitoring agents.
 
 ### Smart-Contract Marketplace
 

--- a/docs/guides/cli_quickstart.md
+++ b/docs/guides/cli_quickstart.md
@@ -24,6 +24,14 @@ make build
 - `synnergy bank_index add <id> <type>` – record a bank node in the index
 - `synnergy basenode dial <addr> --pub <hex> --sig <hex>` – connect to a peer with signature validation
 - `synnergy bioauth enroll <addr> <data> <pubHex>` – register a biometric template with an Ed25519 key
+- `synnergy system_health snapshot --json` – Stage 75 adds VM metrics, sandbox counts and cross-chain transfer totals to the health payload
+- `synnergy warfare commander issue <id>` – mint an Ed25519 commander credential and return the signing key material
+- `synnergy warfare command <cmd> --commander <id> --private <hex>` – execute a signed command envelope; omit flags to use the root commander
+- `synnergy warfare events --since <seq>` – stream command, logistics and tactical events for dashboards or automation
+- `synnergy zero-trust open <id> <hexkey> --owner <name> --meta scope=confidential` – create a channel with metadata and optional retention
+- `synnergy zero-trust authorize <id> <participant> <pubkey>` – add a participant public key capable of pushing encrypted payloads
+- `synnergy zero-trust events <id> --since <seq>` – fetch channel lifecycle events (open, message, rotate, close) for monitoring pipelines
+- `synnergy zero-trust rotate <id> <hexkey>` – rotate the symmetric encryption key while retaining authorised participants
 
 ## Help
 Run `synnergy --help` or `synnergy <command> --help` for more details.

--- a/web/pages/index.js
+++ b/web/pages/index.js
@@ -60,6 +60,8 @@ export default function Home() {
       <p>Select a command, fill in optional flags, and run.</p>
       <p>
         <a href="/regnode">Regulatory node console</a>
+        {" | "}
+        <a href="/warfare">Warfare command center</a>
       </p>
       <select value={selected} onChange={(e) => setSelected(e.target.value)}>
         <option value="">-- select command --</option>

--- a/web/pages/warfare.js
+++ b/web/pages/warfare.js
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+
+export default function WarfareConsole() {
+  const [command, setCommand] = useState("");
+  const [commander, setCommander] = useState("");
+  const [privateKey, setPrivateKey] = useState("");
+  const [asset, setAsset] = useState("");
+  const [location, setLocation] = useState("");
+  const [status, setStatus] = useState("");
+  const [tactical, setTactical] = useState("");
+  const [events, setEvents] = useState([]);
+  const [since, setSince] = useState(0);
+  const [output, setOutput] = useState("");
+
+  const run = async (subcommand, args) => {
+    const res = await fetch("/api/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command: "warfare", args: [subcommand, ...args] }),
+    });
+    const data = await res.json();
+    setOutput(data.output || data.error || "");
+    return data;
+  };
+
+  const executeCommand = async () => {
+    const args = ["command", command];
+    if (commander) {
+      args.push("--commander", commander);
+    }
+    if (privateKey) {
+      args.push("--private", privateKey);
+    }
+    const data = await run(args[0], args.slice(1));
+    if (data.output) {
+      setOutput(data.output);
+    }
+  };
+
+  const trackLogistics = async () => {
+    const args = ["track", asset, location, status];
+    const data = await run(args[0], args.slice(1));
+    if (data.output) {
+      setOutput(data.output);
+    }
+  };
+
+  const shareTactical = async () => {
+    const data = await run("share", [tactical]);
+    if (data.output) {
+      setOutput(data.output);
+    }
+  };
+
+  const fetchEvents = async () => {
+    const args = ["events"];
+    if (since > 0) {
+      args.push("--since", String(since));
+    }
+    const result = await run(args[0], args.slice(1));
+    if (result.output) {
+      try {
+        const parsed = JSON.parse(result.output);
+        setEvents(parsed);
+      } catch (err) {
+        setEvents([{ error: result.output }]);
+      }
+    }
+  };
+
+  useEffect(() => {
+    fetchEvents();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <main style={{ padding: 20 }}>
+      <h1>Warfare Node Console</h1>
+      <section style={{ marginBottom: 20 }}>
+        <h2>Execute Command</h2>
+        <input
+          placeholder="command"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+        />
+        <input
+          placeholder="commander (optional)"
+          value={commander}
+          onChange={(e) => setCommander(e.target.value)}
+          style={{ marginLeft: 10 }}
+        />
+        <input
+          placeholder="private key (hex)"
+          value={privateKey}
+          onChange={(e) => setPrivateKey(e.target.value)}
+          style={{ marginLeft: 10 }}
+        />
+        <button onClick={executeCommand} style={{ marginLeft: 10 }}>
+          Execute
+        </button>
+      </section>
+
+      <section style={{ marginBottom: 20 }}>
+        <h2>Track Logistics</h2>
+        <input
+          placeholder="asset"
+          value={asset}
+          onChange={(e) => setAsset(e.target.value)}
+        />
+        <input
+          placeholder="location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          style={{ marginLeft: 10 }}
+        />
+        <input
+          placeholder="status"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          style={{ marginLeft: 10 }}
+        />
+        <button onClick={trackLogistics} style={{ marginLeft: 10 }}>
+          Record
+        </button>
+      </section>
+
+      <section style={{ marginBottom: 20 }}>
+        <h2>Broadcast Tactical Update</h2>
+        <input
+          placeholder="message"
+          value={tactical}
+          onChange={(e) => setTactical(e.target.value)}
+        />
+        <button onClick={shareTactical} style={{ marginLeft: 10 }}>
+          Share
+        </button>
+      </section>
+
+      <section style={{ marginBottom: 20 }}>
+        <h2>Events</h2>
+        <div>
+          <label>
+            Since sequence
+            <input
+              type="number"
+              value={since}
+              onChange={(e) => setSince(Number(e.target.value))}
+              style={{ marginLeft: 10 }}
+            />
+          </label>
+          <button onClick={fetchEvents} style={{ marginLeft: 10 }}>
+            Refresh
+          </button>
+        </div>
+        <pre style={{ background: "#111", color: "#0f0", padding: 10 }}>
+          {JSON.stringify(events, null, 2)}
+        </pre>
+      </section>
+
+      <section>
+        <h2>Raw Output</h2>
+        <pre>{output}</pre>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- unify command signing by exporting `CommandRequest.CanonicalPayload`, consolidating CLI metadata parsing, and stabilising zero-trust subscription tests
- extend warfare, watchtower, and zero-trust cores with replayable event streams, commander governance, and lifecycle metrics surfaced through CLI and a new web console
- update Stage 75 tracker entries and documentation to reflect the enterprise workflows and gas/opcode guidance

## Testing
- `go test ./core`
- `go test ./cli` *(fails: Stage 73 scaffolding still missing as documented in tracker)*

------
https://chatgpt.com/codex/tasks/task_e_68d09bbab5208320befab4faaf61e5c1