### PR TITLE
Elevate contract link management for Stage 76

### DIFF
--- a/cross_chain_connection.go
+++ b/cross_chain_connection.go
@@ -1,78 +1,463 @@
 package synnergy
 
 import (
+	"context"
 	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
 
+// ConnectionStatus represents the lifecycle state of a cross-chain connection.
+type ConnectionStatus string
+
+const (
+	// ConnectionStatusPending indicates the link has been requested but not yet promoted to active.
+	ConnectionStatusPending ConnectionStatus = "PENDING"
+	// ConnectionStatusActive means the link is fully operational and healthy.
+	ConnectionStatusActive ConnectionStatus = "ACTIVE"
+	// ConnectionStatusClosing indicates the link is winding down and not accepting new flows.
+	ConnectionStatusClosing ConnectionStatus = "CLOSING"
+	// ConnectionStatusClosed marks a link that has been gracefully terminated.
+	ConnectionStatusClosed ConnectionStatus = "CLOSED"
+	// ConnectionStatusFailed marks a link that was forcefully terminated after an unrecoverable error.
+	ConnectionStatusFailed ConnectionStatus = "FAILED"
+)
+
+// ConnectionEventType represents the reason a connection update was emitted.
+type ConnectionEventType string
+
+const (
+	// ConnectionEventOpened is fired when a new connection has been created.
+	ConnectionEventOpened ConnectionEventType = "OPENED"
+	// ConnectionEventHeartbeat is emitted when a heartbeat arrives.
+	ConnectionEventHeartbeat ConnectionEventType = "HEARTBEAT"
+	// ConnectionEventClosing indicates a close operation has been initiated.
+	ConnectionEventClosing ConnectionEventType = "CLOSING"
+	// ConnectionEventClosed indicates a connection has been fully closed.
+	ConnectionEventClosed ConnectionEventType = "CLOSED"
+	// ConnectionEventFailed indicates the connection faulted.
+	ConnectionEventFailed ConnectionEventType = "FAILED"
+)
+
+// ConnectionSpec captures the parameters required to negotiate a cross-chain link.
+type ConnectionSpec struct {
+	LocalChain        string
+	RemoteChain       string
+	LocalEndpoint     string
+	RemoteEndpoint    string
+	GovernanceProfile string
+	GasProfile        string
+	Metadata          map[string]string
+	HeartbeatInterval time.Duration
+	Signer            string
+	HandshakePayload  []byte
+	HandshakeProof    []byte
+}
+
+// ConnectionFault captures contextual information about a connection failure.
+type ConnectionFault struct {
+	Code      string
+	Detail    string
+	Occurred  time.Time
+	Severity  string
+	Recovered bool
+}
+
 // ChainConnection represents an active or historic cross-chain connection.
 type ChainConnection struct {
-	ID          string
-	LocalChain  string
-	RemoteChain string
-	OpenedAt    time.Time
-	ClosedAt    time.Time
-	Closed      bool
+	ID                string
+	Spec              ConnectionSpec
+	Status            ConnectionStatus
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	OpenedAt          time.Time
+	ClosedAt          time.Time
+	ClosingReason     string
+	LastHeartbeat     time.Time
+	HeartbeatInterval time.Duration
+	Faults            []ConnectionFault
+}
+
+// ConnectionEvent notifies observers of lifecycle changes.
+type ConnectionEvent struct {
+	Type         ConnectionEventType
+	ConnectionID string
+	Status       ConnectionStatus
+	Connection   *ChainConnection
+	Fault        *ConnectionFault
+}
+
+// SignatureVerifier validates handshake payloads.
+type SignatureVerifier interface {
+	Verify(ctx context.Context, payload, signature []byte, signer string) error
+}
+
+// SignatureVerifierFunc adapts a function into a SignatureVerifier.
+type SignatureVerifierFunc func(ctx context.Context, payload, signature []byte, signer string) error
+
+// Verify implements SignatureVerifier.
+func (f SignatureVerifierFunc) Verify(ctx context.Context, payload, signature []byte, signer string) error {
+	return f(ctx, payload, signature, signer)
+}
+
+// IDGenerator provides deterministic identifiers useful for testing and auditing.
+type IDGenerator interface {
+	NewID(spec ConnectionSpec) (string, error)
+}
+
+type defaultIDGenerator struct{}
+
+func (defaultIDGenerator) NewID(spec ConnectionSpec) (string, error) {
+	base := fmt.Sprintf("%s|%s|%s|%s|%d", spec.LocalChain, spec.RemoteChain, spec.LocalEndpoint, spec.RemoteEndpoint, time.Now().UTC().UnixNano())
+	sum := sha256.Sum256([]byte(base))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ConnectionFilter allows callers to limit the returned set of connections.
+type ConnectionFilter struct {
+	Statuses     []ConnectionStatus
+	LocalChain   string
+	RemoteChain  string
+	IncludeFault bool
+	IncludeEnded bool
 }
 
 // ConnectionManager manages cross-chain connections.
 type ConnectionManager struct {
-	mu          sync.RWMutex
-	connections map[string]*ChainConnection
+	mu               sync.RWMutex
+	connections      map[string]*ChainConnection
+	watchers         map[int]chan ConnectionEvent
+	nextWatcherID    int
+	verifier         SignatureVerifier
+	idGen            IDGenerator
+	defaultHeartbeat time.Duration
 }
 
-// NewConnectionManager creates an empty ConnectionManager.
-func NewConnectionManager() *ConnectionManager {
-	return &ConnectionManager{connections: make(map[string]*ChainConnection)}
-}
+// ConnectionManagerOption customizes ConnectionManager construction.
+type ConnectionManagerOption func(*ConnectionManager)
 
-// OpenConnection establishes a new link between two chains and returns its ID.
-func (m *ConnectionManager) OpenConnection(localChain, remoteChain string) string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	id := fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%d", localChain, remoteChain, time.Now().UnixNano()))))
-	m.connections[id] = &ChainConnection{
-		ID:          id,
-		LocalChain:  localChain,
-		RemoteChain: remoteChain,
-		OpenedAt:    time.Now(),
+// WithSignatureVerifier overrides the handshake verifier.
+func WithSignatureVerifier(verifier SignatureVerifier) ConnectionManagerOption {
+	return func(m *ConnectionManager) {
+		m.verifier = verifier
 	}
-	return id
 }
 
-// CloseConnection marks a connection as closed.
-func (m *ConnectionManager) CloseConnection(id string) error {
+// WithIDGenerator overrides the identifier generator.
+func WithIDGenerator(gen IDGenerator) ConnectionManagerOption {
+	return func(m *ConnectionManager) {
+		m.idGen = gen
+	}
+}
+
+// WithDefaultHeartbeat configures the fallback heartbeat interval used when a spec omits it.
+func WithDefaultHeartbeat(interval time.Duration) ConnectionManagerOption {
+	return func(m *ConnectionManager) {
+		if interval > 0 {
+			m.defaultHeartbeat = interval
+		}
+	}
+}
+
+// NewConnectionManager creates an empty ConnectionManager with production hardened defaults.
+func NewConnectionManager(opts ...ConnectionManagerOption) *ConnectionManager {
+	m := &ConnectionManager{
+		connections:      make(map[string]*ChainConnection),
+		watchers:         make(map[int]chan ConnectionEvent),
+		defaultHeartbeat: 30 * time.Second,
+		verifier: SignatureVerifierFunc(func(ctx context.Context, payload, signature []byte, signer string) error {
+			if len(payload) == 0 {
+				return errors.New("handshake payload required")
+			}
+			if len(signature) == 0 {
+				return errors.New("handshake signature required")
+			}
+			if signer == "" {
+				return errors.New("signer required")
+			}
+			return nil
+		}),
+		idGen: defaultIDGenerator{},
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+var (
+	// ErrConnectionNotFound is returned when a connection cannot be located.
+	ErrConnectionNotFound = errors.New("connection not found")
+	// ErrConnectionClosed indicates the connection is no longer active for the requested operation.
+	ErrConnectionClosed = errors.New("connection already closed")
+	// ErrConnectionExists prevents accidental overwriting of existing identifiers.
+	ErrConnectionExists = errors.New("connection already exists")
+)
+
+// OpenConnection establishes a new link between two chains and returns its descriptor.
+func (m *ConnectionManager) OpenConnection(ctx context.Context, spec ConnectionSpec) (*ChainConnection, error) {
+	if err := validateSpec(spec); err != nil {
+		return nil, err
+	}
+	if err := m.verifier.Verify(ctx, spec.handshakeCanonicalPayload(), spec.HandshakeProof, spec.Signer); err != nil {
+		return nil, fmt.Errorf("handshake verification failed: %w", err)
+	}
+	id, err := m.idGen.NewID(spec)
+	if err != nil {
+		return nil, fmt.Errorf("generate connection id: %w", err)
+	}
+	now := time.Now().UTC()
+	conn := &ChainConnection{
+		ID:                id,
+		Spec:              cloneSpec(spec),
+		Status:            ConnectionStatusActive,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		OpenedAt:          now,
+		HeartbeatInterval: spec.HeartbeatInterval,
+		LastHeartbeat:     now,
+	}
+	if conn.HeartbeatInterval <= 0 {
+		conn.HeartbeatInterval = m.defaultHeartbeat
+	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	c, ok := m.connections[id]
+	if _, exists := m.connections[id]; exists {
+		m.mu.Unlock()
+		return nil, ErrConnectionExists
+	}
+	m.connections[id] = conn
+	snapshot := cloneConnection(conn)
+	m.mu.Unlock()
+	m.broadcast(ConnectionEvent{Type: ConnectionEventOpened, ConnectionID: id, Status: conn.Status, Connection: snapshot})
+	return snapshot, nil
+}
+
+// CloseConnection marks a connection as closed with the supplied reason.
+func (m *ConnectionManager) CloseConnection(ctx context.Context, id, reason string) (*ChainConnection, error) {
+	m.mu.Lock()
+	conn, ok := m.connections[id]
 	if !ok {
-		return fmt.Errorf("connection not found")
+		m.mu.Unlock()
+		return nil, ErrConnectionNotFound
 	}
-	if c.Closed {
-		return fmt.Errorf("connection already closed")
+	if conn.Status == ConnectionStatusClosed {
+		m.mu.Unlock()
+		return nil, ErrConnectionClosed
 	}
-	c.Closed = true
-	c.ClosedAt = time.Now()
-	return nil
+	conn.Status = ConnectionStatusClosing
+	conn.ClosingReason = reason
+	conn.UpdatedAt = time.Now().UTC()
+	closingSnapshot := cloneConnection(conn)
+	m.mu.Unlock()
+	m.broadcast(ConnectionEvent{Type: ConnectionEventClosing, ConnectionID: id, Status: conn.Status, Connection: closingSnapshot})
+
+	m.mu.Lock()
+	conn, ok = m.connections[id]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrConnectionNotFound
+	}
+	conn.Status = ConnectionStatusClosed
+	conn.UpdatedAt = time.Now().UTC()
+	conn.ClosedAt = conn.UpdatedAt
+	finalSnapshot := cloneConnection(conn)
+	m.mu.Unlock()
+	m.broadcast(ConnectionEvent{Type: ConnectionEventClosed, ConnectionID: id, Status: conn.Status, Connection: finalSnapshot})
+	return finalSnapshot, nil
+}
+
+// FailConnection records an unrecoverable error and marks the link failed.
+func (m *ConnectionManager) FailConnection(id string, fault ConnectionFault) (*ChainConnection, error) {
+	m.mu.Lock()
+	conn, ok := m.connections[id]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrConnectionNotFound
+	}
+	if fault.Occurred.IsZero() {
+		fault.Occurred = time.Now().UTC()
+	}
+	conn.Status = ConnectionStatusFailed
+	conn.Faults = append(conn.Faults, fault)
+	conn.UpdatedAt = fault.Occurred
+	failedSnapshot := cloneConnection(conn)
+	m.mu.Unlock()
+	m.broadcast(ConnectionEvent{Type: ConnectionEventFailed, ConnectionID: id, Status: conn.Status, Connection: failedSnapshot, Fault: &fault})
+	return failedSnapshot, nil
+}
+
+// MarkHeartbeat updates the last seen heartbeat timestamp for a connection.
+func (m *ConnectionManager) MarkHeartbeat(id string, at time.Time) (*ChainConnection, error) {
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	m.mu.Lock()
+	conn, ok := m.connections[id]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrConnectionNotFound
+	}
+	if conn.Status == ConnectionStatusClosed || conn.Status == ConnectionStatusFailed {
+		m.mu.Unlock()
+		return nil, ErrConnectionClosed
+	}
+	conn.LastHeartbeat = at
+	conn.UpdatedAt = at
+	snapshot := cloneConnection(conn)
+	m.mu.Unlock()
+	m.broadcast(ConnectionEvent{Type: ConnectionEventHeartbeat, ConnectionID: id, Status: conn.Status, Connection: snapshot})
+	return snapshot, nil
 }
 
 // GetConnection retrieves connection details by ID.
 func (m *ConnectionManager) GetConnection(id string) (*ChainConnection, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	c, ok := m.connections[id]
-	return c, ok
+	conn, ok := m.connections[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneConnection(conn), true
 }
 
-// ListConnections returns all known connections.
-func (m *ConnectionManager) ListConnections() []*ChainConnection {
+// ListConnections returns all known connections optionally filtered by status.
+func (m *ConnectionManager) ListConnections(filter ConnectionFilter) []*ChainConnection {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	out := make([]*ChainConnection, 0, len(m.connections))
-	for _, c := range m.connections {
-		out = append(out, c)
+	var result []*ChainConnection
+	for _, conn := range m.connections {
+		if len(filter.Statuses) > 0 && !statusAllowed(conn.Status, filter.Statuses) {
+			continue
+		}
+		if !filter.IncludeEnded && (conn.Status == ConnectionStatusClosed || conn.Status == ConnectionStatusFailed) {
+			continue
+		}
+		if filter.LocalChain != "" && conn.Spec.LocalChain != filter.LocalChain {
+			continue
+		}
+		if filter.RemoteChain != "" && conn.Spec.RemoteChain != filter.RemoteChain {
+			continue
+		}
+		result = append(result, cloneConnection(conn))
 	}
-	return out
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
+	return result
+}
+
+// Subscribe registers a watcher that receives lifecycle events. The returned cancel function must be invoked to release resources.
+func (m *ConnectionManager) Subscribe(buffer int) (<-chan ConnectionEvent, func()) {
+	m.mu.Lock()
+	id := m.nextWatcherID
+	m.nextWatcherID++
+	ch := make(chan ConnectionEvent, buffer)
+	m.watchers[id] = ch
+	m.mu.Unlock()
+	cancel := func() {
+		m.mu.Lock()
+		if watcher, ok := m.watchers[id]; ok {
+			delete(m.watchers, id)
+			close(watcher)
+		}
+		m.mu.Unlock()
+	}
+	return ch, cancel
+}
+
+func (m *ConnectionManager) broadcast(event ConnectionEvent) {
+	m.mu.RLock()
+	watchers := make([]chan ConnectionEvent, 0, len(m.watchers))
+	for _, ch := range m.watchers {
+		watchers = append(watchers, ch)
+	}
+	m.mu.RUnlock()
+	for _, ch := range watchers {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+}
+
+func validateSpec(spec ConnectionSpec) error {
+	if spec.LocalChain == "" {
+		return errors.New("local chain required")
+	}
+	if spec.RemoteChain == "" {
+		return errors.New("remote chain required")
+	}
+	if spec.LocalEndpoint == "" {
+		return errors.New("local endpoint required")
+	}
+	if spec.RemoteEndpoint == "" {
+		return errors.New("remote endpoint required")
+	}
+	if spec.Signer == "" {
+		return errors.New("signer required")
+	}
+	return nil
+}
+
+func statusAllowed(status ConnectionStatus, allowed []ConnectionStatus) bool {
+	for _, s := range allowed {
+		if s == status {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneSpec(spec ConnectionSpec) ConnectionSpec {
+	copyMeta := make(map[string]string, len(spec.Metadata))
+	for k, v := range spec.Metadata {
+		copyMeta[k] = v
+	}
+	return ConnectionSpec{
+		LocalChain:        spec.LocalChain,
+		RemoteChain:       spec.RemoteChain,
+		LocalEndpoint:     spec.LocalEndpoint,
+		RemoteEndpoint:    spec.RemoteEndpoint,
+		GovernanceProfile: spec.GovernanceProfile,
+		GasProfile:        spec.GasProfile,
+		Metadata:          copyMeta,
+		HeartbeatInterval: spec.HeartbeatInterval,
+		Signer:            spec.Signer,
+		HandshakePayload:  append([]byte(nil), spec.HandshakePayload...),
+		HandshakeProof:    append([]byte(nil), spec.HandshakeProof...),
+	}
+}
+
+func cloneConnection(conn *ChainConnection) *ChainConnection {
+	if conn == nil {
+		return nil
+	}
+	copyFaults := make([]ConnectionFault, len(conn.Faults))
+	copy(copyFaults, conn.Faults)
+	cloned := &ChainConnection{
+		ID:                conn.ID,
+		Spec:              cloneSpec(conn.Spec),
+		Status:            conn.Status,
+		CreatedAt:         conn.CreatedAt,
+		UpdatedAt:         conn.UpdatedAt,
+		OpenedAt:          conn.OpenedAt,
+		ClosedAt:          conn.ClosedAt,
+		ClosingReason:     conn.ClosingReason,
+		LastHeartbeat:     conn.LastHeartbeat,
+		HeartbeatInterval: conn.HeartbeatInterval,
+		Faults:            copyFaults,
+	}
+	return cloned
+}
+
+func (spec ConnectionSpec) handshakeCanonicalPayload() []byte {
+	if len(spec.HandshakePayload) > 0 {
+		return append([]byte(nil), spec.HandshakePayload...)
+	}
+	base := fmt.Sprintf("%s|%s|%s|%s|%s", spec.LocalChain, spec.RemoteChain, spec.LocalEndpoint, spec.RemoteEndpoint, spec.Signer)
+	return []byte(base)
 }

--- a/cross_chain_connection_test.go
+++ b/cross_chain_connection_test.go
@@ -1,7 +1,279 @@
 package synnergy
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
 
-func TestCrosschainconnectionPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+type staticIDGenerator struct {
+	id string
+}
+
+func (g staticIDGenerator) NewID(ConnectionSpec) (string, error) {
+	if g.id == "" {
+		return "", errors.New("id required")
+	}
+	return g.id, nil
+}
+
+type sequenceIDGenerator struct {
+	next int
+}
+
+func (g *sequenceIDGenerator) NewID(ConnectionSpec) (string, error) {
+	g.next++
+	return fmt.Sprintf("conn-%d", g.next), nil
+}
+
+func TestOpenConnectionSuccess(t *testing.T) {
+	ctx := context.Background()
+	payload := []byte("payload")
+	spec := ConnectionSpec{
+		LocalChain:        "syn-mainnet",
+		RemoteChain:       "eth-mainnet",
+		LocalEndpoint:     "wss://syn",
+		RemoteEndpoint:    "wss://eth",
+		Signer:            "authority-1",
+		HandshakePayload:  payload,
+		HandshakeProof:    []byte("signature"),
+		Metadata:          map[string]string{"vm": "synvm"},
+		HeartbeatInterval: 5 * time.Second,
+	}
+
+	var verified bool
+	verifier := SignatureVerifierFunc(func(ctx context.Context, receivedPayload, signature []byte, signer string) error {
+		verified = true
+		if string(receivedPayload) != string(payload) {
+			t.Fatalf("unexpected payload: %q", receivedPayload)
+		}
+		if string(signature) != "signature" {
+			t.Fatalf("unexpected signature: %q", signature)
+		}
+		if signer != spec.Signer {
+			t.Fatalf("unexpected signer: %q", signer)
+		}
+		return nil
+	})
+
+	mgr := NewConnectionManager(WithSignatureVerifier(verifier), WithIDGenerator(staticIDGenerator{id: "conn-1"}))
+	events, cancel := mgr.Subscribe(4)
+	defer cancel()
+
+	conn, err := mgr.OpenConnection(ctx, spec)
+	if err != nil {
+		t.Fatalf("open connection failed: %v", err)
+	}
+	if !verified {
+		t.Fatalf("signature verifier was not invoked")
+	}
+	if conn.ID != "conn-1" {
+		t.Fatalf("unexpected id: %s", conn.ID)
+	}
+	if conn.Status != ConnectionStatusActive {
+		t.Fatalf("unexpected status: %s", conn.Status)
+	}
+	if conn.Spec.Metadata["vm"] != "synvm" {
+		t.Fatalf("metadata not cloned")
+	}
+	if conn.HeartbeatInterval != spec.HeartbeatInterval {
+		t.Fatalf("unexpected heartbeat: %s", conn.HeartbeatInterval)
+	}
+
+	select {
+	case evt := <-events:
+		if evt.Type != ConnectionEventOpened {
+			t.Fatalf("unexpected event type: %s", evt.Type)
+		}
+		if evt.Connection == nil || evt.Connection.ID != conn.ID {
+			t.Fatalf("expected event snapshot for %s", conn.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected open event")
+	}
+}
+
+func TestOpenConnectionValidation(t *testing.T) {
+	mgr := NewConnectionManager()
+	_, err := mgr.OpenConnection(context.Background(), ConnectionSpec{
+		RemoteChain:      "remote",
+		LocalEndpoint:    "local",
+		RemoteEndpoint:   "remote",
+		Signer:           "signer",
+		HandshakeProof:   []byte("sig"),
+		HandshakePayload: []byte("payload"),
+	})
+	if err == nil {
+		t.Fatal("expected validation error for missing local chain")
+	}
+}
+
+func TestCloseConnectionTransitions(t *testing.T) {
+	ctx := context.Background()
+	mgr := NewConnectionManager(WithIDGenerator(staticIDGenerator{id: "conn-1"}))
+	events, cancel := mgr.Subscribe(8)
+	defer cancel()
+
+	spec := ConnectionSpec{
+		LocalChain:       "syn",
+		RemoteChain:      "ally",
+		LocalEndpoint:    "local",
+		RemoteEndpoint:   "remote",
+		Signer:           "authority",
+		HandshakeProof:   []byte("sig"),
+		HandshakePayload: []byte("payload"),
+	}
+	_, err := mgr.OpenConnection(ctx, spec)
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	<-events // consume opened event
+
+	closed, err := mgr.CloseConnection(ctx, "conn-1", "rotation")
+	if err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	if closed.Status != ConnectionStatusClosed {
+		t.Fatalf("expected closed status, got %s", closed.Status)
+	}
+	if closed.ClosingReason != "rotation" {
+		t.Fatalf("unexpected closing reason: %s", closed.ClosingReason)
+	}
+
+	var closingSeen, closedSeen bool
+	timeout := time.After(time.Second)
+	for !closingSeen || !closedSeen {
+		select {
+		case evt := <-events:
+			switch evt.Type {
+			case ConnectionEventClosing:
+				closingSeen = true
+			case ConnectionEventClosed:
+				closedSeen = true
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for lifecycle events")
+		}
+	}
+
+	if _, err := mgr.CloseConnection(ctx, "conn-1", "again"); !errors.Is(err, ErrConnectionClosed) {
+		t.Fatalf("expected ErrConnectionClosed, got %v", err)
+	}
+}
+
+func TestFailConnectionRecordsFault(t *testing.T) {
+	mgr := NewConnectionManager(WithIDGenerator(staticIDGenerator{id: "faulty"}))
+	_, err := mgr.OpenConnection(context.Background(), ConnectionSpec{
+		LocalChain:       "syn",
+		RemoteChain:      "ally",
+		LocalEndpoint:    "local",
+		RemoteEndpoint:   "remote",
+		Signer:           "authority",
+		HandshakeProof:   []byte("sig"),
+		HandshakePayload: []byte("payload"),
+	})
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+
+	fault := ConnectionFault{Code: "timeout", Detail: "no heartbeat", Severity: "critical"}
+	conn, err := mgr.FailConnection("faulty", fault)
+	if err != nil {
+		t.Fatalf("fail connection: %v", err)
+	}
+	if conn.Status != ConnectionStatusFailed {
+		t.Fatalf("expected failed status, got %s", conn.Status)
+	}
+	if len(conn.Faults) != 1 || conn.Faults[0].Code != "timeout" {
+		t.Fatalf("fault not recorded: %+v", conn.Faults)
+	}
+}
+
+func TestMarkHeartbeat(t *testing.T) {
+	mgr := NewConnectionManager(WithIDGenerator(staticIDGenerator{id: "hb"}))
+	conn, err := mgr.OpenConnection(context.Background(), ConnectionSpec{
+		LocalChain:       "syn",
+		RemoteChain:      "ally",
+		LocalEndpoint:    "local",
+		RemoteEndpoint:   "remote",
+		Signer:           "authority",
+		HandshakeProof:   []byte("sig"),
+		HandshakePayload: []byte("payload"),
+	})
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+
+	nextBeat := conn.LastHeartbeat.Add(10 * time.Second)
+	updated, err := mgr.MarkHeartbeat("hb", nextBeat)
+	if err != nil {
+		t.Fatalf("mark heartbeat: %v", err)
+	}
+	if !updated.LastHeartbeat.Equal(nextBeat) {
+		t.Fatalf("heartbeat not updated: %v", updated.LastHeartbeat)
+	}
+
+	if _, err := mgr.CloseConnection(context.Background(), "hb", "shutdown"); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	if _, err := mgr.MarkHeartbeat("hb", time.Now()); !errors.Is(err, ErrConnectionClosed) {
+		t.Fatalf("expected ErrConnectionClosed, got %v", err)
+	}
+}
+
+func TestListConnectionsFilter(t *testing.T) {
+	seqGen := &sequenceIDGenerator{}
+	mgr := NewConnectionManager(WithIDGenerator(seqGen))
+
+	_, err := mgr.OpenConnection(context.Background(), ConnectionSpec{
+		LocalChain:       "syn",
+		RemoteChain:      "ally",
+		LocalEndpoint:    "local",
+		RemoteEndpoint:   "remote",
+		Signer:           "authority",
+		HandshakeProof:   []byte("sig"),
+		HandshakePayload: []byte("payload"),
+	})
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+
+	_, err = mgr.OpenConnection(context.Background(), ConnectionSpec{
+		LocalChain:       "syn",
+		RemoteChain:      "ally",
+		LocalEndpoint:    "local",
+		RemoteEndpoint:   "remote",
+		Signer:           "authority",
+		HandshakeProof:   []byte("sig"),
+		HandshakePayload: []byte("payload"),
+	})
+	if err != nil {
+		t.Fatalf("second open failed: %v", err)
+	}
+
+	_, err = mgr.FailConnection("conn-2", ConnectionFault{Code: "fault"})
+	if err != nil {
+		t.Fatalf("fail connection: %v", err)
+	}
+
+	active := mgr.ListConnections(ConnectionFilter{Statuses: []ConnectionStatus{ConnectionStatusActive}})
+	if len(active) != 1 {
+		t.Fatalf("expected one active connection, got %d", len(active))
+	}
+
+	ended := mgr.ListConnections(ConnectionFilter{IncludeEnded: true, Statuses: []ConnectionStatus{ConnectionStatusFailed}})
+	if len(ended) != 1 || ended[0].Status != ConnectionStatusFailed {
+		t.Fatalf("expected failed connection in results")
+	}
+}
+
+func TestSubscribeCancellation(t *testing.T) {
+	mgr := NewConnectionManager()
+	events, cancel := mgr.Subscribe(1)
+	cancel()
+	if _, ok := <-events; ok {
+		t.Fatalf("expected channel to be closed after cancel")
+	}
 }

--- a/cross_chain_contracts.go
+++ b/cross_chain_contracts.go
@@ -1,58 +1,740 @@
 package synnergy
 
-import "sync"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
 
-// XContractMapping links a local contract address to a contract on another chain.
-type XContractMapping struct {
-	LocalAddress  string
-	RemoteChain   string
-	RemoteAddress string
+// ContractLinkStatus represents the lifecycle state for a cross-chain contract mapping.
+type ContractLinkStatus string
+
+const (
+	// ContractLinkStatusPending indicates the mapping is awaiting the required approvals.
+	ContractLinkStatusPending ContractLinkStatus = "PENDING"
+	// ContractLinkStatusActive means the mapping can route traffic across the function web.
+	ContractLinkStatusActive ContractLinkStatus = "ACTIVE"
+	// ContractLinkStatusSuspended means the mapping has been temporarily disabled.
+	ContractLinkStatusSuspended ContractLinkStatus = "SUSPENDED"
+	// ContractLinkStatusRetired means the mapping has been permanently decommissioned.
+	ContractLinkStatusRetired ContractLinkStatus = "RETIRED"
+	// ContractLinkStatusFailed captures a mapping that faulted and needs remediation.
+	ContractLinkStatusFailed ContractLinkStatus = "FAILED"
+)
+
+// ContractLinkEventType describes the reason an event was emitted.
+type ContractLinkEventType string
+
+const (
+	ContractLinkEventRegistered       ContractLinkEventType = "REGISTERED"
+	ContractLinkEventApprovalRecorded ContractLinkEventType = "APPROVAL_RECORDED"
+	ContractLinkEventActivated        ContractLinkEventType = "ACTIVATED"
+	ContractLinkEventSuspended        ContractLinkEventType = "SUSPENDED"
+	ContractLinkEventResumed          ContractLinkEventType = "RESUMED"
+	ContractLinkEventUpdated          ContractLinkEventType = "UPDATED"
+	ContractLinkEventRetired          ContractLinkEventType = "RETIRED"
+	ContractLinkEventFailed           ContractLinkEventType = "FAILED"
+)
+
+// AccessPolicy defines the approval and privacy controls applied to a mapping.
+type AccessPolicy struct {
+	AllowedApprovers  []string
+	RequiredApprovals int
+	PrivacyLevel      string
+	EncryptionScheme  string
 }
 
-// XContractRegistry stores cross-chain contract mappings.
-type XContractRegistry struct {
+// ContractLinkSpec captures the configuration for a cross-chain contract mapping.
+type ContractLinkSpec struct {
+	LocalChain     string
+	LocalAddress   string
+	RemoteChain    string
+	RemoteAddress  string
+	ConnectionID   string
+	Capabilities   []string
+	GasProfile     string
+	Metadata       map[string]string
+	AccessPolicy   AccessPolicy
+	AuditTrailHint string
+}
+
+// ContractLinkFailure records failure context for a contract mapping.
+type ContractLinkFailure struct {
+	Code       string
+	Detail     string
+	Occurred   time.Time
+	Resolved   bool
+	ResolvedAt time.Time
+}
+
+// ContractLink models the lifecycle of a cross-chain contract mapping.
+type ContractLink struct {
+	ID                string
+	Spec              ContractLinkSpec
+	Status            ContractLinkStatus
+	Version           uint64
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	ActivatedAt       time.Time
+	SuspendedAt       time.Time
+	RetiredAt         time.Time
+	SuspensionReason  string
+	RetirementReason  string
+	ApprovalThreshold int
+	Approvals         map[string]time.Time
+	Failures          []ContractLinkFailure
+}
+
+// ContractLinkEvent notifies subscribers of lifecycle changes.
+type ContractLinkEvent struct {
+	Type     ContractLinkEventType
+	LinkID   string
+	Link     *ContractLink
+	Approver string
+	Reason   string
+	Failure  *ContractLinkFailure
+}
+
+// ContractLinkFilter allows callers to constrain list results.
+type ContractLinkFilter struct {
+	Statuses     []ContractLinkStatus
+	LocalChain   string
+	RemoteChain  string
+	ConnectionID string
+}
+
+// ConnectionSnapshotSource provides read access to connection snapshots.
+type ConnectionSnapshotSource interface {
+	GetConnection(id string) (*ChainConnection, bool)
+}
+
+// ContractLinkIDGenerator produces deterministic identifiers for mappings.
+type ContractLinkIDGenerator interface {
+	NewContractLinkID(spec ContractLinkSpec) (string, error)
+}
+
+// defaultContractLinkIDGenerator hashes the specification to produce a stable ID.
+type defaultContractLinkIDGenerator struct{}
+
+// NewContractLinkID implements ContractLinkIDGenerator.
+func (defaultContractLinkIDGenerator) NewContractLinkID(spec ContractLinkSpec) (string, error) {
+	segments := []string{
+		strings.ToLower(strings.TrimSpace(spec.LocalChain)),
+		strings.ToLower(strings.TrimSpace(spec.LocalAddress)),
+		strings.ToLower(strings.TrimSpace(spec.RemoteChain)),
+		strings.ToLower(strings.TrimSpace(spec.RemoteAddress)),
+		strings.ToLower(strings.TrimSpace(spec.ConnectionID)),
+	}
+	for _, segment := range segments {
+		if segment == "" {
+			return "", fmt.Errorf("%w: specification missing required fields", ErrContractLinkInvalidSpec)
+		}
+	}
+	sum := sha256.Sum256([]byte(strings.Join(segments, "|")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ContractLinkManager orchestrates contract link lifecycles and telemetry.
+type ContractLinkManager struct {
 	mu       sync.RWMutex
-	mappings map[string]XContractMapping
+	links    map[string]*ContractLink
+	byLocal  map[string]string
+	watchers map[int]chan ContractLinkEvent
+	nextID   int
+	resolver ConnectionSnapshotSource
+	idGen    ContractLinkIDGenerator
+	clock    func() time.Time
 }
 
-// NewXContractRegistry creates an empty XContractRegistry.
-func NewXContractRegistry() *XContractRegistry {
-	return &XContractRegistry{mappings: make(map[string]XContractMapping)}
-}
+// ContractLinkManagerOption customises manager construction.
+type ContractLinkManagerOption func(*ContractLinkManager)
 
-// RegisterMapping records a new cross-chain contract mapping.
-func (r *XContractRegistry) RegisterMapping(localAddr, remoteChain, remoteAddr string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.mappings[localAddr] = XContractMapping{
-		LocalAddress:  localAddr,
-		RemoteChain:   remoteChain,
-		RemoteAddress: remoteAddr,
+// WithContractLinkResolver configures the manager to verify connections.
+func WithContractLinkResolver(resolver ConnectionSnapshotSource) ContractLinkManagerOption {
+	return func(m *ContractLinkManager) {
+		m.resolver = resolver
 	}
 }
 
-// ListMappings returns all registered contract mappings.
-func (r *XContractRegistry) ListMappings() []XContractMapping {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	out := make([]XContractMapping, 0, len(r.mappings))
-	for _, m := range r.mappings {
-		out = append(out, m)
+// WithContractLinkIDGenerator overrides the identifier generator.
+func WithContractLinkIDGenerator(gen ContractLinkIDGenerator) ContractLinkManagerOption {
+	return func(m *ContractLinkManager) {
+		if gen != nil {
+			m.idGen = gen
+		}
+	}
+}
+
+// WithContractLinkClock overrides the clock used for timestamps (primarily for tests).
+func WithContractLinkClock(clock func() time.Time) ContractLinkManagerOption {
+	return func(m *ContractLinkManager) {
+		if clock != nil {
+			m.clock = clock
+		}
+	}
+}
+
+// NewContractLinkManager builds a hardened manager suitable for enterprise workflows.
+func NewContractLinkManager(opts ...ContractLinkManagerOption) *ContractLinkManager {
+	m := &ContractLinkManager{
+		links:    make(map[string]*ContractLink),
+		byLocal:  make(map[string]string),
+		watchers: make(map[int]chan ContractLinkEvent),
+		idGen:    defaultContractLinkIDGenerator{},
+		clock: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+var (
+	// ErrContractLinkExists indicates the mapping already exists.
+	ErrContractLinkExists = errors.New("contract link already exists")
+	// ErrContractLinkNotFound indicates the requested mapping does not exist.
+	ErrContractLinkNotFound = errors.New("contract link not found")
+	// ErrContractLinkConnectionUnknown indicates the referenced connection is missing.
+	ErrContractLinkConnectionUnknown = errors.New("contract link connection unknown")
+	// ErrContractLinkConnectionInactive indicates the referenced connection is not active.
+	ErrContractLinkConnectionInactive = errors.New("contract link connection inactive")
+	// ErrContractLinkInvalidSpec indicates the provided specification is invalid.
+	ErrContractLinkInvalidSpec = errors.New("contract link specification invalid")
+	// ErrContractLinkApproverNotAllowed indicates the approver is not authorised for the mapping.
+	ErrContractLinkApproverNotAllowed = errors.New("approver not permitted for this contract link")
+	// ErrContractLinkApprovalDuplicate indicates the approver has already signed off on the mapping.
+	ErrContractLinkApprovalDuplicate = errors.New("approval already recorded for contract link")
+	// ErrContractLinkInvalidState indicates the mapping is not in a state that supports the requested transition.
+	ErrContractLinkInvalidState = errors.New("contract link is in an invalid state for this operation")
+)
+
+// ContractLinkUpdate captures mutable attributes for a mapping.
+type ContractLinkUpdate struct {
+	Capabilities []string
+	GasProfile   string
+	Metadata     map[string]string
+}
+
+// Register adds a new contract mapping into the catalogue.
+func (m *ContractLinkManager) Register(spec ContractLinkSpec) (*ContractLink, error) {
+	if err := validateContractLinkSpec(spec); err != nil {
+		return nil, err
+	}
+	if err := m.ensureConnectionActive(spec.ConnectionID); err != nil {
+		return nil, err
+	}
+	canonicalSpec := cloneContractLinkSpec(spec)
+	id, err := m.idGen.NewContractLinkID(canonicalSpec)
+	if err != nil {
+		return nil, err
+	}
+	now := m.now()
+	approvals := make(map[string]time.Time)
+	status := ContractLinkStatusPending
+	if canonicalSpec.AccessPolicy.RequiredApprovals <= 0 {
+		status = ContractLinkStatusActive
+	}
+	link := &ContractLink{
+		ID:                id,
+		Spec:              canonicalSpec,
+		Status:            status,
+		Version:           1,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		ApprovalThreshold: canonicalSpec.AccessPolicy.RequiredApprovals,
+		Approvals:         approvals,
+	}
+	if status == ContractLinkStatusActive {
+		link.ActivatedAt = now
+	}
+	localKey := normalizeKey(canonicalSpec.LocalChain, canonicalSpec.LocalAddress)
+
+	m.mu.Lock()
+	if _, exists := m.links[id]; exists {
+		m.mu.Unlock()
+		return nil, ErrContractLinkExists
+	}
+	if existing, ok := m.byLocal[localKey]; ok {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("%w: local contract already mapped to %s", ErrContractLinkExists, existing)
+	}
+	m.links[id] = link
+	m.byLocal[localKey] = id
+	snapshot := cloneContractLink(link)
+	activated := status == ContractLinkStatusActive
+	m.mu.Unlock()
+
+	m.broadcast(ContractLinkEvent{Type: ContractLinkEventRegistered, LinkID: id, Link: snapshot})
+	if activated {
+		m.broadcast(ContractLinkEvent{Type: ContractLinkEventActivated, LinkID: id, Link: snapshot})
+	}
+	return snapshot, nil
+}
+
+// RecordApproval records an approval for a mapping and activates it when the threshold is reached.
+func (m *ContractLinkManager) RecordApproval(linkID, approver string) (*ContractLink, error) {
+	normalizedApprover := strings.ToLower(strings.TrimSpace(approver))
+	if normalizedApprover == "" {
+		return nil, fmt.Errorf("%w: approver required", ErrContractLinkApproverNotAllowed)
+	}
+	m.mu.Lock()
+	link, ok := m.links[linkID]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrContractLinkNotFound
+	}
+	if link.Status != ContractLinkStatusPending {
+		m.mu.Unlock()
+		return nil, ErrContractLinkInvalidState
+	}
+	if !approverAllowed(link.Spec.AccessPolicy, approver) {
+		m.mu.Unlock()
+		return nil, ErrContractLinkApproverNotAllowed
+	}
+	if _, exists := link.Approvals[normalizedApprover]; exists {
+		m.mu.Unlock()
+		return nil, ErrContractLinkApprovalDuplicate
+	}
+	now := m.now()
+	link.Approvals[normalizedApprover] = now
+	link.UpdatedAt = now
+	link.Version++
+	activated := false
+	if len(link.Approvals) >= link.ApprovalThreshold {
+		link.Status = ContractLinkStatusActive
+		link.ActivatedAt = now
+		activated = true
+	}
+	snapshot := cloneContractLink(link)
+	m.mu.Unlock()
+
+	m.broadcast(ContractLinkEvent{Type: ContractLinkEventApprovalRecorded, LinkID: linkID, Link: snapshot, Approver: approver})
+	if activated {
+		m.broadcast(ContractLinkEvent{Type: ContractLinkEventActivated, LinkID: linkID, Link: snapshot})
+	}
+	return snapshot, nil
+}
+
+// Update mutates metadata, capabilities, or gas profile for a mapping.
+func (m *ContractLinkManager) Update(linkID string, update ContractLinkUpdate) (*ContractLink, error) {
+	m.mu.Lock()
+	link, ok := m.links[linkID]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrContractLinkNotFound
+	}
+	if link.Status == ContractLinkStatusRetired {
+		m.mu.Unlock()
+		return nil, ErrContractLinkInvalidState
+	}
+	changed := false
+	if update.GasProfile != "" && update.GasProfile != link.Spec.GasProfile {
+		link.Spec.GasProfile = strings.TrimSpace(update.GasProfile)
+		changed = true
+	}
+	if update.Metadata != nil {
+		link.Spec.Metadata = cloneStringMap(update.Metadata)
+		changed = true
+	}
+	if update.Capabilities != nil {
+		link.Spec.Capabilities = cloneStringSlice(update.Capabilities)
+		changed = true
+	}
+	if changed {
+		link.Version++
+		link.UpdatedAt = m.now()
+	}
+	snapshot := cloneContractLink(link)
+	m.mu.Unlock()
+	if changed {
+		m.broadcast(ContractLinkEvent{Type: ContractLinkEventUpdated, LinkID: linkID, Link: snapshot})
+	}
+	return snapshot, nil
+}
+
+// Suspend disables a mapping while retaining its configuration.
+func (m *ContractLinkManager) Suspend(linkID, reason string) (*ContractLink, error) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return nil, fmt.Errorf("%w: suspension reason required", ErrContractLinkInvalidState)
+	}
+	m.mu.Lock()
+	link, ok := m.links[linkID]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrContractLinkNotFound
+	}
+	if link.Status != ContractLinkStatusActive {
+		m.mu.Unlock()
+		return nil, ErrContractLinkInvalidState
+	}
+	now := m.now()
+	link.Status = ContractLinkStatusSuspended
+	link.SuspensionReason = reason
+	link.SuspendedAt = now
+	link.UpdatedAt = now
+	link.Version++
+	snapshot := cloneContractLink(link)
+	m.mu.Unlock()
+	m.broadcast(ContractLinkEvent{Type: ContractLinkEventSuspended, LinkID: linkID, Link: snapshot, Reason: reason})
+	return snapshot, nil
+}
+
+// Resume re-enables a suspended or failed mapping after remediation.
+func (m *ContractLinkManager) Resume(linkID string) (*ContractLink, error) {
+	m.mu.Lock()
+	link, ok := m.links[linkID]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrContractLinkNotFound
+	}
+	if link.Status != ContractLinkStatusSuspended && link.Status != ContractLinkStatusFailed {
+		m.mu.Unlock()
+		return nil, ErrContractLinkInvalidState
+	}
+	now := m.now()
+	link.Status = ContractLinkStatusActive
+	link.SuspensionReason = ""
+	link.SuspendedAt = time.Time{}
+	link.UpdatedAt = now
+	link.Version++
+	for i := len(link.Failures) - 1; i >= 0; i-- {
+		if !link.Failures[i].Resolved {
+			link.Failures[i].Resolved = true
+			link.Failures[i].ResolvedAt = now
+			break
+		}
+	}
+	snapshot := cloneContractLink(link)
+	m.mu.Unlock()
+	m.broadcast(ContractLinkEvent{Type: ContractLinkEventResumed, LinkID: linkID, Link: snapshot})
+	return snapshot, nil
+}
+
+// Retire decommissions a mapping permanently.
+func (m *ContractLinkManager) Retire(linkID, reason string) (*ContractLink, error) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return nil, fmt.Errorf("%w: retirement reason required", ErrContractLinkInvalidState)
+	}
+	m.mu.Lock()
+	link, ok := m.links[linkID]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrContractLinkNotFound
+	}
+	if link.Status == ContractLinkStatusRetired {
+		m.mu.Unlock()
+		return nil, ErrContractLinkInvalidState
+	}
+	now := m.now()
+	link.Status = ContractLinkStatusRetired
+	link.RetirementReason = reason
+	link.RetiredAt = now
+	link.UpdatedAt = now
+	link.Version++
+	localKey := normalizeKey(link.Spec.LocalChain, link.Spec.LocalAddress)
+	delete(m.byLocal, localKey)
+	snapshot := cloneContractLink(link)
+	m.mu.Unlock()
+	m.broadcast(ContractLinkEvent{Type: ContractLinkEventRetired, LinkID: linkID, Link: snapshot, Reason: reason})
+	return snapshot, nil
+}
+
+// ReportFailure records a fault and transitions the mapping to FAILED.
+func (m *ContractLinkManager) ReportFailure(linkID, code, detail string) (*ContractLink, error) {
+	code = strings.TrimSpace(code)
+	detail = strings.TrimSpace(detail)
+	if code == "" || detail == "" {
+		return nil, fmt.Errorf("%w: failure code and detail required", ErrContractLinkInvalidState)
+	}
+	m.mu.Lock()
+	link, ok := m.links[linkID]
+	if !ok {
+		m.mu.Unlock()
+		return nil, ErrContractLinkNotFound
+	}
+	if link.Status == ContractLinkStatusRetired {
+		m.mu.Unlock()
+		return nil, ErrContractLinkInvalidState
+	}
+	now := m.now()
+	failure := ContractLinkFailure{Code: code, Detail: detail, Occurred: now}
+	link.Failures = append(link.Failures, failure)
+	link.Status = ContractLinkStatusFailed
+	link.SuspensionReason = detail
+	link.SuspendedAt = now
+	link.UpdatedAt = now
+	link.Version++
+	snapshot := cloneContractLink(link)
+	m.mu.Unlock()
+	m.broadcast(ContractLinkEvent{Type: ContractLinkEventFailed, LinkID: linkID, Link: snapshot, Reason: detail, Failure: &failure})
+	return snapshot, nil
+}
+
+// Get returns a copy of the mapping by ID.
+func (m *ContractLinkManager) Get(linkID string) (*ContractLink, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	link, ok := m.links[linkID]
+	if !ok {
+		return nil, false
+	}
+	return cloneContractLink(link), true
+}
+
+// List enumerates known mappings according to the provided filter.
+func (m *ContractLinkManager) List(filter ContractLinkFilter) []*ContractLink {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var statuses map[ContractLinkStatus]struct{}
+	if len(filter.Statuses) > 0 {
+		statuses = make(map[ContractLinkStatus]struct{}, len(filter.Statuses))
+		for _, st := range filter.Statuses {
+			statuses[st] = struct{}{}
+		}
+	}
+	var out []*ContractLink
+	for _, link := range m.links {
+		if statuses != nil {
+			if _, ok := statuses[link.Status]; !ok {
+				continue
+			}
+		}
+		if filter.LocalChain != "" && !strings.EqualFold(filter.LocalChain, link.Spec.LocalChain) {
+			continue
+		}
+		if filter.RemoteChain != "" && !strings.EqualFold(filter.RemoteChain, link.Spec.RemoteChain) {
+			continue
+		}
+		if filter.ConnectionID != "" && filter.ConnectionID != link.Spec.ConnectionID {
+			continue
+		}
+		out = append(out, cloneContractLink(link))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out
+}
+
+// Subscribe registers a watcher for lifecycle events.
+func (m *ContractLinkManager) Subscribe(buffer int) (<-chan ContractLinkEvent, func()) {
+	if buffer <= 0 {
+		buffer = 1
+	}
+	m.mu.Lock()
+	id := m.nextID
+	m.nextID++
+	ch := make(chan ContractLinkEvent, buffer)
+	m.watchers[id] = ch
+	m.mu.Unlock()
+	cancel := func() {
+		m.mu.Lock()
+		if watcher, ok := m.watchers[id]; ok {
+			delete(m.watchers, id)
+			close(watcher)
+		}
+		m.mu.Unlock()
+	}
+	return ch, cancel
+}
+
+func (m *ContractLinkManager) broadcast(event ContractLinkEvent) {
+	m.mu.RLock()
+	watchers := make([]chan ContractLinkEvent, 0, len(m.watchers))
+	for _, ch := range m.watchers {
+		watchers = append(watchers, ch)
+	}
+	m.mu.RUnlock()
+	for _, ch := range watchers {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+}
+
+func (m *ContractLinkManager) ensureConnectionActive(connectionID string) error {
+	if strings.TrimSpace(connectionID) == "" {
+		return fmt.Errorf("%w: connection id required", ErrContractLinkInvalidSpec)
+	}
+	if m.resolver == nil {
+		return nil
+	}
+	conn, ok := m.resolver.GetConnection(connectionID)
+	if !ok {
+		return ErrContractLinkConnectionUnknown
+	}
+	if conn.Status != ConnectionStatusActive {
+		return ErrContractLinkConnectionInactive
+	}
+	return nil
+}
+
+func (m *ContractLinkManager) now() time.Time {
+	if m.clock != nil {
+		return m.clock()
+	}
+	return time.Now().UTC()
+}
+
+func normalizeKey(chain, address string) string {
+	return strings.ToLower(strings.TrimSpace(chain)) + "|" + strings.ToLower(strings.TrimSpace(address))
+}
+
+func cloneContractLink(link *ContractLink) *ContractLink {
+	if link == nil {
+		return nil
+	}
+	approvals := make(map[string]time.Time, len(link.Approvals))
+	for k, v := range link.Approvals {
+		approvals[k] = v
+	}
+	failures := make([]ContractLinkFailure, len(link.Failures))
+	copy(failures, link.Failures)
+	return &ContractLink{
+		ID:                link.ID,
+		Spec:              cloneContractLinkSpec(link.Spec),
+		Status:            link.Status,
+		Version:           link.Version,
+		CreatedAt:         link.CreatedAt,
+		UpdatedAt:         link.UpdatedAt,
+		ActivatedAt:       link.ActivatedAt,
+		SuspendedAt:       link.SuspendedAt,
+		RetiredAt:         link.RetiredAt,
+		SuspensionReason:  link.SuspensionReason,
+		RetirementReason:  link.RetirementReason,
+		ApprovalThreshold: link.ApprovalThreshold,
+		Approvals:         approvals,
+		Failures:          failures,
+	}
+}
+
+func cloneContractLinkSpec(spec ContractLinkSpec) ContractLinkSpec {
+	return ContractLinkSpec{
+		LocalChain:    strings.TrimSpace(spec.LocalChain),
+		LocalAddress:  strings.TrimSpace(spec.LocalAddress),
+		RemoteChain:   strings.TrimSpace(spec.RemoteChain),
+		RemoteAddress: strings.TrimSpace(spec.RemoteAddress),
+		ConnectionID:  strings.TrimSpace(spec.ConnectionID),
+		Capabilities:  cloneStringSlice(spec.Capabilities),
+		GasProfile:    strings.TrimSpace(spec.GasProfile),
+		Metadata:      cloneStringMap(spec.Metadata),
+		AccessPolicy: AccessPolicy{
+			AllowedApprovers:  cloneAndSortApprovers(spec.AccessPolicy.AllowedApprovers),
+			RequiredApprovals: spec.AccessPolicy.RequiredApprovals,
+			PrivacyLevel:      strings.TrimSpace(spec.AccessPolicy.PrivacyLevel),
+			EncryptionScheme:  strings.TrimSpace(spec.AccessPolicy.EncryptionScheme),
+		},
+		AuditTrailHint: strings.TrimSpace(spec.AuditTrailHint),
+	}
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
 	}
 	return out
 }
 
-// GetMapping retrieves a mapping by the local contract address.
-func (r *XContractRegistry) GetMapping(localAddr string) (XContractMapping, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	m, ok := r.mappings[localAddr]
-	return m, ok
+func cloneAndSortApprovers(values []string) []string {
+	out := cloneStringSlice(values)
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i]) < strings.ToLower(out[j])
+	})
+	return out
 }
 
-// RemoveMapping deletes a mapping by its local address.
-func (r *XContractRegistry) RemoveMapping(localAddr string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.mappings, localAddr)
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		key := strings.TrimSpace(k)
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(v)
+	}
+	return out
+}
+
+func approverAllowed(policy AccessPolicy, approver string) bool {
+	if len(policy.AllowedApprovers) == 0 {
+		return true
+	}
+	candidate := strings.TrimSpace(approver)
+	for _, allowed := range policy.AllowedApprovers {
+		if strings.EqualFold(allowed, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateContractLinkSpec(spec ContractLinkSpec) error {
+	if strings.TrimSpace(spec.LocalChain) == "" {
+		return fmt.Errorf("%w: local chain required", ErrContractLinkInvalidSpec)
+	}
+	if strings.TrimSpace(spec.LocalAddress) == "" {
+		return fmt.Errorf("%w: local address required", ErrContractLinkInvalidSpec)
+	}
+	if strings.TrimSpace(spec.RemoteChain) == "" {
+		return fmt.Errorf("%w: remote chain required", ErrContractLinkInvalidSpec)
+	}
+	if strings.TrimSpace(spec.RemoteAddress) == "" {
+		return fmt.Errorf("%w: remote address required", ErrContractLinkInvalidSpec)
+	}
+	if strings.TrimSpace(spec.ConnectionID) == "" {
+		return fmt.Errorf("%w: connection id required", ErrContractLinkInvalidSpec)
+	}
+	if spec.AccessPolicy.RequiredApprovals < 0 {
+		return fmt.Errorf("%w: required approvals cannot be negative", ErrContractLinkInvalidSpec)
+	}
+	if spec.AccessPolicy.RequiredApprovals > 0 {
+		if len(spec.AccessPolicy.AllowedApprovers) == 0 {
+			return fmt.Errorf("%w: allowed approvers required when approvals are mandated", ErrContractLinkInvalidSpec)
+		}
+		unique := make(map[string]struct{}, len(spec.AccessPolicy.AllowedApprovers))
+		for _, approver := range spec.AccessPolicy.AllowedApprovers {
+			key := strings.ToLower(strings.TrimSpace(approver))
+			if key == "" {
+				continue
+			}
+			unique[key] = struct{}{}
+		}
+		if spec.AccessPolicy.RequiredApprovals > len(unique) {
+			return fmt.Errorf("%w: approval threshold exceeds distinct approvers", ErrContractLinkInvalidSpec)
+		}
+	}
+	return nil
 }

--- a/cross_chain_contracts_test.go
+++ b/cross_chain_contracts_test.go
@@ -1,7 +1,357 @@
 package synnergy
 
-import "testing"
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
 
-func TestCrosschaincontractsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+type stubConnectionSource struct {
+	mu          sync.RWMutex
+	connections map[string]*ChainConnection
+}
+
+func newStubConnectionSource() *stubConnectionSource {
+	return &stubConnectionSource{connections: make(map[string]*ChainConnection)}
+}
+
+func (s *stubConnectionSource) GetConnection(id string) (*ChainConnection, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	conn, ok := s.connections[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneConnection(conn), true
+}
+
+func (s *stubConnectionSource) setConnection(conn *ChainConnection) {
+	s.mu.Lock()
+	s.connections[conn.ID] = conn
+	s.mu.Unlock()
+}
+
+type deterministicClock struct {
+	mu      sync.Mutex
+	current time.Time
+	step    time.Duration
+}
+
+func newDeterministicClock(start time.Time) *deterministicClock {
+	return &deterministicClock{current: start, step: time.Second}
+}
+
+func (c *deterministicClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.current
+	c.current = c.current.Add(c.step)
+	return now
+}
+
+func newTestContractLinkManager(t *testing.T) (*ContractLinkManager, *deterministicClock, *stubConnectionSource) {
+	t.Helper()
+	clock := newDeterministicClock(time.Unix(1_700_000_000, 0))
+	resolver := newStubConnectionSource()
+	resolver.setConnection(&ChainConnection{
+		ID:     "conn-1",
+		Status: ConnectionStatusActive,
+		Spec: ConnectionSpec{
+			LocalChain:     "synnergy-main",
+			RemoteChain:    "ally-main",
+			LocalEndpoint:  "https://synnergy.local",
+			RemoteEndpoint: "https://ally.local",
+			GasProfile:     "syn-default",
+		},
+		CreatedAt: clock.Now(),
+		UpdatedAt: clock.Now(),
+		OpenedAt:  clock.Now(),
+	})
+	manager := NewContractLinkManager(
+		WithContractLinkResolver(resolver),
+		WithContractLinkClock(clock.Now),
+	)
+	return manager, clock, resolver
+}
+
+func baseContractLinkSpec() ContractLinkSpec {
+	return ContractLinkSpec{
+		LocalChain:    "synnergy-main",
+		LocalAddress:  "0xabc",
+		RemoteChain:   "ally-main",
+		RemoteAddress: "0xdef",
+		ConnectionID:  "conn-1",
+		Capabilities:  []string{"invoke", "query"},
+		GasProfile:    "syn-default",
+		Metadata: map[string]string{
+			"department": "treasury",
+		},
+		AccessPolicy: AccessPolicy{
+			AllowedApprovers:  []string{"alice", "bob"},
+			RequiredApprovals: 0,
+			PrivacyLevel:      "confidential",
+			EncryptionScheme:  "aes-gcm-256",
+		},
+		AuditTrailHint: "ops",
+	}
+}
+
+func TestContractLinkRegisterValidation(t *testing.T) {
+	manager, _, _ := newTestContractLinkManager(t)
+	spec := baseContractLinkSpec()
+	spec.LocalAddress = ""
+	if _, err := manager.Register(spec); !errors.Is(err, ErrContractLinkInvalidSpec) {
+		t.Fatalf("expected ErrContractLinkInvalidSpec, got %v", err)
+	}
+
+	spec = baseContractLinkSpec()
+	spec.AccessPolicy.RequiredApprovals = 1
+	spec.AccessPolicy.AllowedApprovers = nil
+	if _, err := manager.Register(spec); !errors.Is(err, ErrContractLinkInvalidSpec) {
+		t.Fatalf("expected ErrContractLinkInvalidSpec for missing approvers, got %v", err)
+	}
+}
+
+func TestContractLinkRegisterRequiresActiveConnection(t *testing.T) {
+	clock := newDeterministicClock(time.Unix(1_700_010_000, 0))
+	resolver := newStubConnectionSource()
+	resolver.setConnection(&ChainConnection{ID: "conn-1", Status: ConnectionStatusPending})
+	manager := NewContractLinkManager(WithContractLinkResolver(resolver), WithContractLinkClock(clock.Now))
+	if _, err := manager.Register(baseContractLinkSpec()); !errors.Is(err, ErrContractLinkConnectionInactive) {
+		t.Fatalf("expected ErrContractLinkConnectionInactive, got %v", err)
+	}
+
+	resolverEmpty := newStubConnectionSource()
+	manager = NewContractLinkManager(WithContractLinkResolver(resolverEmpty), WithContractLinkClock(clock.Now))
+	if _, err := manager.Register(baseContractLinkSpec()); !errors.Is(err, ErrContractLinkConnectionUnknown) {
+		t.Fatalf("expected ErrContractLinkConnectionUnknown, got %v", err)
+	}
+}
+
+func TestContractLinkRegisterAutoActive(t *testing.T) {
+	manager, _, _ := newTestContractLinkManager(t)
+	link, err := manager.Register(baseContractLinkSpec())
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	if link.Status != ContractLinkStatusActive {
+		t.Fatalf("expected active status, got %s", link.Status)
+	}
+	if link.ActivatedAt.IsZero() {
+		t.Fatalf("expected activation timestamp to be set")
+	}
+	if link.Version != 1 {
+		t.Fatalf("expected version 1, got %d", link.Version)
+	}
+}
+
+func TestContractLinkApprovalFlow(t *testing.T) {
+	manager, _, _ := newTestContractLinkManager(t)
+	spec := baseContractLinkSpec()
+	spec.LocalAddress = "0xaaa"
+	spec.AccessPolicy.RequiredApprovals = 2
+	spec.AccessPolicy.AllowedApprovers = []string{"alice", "bob", "carol"}
+	link, err := manager.Register(spec)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	if link.Status != ContractLinkStatusPending {
+		t.Fatalf("expected pending status, got %s", link.Status)
+	}
+	if link.Version != 1 {
+		t.Fatalf("expected version 1 after registration, got %d", link.Version)
+	}
+
+	updated, err := manager.RecordApproval(link.ID, "alice")
+	if err != nil {
+		t.Fatalf("record approval failed: %v", err)
+	}
+	if updated.Status != ContractLinkStatusPending {
+		t.Fatalf("expected pending after first approval, got %s", updated.Status)
+	}
+	if updated.Version != 2 {
+		t.Fatalf("expected version 2 after approval, got %d", updated.Version)
+	}
+
+	if _, err = manager.RecordApproval(link.ID, "ALICE"); !errors.Is(err, ErrContractLinkApprovalDuplicate) {
+		t.Fatalf("expected duplicate approval error, got %v", err)
+	}
+
+	activated, err := manager.RecordApproval(link.ID, "bob")
+	if err != nil {
+		t.Fatalf("second approval failed: %v", err)
+	}
+	if activated.Status != ContractLinkStatusActive {
+		t.Fatalf("expected active status after threshold, got %s", activated.Status)
+	}
+	if len(activated.Approvals) != 2 {
+		t.Fatalf("expected two approvals, got %d", len(activated.Approvals))
+	}
+	if activated.Version != 3 {
+		t.Fatalf("expected version 3 after activation, got %d", activated.Version)
+	}
+}
+
+func TestContractLinkSuspendResumeAndFailure(t *testing.T) {
+	manager, _, _ := newTestContractLinkManager(t)
+	link, err := manager.Register(baseContractLinkSpec())
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	failed, err := manager.ReportFailure(link.ID, "SYNC_TIMEOUT", "remote acknowledgement missing")
+	if err != nil {
+		t.Fatalf("report failure failed: %v", err)
+	}
+	if failed.Status != ContractLinkStatusFailed {
+		t.Fatalf("expected failed status, got %s", failed.Status)
+	}
+	if len(failed.Failures) != 1 {
+		t.Fatalf("expected one failure record, got %d", len(failed.Failures))
+	}
+
+	resumed, err := manager.Resume(link.ID)
+	if err != nil {
+		t.Fatalf("resume failed: %v", err)
+	}
+	if resumed.Status != ContractLinkStatusActive {
+		t.Fatalf("expected active status after resume, got %s", resumed.Status)
+	}
+	last := resumed.Failures[len(resumed.Failures)-1]
+	if !last.Resolved {
+		t.Fatalf("expected failure to be resolved after resume")
+	}
+
+	suspended, err := manager.Suspend(link.ID, "maintenance window")
+	if err != nil {
+		t.Fatalf("suspend failed: %v", err)
+	}
+	if suspended.Status != ContractLinkStatusSuspended {
+		t.Fatalf("expected suspended status, got %s", suspended.Status)
+	}
+
+	resumed, err = manager.Resume(link.ID)
+	if err != nil {
+		t.Fatalf("resume after suspension failed: %v", err)
+	}
+	if resumed.Status != ContractLinkStatusActive {
+		t.Fatalf("expected active status after resume, got %s", resumed.Status)
+	}
+
+	if _, err := manager.Suspend(link.ID, ""); err == nil {
+		t.Fatalf("expected error when suspending without reason")
+	}
+}
+
+func TestContractLinkListFiltering(t *testing.T) {
+	manager, _, _ := newTestContractLinkManager(t)
+	first, err := manager.Register(baseContractLinkSpec())
+	if err != nil {
+		t.Fatalf("register first failed: %v", err)
+	}
+	spec := baseContractLinkSpec()
+	spec.LocalAddress = "0x999"
+	spec.RemoteChain = "ally-analytics"
+	spec.RemoteAddress = "0xeee"
+	spec.AccessPolicy.RequiredApprovals = 1
+	spec.AccessPolicy.AllowedApprovers = []string{"dora"}
+	second, err := manager.Register(spec)
+	if err != nil {
+		t.Fatalf("register second failed: %v", err)
+	}
+	if second.Status != ContractLinkStatusPending {
+		t.Fatalf("expected pending status for second, got %s", second.Status)
+	}
+
+	pending := manager.List(ContractLinkFilter{Statuses: []ContractLinkStatus{ContractLinkStatusPending}})
+	if len(pending) != 1 || pending[0].ID != second.ID {
+		t.Fatalf("expected only pending contract, got %#v", pending)
+	}
+
+	ally := manager.List(ContractLinkFilter{RemoteChain: "ally-main"})
+	if len(ally) != 1 || ally[0].ID != first.ID {
+		t.Fatalf("expected filter by remote chain to return first mapping")
+	}
+
+	none := manager.List(ContractLinkFilter{ConnectionID: "missing"})
+	if len(none) != 0 {
+		t.Fatalf("expected no results for unknown connection, got %d", len(none))
+	}
+}
+
+func TestContractLinkUpdate(t *testing.T) {
+	manager, _, _ := newTestContractLinkManager(t)
+	link, err := manager.Register(baseContractLinkSpec())
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	updated, err := manager.Update(link.ID, ContractLinkUpdate{
+		GasProfile:   "syn-premium",
+		Metadata:     map[string]string{"tier": "gold"},
+		Capabilities: []string{"invoke", "audit"},
+	})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if updated.Spec.GasProfile != "syn-premium" {
+		t.Fatalf("expected gas profile to change, got %s", updated.Spec.GasProfile)
+	}
+	if updated.Spec.Metadata["tier"] != "gold" {
+		t.Fatalf("expected metadata to include tier, got %#v", updated.Spec.Metadata)
+	}
+	if updated.Version != 2 {
+		t.Fatalf("expected version 2 after update, got %d", updated.Version)
+	}
+
+	same, err := manager.Update(link.ID, ContractLinkUpdate{})
+	if err != nil {
+		t.Fatalf("second update failed: %v", err)
+	}
+	if same.Version != updated.Version {
+		t.Fatalf("expected version to remain unchanged on no-op update")
+	}
+}
+
+func TestContractLinkSubscribeEvents(t *testing.T) {
+	manager, _, _ := newTestContractLinkManager(t)
+	ch, cancel := manager.Subscribe(4)
+	defer cancel()
+
+	spec := baseContractLinkSpec()
+	spec.LocalAddress = "0x123"
+	spec.AccessPolicy.RequiredApprovals = 1
+	spec.AccessPolicy.AllowedApprovers = []string{"alice"}
+	link, err := manager.Register(spec)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	expectEvent(t, ch, ContractLinkEventRegistered, link.ID)
+
+	if _, err := manager.RecordApproval(link.ID, "alice"); err != nil {
+		t.Fatalf("approval failed: %v", err)
+	}
+
+	expectEvent(t, ch, ContractLinkEventApprovalRecorded, link.ID)
+	expectEvent(t, ch, ContractLinkEventActivated, link.ID)
+}
+
+func expectEvent(t *testing.T, ch <-chan ContractLinkEvent, eventType ContractLinkEventType, linkID string) {
+	t.Helper()
+	select {
+	case evt := <-ch:
+		if evt.Type != eventType {
+			t.Fatalf("expected event %s, got %s", eventType, evt.Type)
+		}
+		if evt.LinkID != linkID {
+			t.Fatalf("expected link id %s, got %s", linkID, evt.LinkID)
+		}
+		if evt.Link == nil {
+			t.Fatalf("expected snapshot to be included")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("timed out waiting for event %s", eventType)
+	}
 }

--- a/cross_chain_stage18_test.go
+++ b/cross_chain_stage18_test.go
@@ -1,6 +1,10 @@
 package synnergy
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
 func TestCrossChainManager(t *testing.T) {
 	m := NewCrossChainManager()
@@ -62,31 +66,135 @@ func TestBridgeTransferManager(t *testing.T) {
 
 func TestConnectionManager(t *testing.T) {
 	m := NewConnectionManager()
-	id := m.OpenConnection("chainA", "chainB")
-	if len(m.ListConnections()) != 1 {
+	ctx := context.Background()
+	conn, err := m.OpenConnection(ctx, ConnectionSpec{
+		LocalChain:       "chainA",
+		RemoteChain:      "chainB",
+		LocalEndpoint:    "chainA-endpoint",
+		RemoteEndpoint:   "chainB-endpoint",
+		Signer:           "authority-chainA",
+		HandshakeProof:   []byte("proof"),
+		HandshakePayload: []byte("payload"),
+	})
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	conns := m.ListConnections(ConnectionFilter{})
+	if len(conns) != 1 {
 		t.Fatalf("expected 1 connection")
 	}
-	if err := m.CloseConnection(id); err != nil {
+	closed, err := m.CloseConnection(ctx, conn.ID, "test shutdown")
+	if err != nil {
 		t.Fatalf("close failed: %v", err)
 	}
-	if err := m.CloseConnection(id); err == nil {
-		t.Fatalf("expected error on double close")
+	if closed.Status != ConnectionStatusClosed {
+		t.Fatalf("expected closed status, got %s", closed.Status)
+	}
+	if _, err := m.CloseConnection(ctx, conn.ID, "double close"); !errors.Is(err, ErrConnectionClosed) {
+		t.Fatalf("expected ErrConnectionClosed, got %v", err)
 	}
 }
 
-func TestXContractRegistry(t *testing.T) {
-	r := NewXContractRegistry()
-	r.RegisterMapping("local1", "chainB", "remote1")
-	if len(r.ListMappings()) != 1 {
-		t.Fatalf("expected 1 mapping")
+func TestContractLinkManager(t *testing.T) {
+	manager := NewContractLinkManager()
+	spec := ContractLinkSpec{
+		LocalChain:    "chainA",
+		LocalAddress:  "0xabc",
+		RemoteChain:   "chainB",
+		RemoteAddress: "0xdef",
+		ConnectionID:  "conn-1",
+		Capabilities:  []string{"invoke"},
+		GasProfile:    "balanced",
+		Metadata: map[string]string{
+			"department": "operations",
+		},
+		AccessPolicy: AccessPolicy{
+			AllowedApprovers:  []string{"ops"},
+			RequiredApprovals: 1,
+		},
 	}
-	m, ok := r.GetMapping("local1")
-	if !ok || m.RemoteAddress != "remote1" {
-		t.Fatalf("unexpected mapping: %+v", m)
+	link, err := manager.Register(spec)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
 	}
-	r.RemoveMapping("local1")
-	if _, ok := r.GetMapping("local1"); ok {
-		t.Fatalf("mapping should be removed")
+	if link.Status != ContractLinkStatusPending {
+		t.Fatalf("expected pending status, got %s", link.Status)
+	}
+
+	active, err := manager.RecordApproval(link.ID, "ops")
+	if err != nil {
+		t.Fatalf("approval failed: %v", err)
+	}
+	if active.Status != ContractLinkStatusActive {
+		t.Fatalf("expected active status after approval, got %s", active.Status)
+	}
+
+	updated, err := manager.Update(link.ID, ContractLinkUpdate{
+		GasProfile: "priority",
+		Metadata: map[string]string{
+			"department": "operations",
+			"region":     "eu",
+		},
+	})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if updated.Spec.Metadata["region"] != "eu" {
+		t.Fatalf("expected metadata update to persist, got %+v", updated.Spec.Metadata)
+	}
+
+	failed, err := manager.ReportFailure(link.ID, "HEARTBEAT_TIMEOUT", "remote contract unresponsive")
+	if err != nil {
+		t.Fatalf("report failure failed: %v", err)
+	}
+	if failed.Status != ContractLinkStatusFailed {
+		t.Fatalf("expected failed status, got %s", failed.Status)
+	}
+
+	resumed, err := manager.Resume(link.ID)
+	if err != nil {
+		t.Fatalf("resume failed: %v", err)
+	}
+	if resumed.Status != ContractLinkStatusActive {
+		t.Fatalf("expected active status after resume, got %s", resumed.Status)
+	}
+
+	suspended, err := manager.Suspend(link.ID, "governance review")
+	if err != nil {
+		t.Fatalf("suspend failed: %v", err)
+	}
+	if suspended.Status != ContractLinkStatusSuspended {
+		t.Fatalf("expected suspended status, got %s", suspended.Status)
+	}
+
+	resumed, err = manager.Resume(link.ID)
+	if err != nil {
+		t.Fatalf("resume after suspension failed: %v", err)
+	}
+	if resumed.Status != ContractLinkStatusActive {
+		t.Fatalf("expected active status, got %s", resumed.Status)
+	}
+
+	retired, err := manager.Retire(link.ID, "sunset")
+	if err != nil {
+		t.Fatalf("retire failed: %v", err)
+	}
+	if retired.Status != ContractLinkStatusRetired {
+		t.Fatalf("expected retired status, got %s", retired.Status)
+	}
+
+	if matches := manager.List(ContractLinkFilter{ConnectionID: "conn-1", Statuses: []ContractLinkStatus{ContractLinkStatusRetired}}); len(matches) != 1 {
+		t.Fatalf("expected retired mapping to be discoverable, got %d", len(matches))
+	}
+
+	spec.RemoteAddress = "0x999"
+	spec.Metadata["department"] = "innovation"
+	replacement, err := manager.Register(spec)
+	if err != nil {
+		t.Fatalf("expected replacement mapping to register, got %v", err)
+	}
+	if replacement.ID == link.ID {
+		t.Fatalf("replacement should allocate a new identifier")
 	}
 }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1681,11 +1681,11 @@ Stage 72 complete: concurrency-safe financial token suite with comprehensive tes
 - [ ] cross_chain_bridge_test.go
 
 **Stage 76**
-- [ ] cross_chain_connection.go
-- [ ] cross_chain_connection_test.go
-- [ ] cross_chain_contracts.go
-- [ ] cross_chain_contracts_test.go
-- [ ] cross_chain_stage18_test.go
+- [x] cross_chain_connection.go – Enterprise-grade lifecycle manager with signed handshakes, heartbeat health, event streams, and filtering hooks.
+- [x] cross_chain_connection_test.go – Comprehensive unit tests covering validation, lifecycle transitions, health, filtering, and watcher cancellation.
+- [x] cross_chain_contracts.go – Enterprise contract link manager with approval workflows, failure handling, suspension/resume, metadata updates, and connection-aware registration.
+- [x] cross_chain_contracts_test.go – Deterministic lifecycle, approval, filtering, event, and failure recovery tests covering the contract link manager API.
+- [x] cross_chain_stage18_test.go – Regression harness extends to contract link lifecycle flows including approvals, suspension, recovery, and replacement registration.
 - [ ] cross_chain_test.go
 - [ ] cross_chain_transactions.go
 - [ ] cross_chain_transactions_benchmark_test.go


### PR DESCRIPTION
## Summary
- replace the simple cross-chain contract registry with an approval-aware contract link manager that tracks lifecycle status, failures, suspension, and metadata updates for function-web integrations.
- add deterministic contract link unit coverage validating approvals, filtering, event delivery, failure recovery, and status transitions.
- extend the Stage 18 regression harness and tracker to exercise the enterprise contract link workflow and document Stage 76 progress.

## Testing
- `go test` *(fails: synnergy/cli references Stage 73 helpers that are not defined in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d09bc56c4883209932f328e12e874a