### PR TITLE
Harden stage 98 operational tooling

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2169,12 +2169,13 @@ Stage 79 complete: runtime bootstrap aligned CLI, VM, consensus, ledger and wall
 - [ ] scripts/certificate_issue.sh
 
 **Stage 98**
-- [ ] scripts/certificate_renew.sh
-- [ ] scripts/chain_rollback_prevention.sh
-- [ ] scripts/chain_state_snapshot.sh
-- [ ] scripts/ci_setup.sh
-- [ ] scripts/cleanup_artifacts.sh
-- [ ] scripts/cli_help_generator.sh
+- [x] scripts/certificate_renew.sh – enterprise renewal workflow with CLI submission, metrics, locking, and dry-run coverage
+- [x] scripts/chain_rollback_prevention.sh – enterprise rollback guard with CLI mitigation,
+  checkpoint automation, metrics emission, and concurrency-safe locking
+- [x] scripts/chain_state_snapshot.sh – snapshot automation with retention, metrics, locking, and CLI/fixture parity for audit trails
+- [x] scripts/ci_setup.sh – profile-aware CI bootstrap with dry-run reporting, locking, cache/log handling, and toolchain orchestration
+- [x] scripts/cleanup_artifacts.sh – safety-aware artifact pruning with retention filters, pattern controls, metrics, and concurrency guards
+- [x] scripts/cli_help_generator.sh – CLI help publisher supporting recorded definitions, live introspection, markdown/json output, and metrics emission
 - [ ] scripts/cli_tooling.sh
 - [ ] scripts/compliance_audit.sh
 - [ ] scripts/compliance_rule_update.sh
@@ -2188,6 +2189,8 @@ Stage 79 complete: runtime bootstrap aligned CLI, VM, consensus, ledger and wall
 - [ ] scripts/consensus_start.sh
 - [ ] scripts/consensus_validator_manage.sh
 - [ ] scripts/content_node_setup.sh
+
+_Stage 98 progress: certificate automation, rollback guard, and four CLI/operations utilities upgraded; twelve scripts pending enterprise hardening._
 
 **Stage 99**
 - [ ] scripts/contract_coverage_report.sh

--- a/scripts/certificate_renew.sh
+++ b/scripts/certificate_renew.sh
@@ -1,17 +1,423 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME=$(basename "$0")
 
 usage() {
   cat <<'USAGE'
-Usage: $(basename "$0") [options]
-Placeholder script. Implementation pending.
+Usage: certificate_renew.sh --cert <path> --key <path> [options]
+
+Enterprise-grade certificate renewal helper for Synnergy Network nodes.
+
+Required arguments:
+  --cert PATH           Existing PEM encoded certificate to inspect for expiry.
+  --key PATH            Private key used to sign the renewal CSR. Use --rotate-key
+                        to generate a fresh key instead.
+
+Optional arguments:
+  --output-dir PATH     Directory to write CSR, rotated keys, and logs. Defaults
+                        to <cert directory>/renewals.
+  --csr-out PATH        Explicit path for generated certificate signing request.
+  --renew-within DAYS   Renew when certificate expires within DAYS (default: 30).
+  --force               Force renewal regardless of expiry window.
+  --dry-run             Generate CSR and metrics without invoking the CLI.
+  --cli PATH            Explicit Synnergy CLI binary to invoke for renewal.
+                        Defaults to $SYN_CLI, then synnergy, then synnergy-cli.
+  --endpoint URL        Override API endpoint when invoking the CLI.
+  --profile NAME        CLI profile (default: production).
+  --rotate-key          Generate a brand-new private key for the CSR.
+  --key-type TYPE       Key type for rotation: rsa (default) or ec.
+  --key-bits BITS       RSA key size when rotating (default: 4096).
+  --ec-curve CURVE      EC curve name when rotating (default: prime256v1).
+  --subject SUBJECT     CSR subject. Defaults to the current certificate subject.
+  --hook PATH           Executable notified post-renewal with CSR, cert, key paths.
+  --lock-file PATH      Use flock-based locking to avoid concurrent renewals.
+  --metrics-file PATH   Emit JSON metrics describing the renewal activity.
+  --help, -h            Display this help message.
+
+Examples:
+  # Dry-run renewal and emit metrics.
+  certificate_renew.sh --cert node.pem --key node.key --dry-run \\
+    --metrics-file /var/log/synnergy/cert_renewal.json
+
+  # Force renewal, rotate key, and submit CSR via custom CLI binary.
+  certificate_renew.sh --cert node.pem --rotate-key --output-dir /etc/synnergy/certs \\
+    --cli /usr/local/bin/synnergy --force
 USAGE
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+log() {
+  local level=$1
+  local message=$2
+  printf '%s [%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$level" "$message" >&2
+}
+
+fatal() {
+  local message=$1
+  local code=${2:-1}
+  log "ERROR" "$message"
+  exit "$code"
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${TMP_WORKDIR:-}" && -d "${TMP_WORKDIR:-}" ]]; then
+    rm -rf "$TMP_WORKDIR"
+  fi
+  if [[ -n "${LOCK_FD:-}" ]]; then
+    eval "exec ${LOCK_FD}>&-"
+  fi
+  if [[ $status -ne 0 ]]; then
+    log "ERROR" "${SCRIPT_NAME} terminated with status $status"
+  fi
+}
+trap cleanup EXIT
+trap 'fatal "${SCRIPT_NAME} interrupted" 2' INT TERM
+
+require_command() {
+  local cmd=$1
+  local description=${2:-$1}
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fatal "$description is required but not installed"
+  fi
+}
+
+resolve_cli() {
+  local candidate=$1
+  if [[ -z "$candidate" ]]; then
+    if [[ -n "${SYN_CLI:-}" ]]; then
+      candidate=$SYN_CLI
+    elif command -v synnergy >/dev/null 2>&1; then
+      candidate=$(command -v synnergy)
+    elif command -v synnergy-cli >/dev/null 2>&1; then
+      candidate=$(command -v synnergy-cli)
+    else
+      fatal "CLI binary not found. Provide --cli or set SYN_CLI"
+    fi
+  fi
+
+  if [[ -x "$candidate" ]]; then
+    echo "$candidate"
+    return 0
+  fi
+
+  if command -v "$candidate" >/dev/null 2>&1; then
+    command -v "$candidate"
+    return 0
+  fi
+
+  fatal "CLI binary '$candidate' not found"
+}
+
+generate_rsa_key() {
+  local path=$1
+  local bits=$2
+  log "INFO" "Generating RSA key (${bits} bits) at $path"
+  openssl genpkey -quiet -algorithm RSA -pkeyopt "rsa_keygen_bits:${bits}" -out "$path"
+}
+
+generate_ec_key() {
+  local path=$1
+  local curve=$2
+  log "INFO" "Generating EC key (${curve}) at $path"
+  openssl ecparam -name "$curve" -genkey -noout -out "$path"
+}
+
+emit_metrics() {
+  local metrics_path=$1
+  local csr=$2
+  local key_path=$3
+  local cert_path=$4
+  local days_remaining=$5
+  local dry_run=$6
+  local cli_invoked=$7
+  local profile=$8
+  local endpoint=$9
+
+  cat >"$metrics_path" <<METRICS
+{
+  "certificate": "${cert_path}",
+  "csr": "${csr}",
+  "key": "${key_path}",
+  "days_remaining": ${days_remaining},
+  "dry_run": ${dry_run},
+  "cli_invoked": ${cli_invoked},
+  "profile": "${profile}",
+  "endpoint": "${endpoint}",
+  "renewed_at": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+}
+METRICS
+}
+
+normalize_subject() {
+  local raw=$1
+  if [[ -z "$raw" ]]; then
+    echo ""
+    return
+  fi
+
+  raw=${raw#subject=}
+  # Normalize spacing around separators without touching escaped spaces inside values.
+  raw=$(echo "$raw" | sed -E 's/, */,/g; s/ *= */=/g')
+
+  if [[ "$raw" == /* ]]; then
+    echo "$raw"
+    return
+  fi
+
+  if [[ "$raw" == *"="* ]]; then
+    echo "/${raw//,/\/}"
+    return
+  fi
+
+  echo "$raw"
+}
+
+if [[ $# -eq 0 ]]; then
   usage
+  exit 1
+fi
+
+CERT_PATH=""
+KEY_PATH=""
+OUTPUT_DIR=""
+CSR_OUT=""
+RENEW_WITHIN_DAYS=30
+FORCE_RENEW=0
+DRY_RUN=0
+CLI_PATH=${SYN_CLI:-}
+ENDPOINT=""
+PROFILE="production"
+ROTATE_KEY=0
+KEY_TYPE="rsa"
+KEY_BITS=4096
+EC_CURVE="prime256v1"
+SUBJECT_OVERRIDE=""
+HOOK_SCRIPT=""
+LOCK_FILE=""
+LOCK_FD=""
+METRICS_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --cert)
+      CERT_PATH=$2
+      shift 2
+      ;;
+    --key)
+      KEY_PATH=$2
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR=$2
+      shift 2
+      ;;
+    --csr-out)
+      CSR_OUT=$2
+      shift 2
+      ;;
+    --renew-within)
+      RENEW_WITHIN_DAYS=$2
+      shift 2
+      ;;
+    --force)
+      FORCE_RENEW=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --cli)
+      CLI_PATH=$2
+      shift 2
+      ;;
+    --endpoint)
+      ENDPOINT=$2
+      shift 2
+      ;;
+    --profile)
+      PROFILE=$2
+      shift 2
+      ;;
+    --rotate-key)
+      ROTATE_KEY=1
+      shift
+      ;;
+    --key-type)
+      KEY_TYPE=$2
+      shift 2
+      ;;
+    --key-bits)
+      KEY_BITS=$2
+      shift 2
+      ;;
+    --ec-curve)
+      EC_CURVE=$2
+      shift 2
+      ;;
+    --subject)
+      SUBJECT_OVERRIDE=$2
+      shift 2
+      ;;
+    --hook)
+      HOOK_SCRIPT=$2
+      shift 2
+      ;;
+    --lock-file)
+      LOCK_FILE=$2
+      shift 2
+      ;;
+    --metrics-file)
+      METRICS_FILE=$2
+      shift 2
+      ;;
+    *)
+      printf 'Unknown option: %s\n' "$1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  done
+
+require_command openssl "OpenSSL"
+require_command sed "sed"
+
+if [[ -z "$CERT_PATH" ]]; then
+  fatal "--cert is required"
+fi
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="$(dirname "$CERT_PATH")/renewals"
+fi
+
+if [[ -n "$LOCK_FILE" ]]; then
+  require_command flock "flock"
+  LOCK_FD=200
+  eval "exec ${LOCK_FD}>\"${LOCK_FILE}\""
+  if ! flock -n "$LOCK_FD"; then
+    fatal "Unable to acquire lock at ${LOCK_FILE}; another renewal may be running"
+  fi
+fi
+
+mkdir -p "$OUTPUT_DIR"
+umask 077
+
+if [[ ! -f "$CERT_PATH" ]]; then
+  fatal "certificate '$CERT_PATH' not found"
+fi
+
+TMP_WORKDIR=$(mktemp -d "${OUTPUT_DIR%/}/.renew-XXXXXX")
+
+if [[ $ROTATE_KEY -eq 1 ]]; then
+  KEY_PATH="${TMP_WORKDIR}/rotated.key"
+  case "$KEY_TYPE" in
+    rsa)
+      generate_rsa_key "$KEY_PATH" "$KEY_BITS"
+      ;;
+    ec)
+      generate_ec_key "$KEY_PATH" "$EC_CURVE"
+      ;;
+    *)
+      fatal "Unsupported key type '$KEY_TYPE'. Use rsa or ec."
+      ;;
+  esac
+elif [[ -z "$KEY_PATH" ]]; then
+  fatal "--key is required unless --rotate-key is supplied"
+fi
+
+if [[ ! -f "$KEY_PATH" ]]; then
+  fatal "private key '$KEY_PATH' not found"
+fi
+
+if [[ -z "$CSR_OUT" ]]; then
+  CSR_OUT="${OUTPUT_DIR%/}/$(basename "${CERT_PATH}").$(date -u +'%Y%m%dT%H%M%SZ').csr"
+fi
+
+expiry_raw=$(openssl x509 -enddate -noout -in "$CERT_PATH" | cut -d= -f2 || true)
+if [[ -z "$expiry_raw" ]]; then
+  fatal "unable to read expiry from certificate $CERT_PATH"
+fi
+
+if ! expiry_epoch=$(date -d "$expiry_raw" +%s 2>/dev/null); then
+  fatal "unable to parse certificate expiry '${expiry_raw}'"
+fi
+
+current_epoch=$(date +%s)
+seconds_remaining=$((expiry_epoch - current_epoch))
+days_remaining=$((seconds_remaining / 86400))
+
+if [[ $FORCE_RENEW -ne 1 && $days_remaining -gt $RENEW_WITHIN_DAYS ]]; then
+  log "INFO" "Certificate has ${days_remaining} day(s) left; renewal not required."
   exit 0
 fi
 
-echo "$(basename "$0") is not yet implemented." >&2
-exit 1
+if [[ -z "$SUBJECT_OVERRIDE" ]]; then
+  SUBJECT_OVERRIDE=$(openssl x509 -subject -nameopt RFC2253 -noout -in "$CERT_PATH")
+fi
+
+SUBJECT_OVERRIDE=$(normalize_subject "$SUBJECT_OVERRIDE")
+
+if [[ -z "$SUBJECT_OVERRIDE" ]]; then
+  fatal "unable to determine CSR subject"
+fi
+
+CSR_TEMP="${TMP_WORKDIR}/request.csr"
+openssl req -new -key "$KEY_PATH" -out "$CSR_TEMP" -subj "$SUBJECT_OVERRIDE" -sha256
+mv "$CSR_TEMP" "$CSR_OUT"
+
+log "INFO" "Generated CSR at ${CSR_OUT}"
+
+CLI_INVOKED=0
+CLI_EXEC=""
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  CLI_EXEC=$(resolve_cli "$CLI_PATH")
+  CLI_ARGS=(certificate renew --csr "$CSR_OUT" --profile "$PROFILE")
+  if [[ -n "$ENDPOINT" ]]; then
+    CLI_ARGS+=(--endpoint "$ENDPOINT")
+  fi
+
+  log "INFO" "Invoking CLI: ${CLI_EXEC} ${CLI_ARGS[*]}"
+  if ! "$CLI_EXEC" "${CLI_ARGS[@]}"; then
+    fatal "CLI renewal command failed"
+  fi
+  CLI_INVOKED=1
+fi
+
+if [[ -n "$HOOK_SCRIPT" ]]; then
+  if [[ ! -x "$HOOK_SCRIPT" ]]; then
+    fatal "hook '$HOOK_SCRIPT' is not executable"
+  fi
+  "$HOOK_SCRIPT" "$CSR_OUT" "$CERT_PATH" "$KEY_PATH"
+fi
+
+if [[ -n "$METRICS_FILE" ]]; then
+  mkdir -p "$(dirname "$METRICS_FILE")"
+  emit_metrics "$METRICS_FILE" "$CSR_OUT" "$KEY_PATH" "$CERT_PATH" "$days_remaining" "$DRY_RUN" "$CLI_INVOKED" "$PROFILE" "$ENDPOINT"
+  log "INFO" "Metrics written to ${METRICS_FILE}"
+fi
+
+TARGET_KEY_PATH="${OUTPUT_DIR%/}/$(basename "$KEY_PATH")"
+if [[ "$KEY_PATH" != "$TARGET_KEY_PATH" ]]; then
+  cp "$KEY_PATH" "$TARGET_KEY_PATH"
+else
+  log "INFO" "Key already resides at ${TARGET_KEY_PATH}; skipping copy"
+fi
+
+cat <<SUMMARY
+CSR_PATH=${CSR_OUT}
+KEY_PATH=${TARGET_KEY_PATH}
+CERT_PATH=${CERT_PATH}
+DAYS_REMAINING=${days_remaining}
+DRY_RUN=${DRY_RUN}
+CLI_INVOKED=${CLI_INVOKED}
+SUMMARY
+
+log "INFO" "${SCRIPT_NAME} completed successfully"

--- a/scripts/chain_rollback_prevention.sh
+++ b/scripts/chain_rollback_prevention.sh
@@ -1,17 +1,495 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME=$(basename "$0")
 
 usage() {
   cat <<'USAGE'
-Usage: $(basename "$0") [options]
-Placeholder script. Implementation pending.
+Usage: chain_rollback_prevention.sh --network <name> --checkpoint-file <path> [options]
+
+Enterprise-grade rollback guard for Synnergy Network chains. The guard compares the
+current head/finality status with a persisted checkpoint and initiates mitigation
+when a rollback is detected.
+
+Required arguments:
+  --network NAME            Logical network name (e.g., mainnet, testnet).
+  --checkpoint-file PATH    JSON checkpoint written by previous guard runs.
+
+Optional arguments:
+  --status-file PATH        Pre-recorded chain status JSON (used for tests and dry-runs).
+  --cli PATH                Explicit Synnergy CLI binary used to fetch status/mitigate.
+                             Defaults to $SYN_CLI, then synnergy, then synnergy-cli.
+  --endpoint URL            Override API endpoint for CLI calls.
+  --profile NAME            CLI profile (default: production).
+  --mitigation-action ACT   Mitigation strategy when rollback occurs: none, quarantine,
+                             or halt (default: quarantine).
+  --allow-finality-drift N  Allow checkpoint to exceed current finality by up to N blocks
+                             before classifying as rollback (default: 0).
+  --max-finality-lag N      Maximum tolerated difference between head and finalized height
+                             before flagging degraded finality (default: 500).
+  --lock-file PATH          File used for flock-based mutual exclusion.
+  --metrics-file PATH       Emit JSON metrics describing the guard evaluation.
+  --hook PATH               Executable invoked after evaluation. Receives the evaluation
+                             result (ok|rollback|degraded) as its first argument.
+  --dry-run                 Skip CLI invocations while still performing validations.
+  --no-update-checkpoint    Do not update the checkpoint even when evaluation succeeds.
+  --help, -h                Display this help message.
+
+The guard expects chain status JSON to provide the following fields:
+  network, height, hash, finalized_height, finalized_hash
+
+Examples:
+  # Validate using recorded status and update checkpoint.
+  chain_rollback_prevention.sh --network mainnet \
+    --checkpoint-file /var/lib/synnergy/rollback/checkpoint.json \
+    --status-file /tmp/status.json --mitigation-action none
+
+  # Production invocation that fetches live status and mitigates automatically.
+  chain_rollback_prevention.sh --network mainnet --checkpoint-file /var/lib/synnergy/rollback/checkpoint.json \
+    --lock-file /var/run/synnergy/rollback.lock --metrics-file /var/log/synnergy/rollback.json
 USAGE
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+log() {
+  local level=$1
+  local message=$2
+  printf '%s [%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$level" "$message" >&2
+}
+
+fatal() {
+  local message=$1
+  local code=${2:-1}
+  log "ERROR" "$message"
+  exit "$code"
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${TMP_STATUS_FILE:-}" && -f "${TMP_STATUS_FILE}" ]]; then
+    rm -f "$TMP_STATUS_FILE"
+  fi
+  if [[ -n "${LOCK_FD:-}" ]]; then
+    eval "exec ${LOCK_FD}>&-"
+  fi
+  if [[ $status -ne 0 ]]; then
+    log "ERROR" "${SCRIPT_NAME} terminated with status $status"
+  fi
+}
+trap cleanup EXIT
+trap 'fatal "${SCRIPT_NAME} interrupted" 2' INT TERM
+
+require_command() {
+  local cmd=$1
+  local description=${2:-$1}
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fatal "$description is required but not installed"
+  fi
+}
+
+resolve_cli() {
+  local candidate=$1
+  if [[ -z "$candidate" ]]; then
+    if [[ -n "${SYN_CLI:-}" ]]; then
+      candidate=$SYN_CLI
+    elif command -v synnergy >/dev/null 2>&1; then
+      candidate=$(command -v synnergy)
+    elif command -v synnergy-cli >/dev/null 2>&1; then
+      candidate=$(command -v synnergy-cli)
+    else
+      fatal "CLI binary not found. Provide --cli or set SYN_CLI"
+    fi
+  fi
+
+  if [[ -x "$candidate" ]]; then
+    echo "$candidate"
+    return 0
+  fi
+
+  if command -v "$candidate" >/dev/null 2>&1; then
+    command -v "$candidate"
+    return 0
+  fi
+
+  fatal "CLI binary '$candidate' not found"
+}
+
+acquire_lock() {
+  local path=$1
+  if [[ -z "$path" ]]; then
+    return
+  fi
+
+  mkdir -p "$(dirname "$path")"
+  LOCK_FD=212
+  eval "exec ${LOCK_FD}>\"$path\""
+  if ! flock -n "$LOCK_FD"; then
+    fatal "another rollback guard instance already holds the lock at $path"
+  fi
+}
+
+parse_json_file() {
+  local file=$1
+  local prefix=$2
+  local stdout
+  local stderr
+  stderr=$(mktemp)
+  if ! stdout=$(python3 - "$file" "$prefix" <<'PY' 2>"$stderr"
+import json
+import shlex
+import sys
+
+file_path = sys.argv[1]
+prefix = sys.argv[2]
+required = ["network", "height", "hash", "finalized_height", "finalized_hash"]
+try:
+    with open(file_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception as exc:  # pragma: no cover - handled in shell
+    print(f"unable to read {file_path}: {exc}", file=sys.stderr)
+    sys.exit(2)
+missing = [key for key in required if key not in data]
+if missing:
+    print(f"{file_path} missing required keys: {', '.join(missing)}", file=sys.stderr)
+    sys.exit(3)
+for key in required:
+    value = data[key]
+    if isinstance(value, bool):
+        value = "1" if value else "0"
+    else:
+        value = str(value)
+    print(f"{prefix}{key.upper()}={shlex.quote(value)}")
+optional_keys = ["timestamp", "finality_threshold", "finalized_by"]
+for key in optional_keys:
+    if key in data:
+        value = data[key]
+        if isinstance(value, bool):
+            value = "1" if value else "0"
+        else:
+            value = str(value)
+        print(f"{prefix}{key.upper()}={shlex.quote(value)}")
+PY
+  ); then
+    local message
+    message=$(<"$stderr")
+    rm -f "$stderr"
+    fatal "failed to parse $file: ${message:-unknown error}"
+  fi
+  rm -f "$stderr"
+  eval "$stdout"
+}
+
+write_checkpoint() {
+  local file=$1
+  local network=$2
+  local head_height=$3
+  local head_hash=$4
+  local finalized_height=$5
+  local finalized_hash=$6
+  local timestamp
+  timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  mkdir -p "$(dirname "$file")"
+  cat >"$file" <<JSON
+{
+  "network": "${network}",
+  "height": ${head_height},
+  "hash": "${head_hash}",
+  "finalized_height": ${finalized_height},
+  "finalized_hash": "${finalized_hash}",
+  "timestamp": "${timestamp}"
+}
+JSON
+}
+
+emit_metrics() {
+  local file=$1
+  local network=$2
+  local head_height=$3
+  local head_hash=$4
+  local finalized_height=$5
+  local finalized_hash=$6
+  local checkpoint_finalized_height=$7
+  local checkpoint_finalized_hash=$8
+  local rollback_detected=$9
+  local mitigation=${10}
+  local dry_run=${11}
+  local updated_checkpoint=${12}
+  local degraded=${13}
+  local initialized=${14}
+
+  if [[ -z "$file" ]]; then
+    return
+  fi
+
+  mkdir -p "$(dirname "$file")"
+  cat >"$file" <<JSON
+{
+  "network": "${network}",
+  "head_height": ${head_height},
+  "head_hash": "${head_hash}",
+  "finalized_height": ${finalized_height},
+  "finalized_hash": "${finalized_hash}",
+  "checkpoint_finalized_height": ${checkpoint_finalized_height},
+  "checkpoint_finalized_hash": "${checkpoint_finalized_hash}",
+  "rollback_detected": ${rollback_detected},
+  "mitigation": "${mitigation}",
+  "dry_run": ${dry_run},
+  "updated_checkpoint": ${updated_checkpoint},
+  "degraded_finality": ${degraded},
+  "initialized_checkpoint": ${initialized},
+  "evaluated_at": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+}
+JSON
+}
+
+invoke_cli() {
+  local dry_run_flag=$1
+  shift
+  if [[ "$dry_run_flag" -eq 1 ]]; then
+    log "INFO" "dry-run: would invoke CLI $*"
+    return 0
+  fi
+  "$@"
+}
+
+run_hook() {
+  local result=$1
+  if [[ -z "${HOOK_PATH:-}" ]]; then
+    return
+  fi
+  if [[ ! -x "$HOOK_PATH" ]]; then
+    fatal "hook $HOOK_PATH is not executable"
+  fi
+  ROLLBACK_RESULT=$result \
+  ROLLBACK_DETECTED=$ROLLBACK_DETECTED \
+  ROLLBACK_REASON="$ROLLBACK_REASON" \
+  ROLLBACK_NETWORK="$NETWORK" \
+  ROLLBACK_FINALIZED_HEIGHT="$STATUS_FINALIZED_HEIGHT" \
+  ROLLBACK_FINALIZED_HASH="$STATUS_FINALIZED_HASH" \
+  ROLLBACK_HEAD_HEIGHT="$STATUS_HEAD_HEIGHT" \
+  ROLLBACK_HEAD_HASH="$STATUS_HEAD_HASH" \
+  ROLLBACK_CHECKPOINT="$CHECKPOINT_FILE" \
+  "$HOOK_PATH" "$result"
+}
+
+NETWORK=""
+CHECKPOINT_FILE=""
+STATUS_FILE=""
+CLI_BINARY=""
+ENDPOINT=""
+PROFILE="production"
+MITIGATION_ACTION="quarantine"
+ALLOW_FINALITY_DRIFT=0
+MAX_FINALITY_LAG=500
+LOCK_PATH=""
+METRICS_FILE=""
+HOOK_PATH=""
+DRY_RUN=0
+UPDATE_CHECKPOINT=1
+
+if [[ $# -eq 0 ]]; then
   usage
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --network)
+      NETWORK=${2:-}
+      shift 2
+      ;;
+    --checkpoint-file)
+      CHECKPOINT_FILE=${2:-}
+      shift 2
+      ;;
+    --status-file)
+      STATUS_FILE=${2:-}
+      shift 2
+      ;;
+    --cli)
+      CLI_BINARY=${2:-}
+      shift 2
+      ;;
+    --endpoint)
+      ENDPOINT=${2:-}
+      shift 2
+      ;;
+    --profile)
+      PROFILE=${2:-}
+      shift 2
+      ;;
+    --mitigation-action)
+      MITIGATION_ACTION=${2:-}
+      shift 2
+      ;;
+    --allow-finality-drift)
+      ALLOW_FINALITY_DRIFT=${2:-0}
+      shift 2
+      ;;
+    --max-finality-lag)
+      MAX_FINALITY_LAG=${2:-500}
+      shift 2
+      ;;
+    --lock-file)
+      LOCK_PATH=${2:-}
+      shift 2
+      ;;
+    --metrics-file)
+      METRICS_FILE=${2:-}
+      shift 2
+      ;;
+    --hook)
+      HOOK_PATH=${2:-}
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-update-checkpoint)
+      UPDATE_CHECKPOINT=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fatal "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$NETWORK" ]]; then
+  fatal "--network is required"
+fi
+if [[ -z "$CHECKPOINT_FILE" ]]; then
+  fatal "--checkpoint-file is required"
+fi
+if ! [[ "$ALLOW_FINALITY_DRIFT" =~ ^[0-9]+$ ]]; then
+  fatal "--allow-finality-drift must be a non-negative integer"
+fi
+if ! [[ "$MAX_FINALITY_LAG" =~ ^[0-9]+$ ]]; then
+  fatal "--max-finality-lag must be a non-negative integer"
+fi
+
+require_command python3 "python3"
+acquire_lock "$LOCK_PATH"
+
+TMP_STATUS_FILE=$(mktemp)
+
+if [[ -n "$STATUS_FILE" ]]; then
+  if [[ ! -f "$STATUS_FILE" ]]; then
+    fatal "status file '$STATUS_FILE' not found"
+  fi
+  cp "$STATUS_FILE" "$TMP_STATUS_FILE"
+else
+  CLI_BINARY=$(resolve_cli "$CLI_BINARY")
+  STATUS_CMD=("$CLI_BINARY" "chain" "status" "--network" "$NETWORK" "--output" "json" "--profile" "$PROFILE")
+  if [[ -n "$ENDPOINT" ]]; then
+    STATUS_CMD+=("--endpoint" "$ENDPOINT")
+  fi
+  log "INFO" "collecting chain status via CLI"
+  if ! invoke_cli "$DRY_RUN" "${STATUS_CMD[@]}" >"$TMP_STATUS_FILE"; then
+    fatal "failed to collect chain status"
+  fi
+fi
+
+parse_json_file "$TMP_STATUS_FILE" "STATUS_"
+
+STATUS_HEAD_HEIGHT=${STATUS_HEIGHT}
+STATUS_HEAD_HASH=${STATUS_HASH}
+STATUS_FINALIZED_HEIGHT=${STATUS_FINALIZED_HEIGHT}
+STATUS_FINALIZED_HASH=${STATUS_FINALIZED_HASH}
+
+if [[ "$STATUS_NETWORK" != "$NETWORK" ]]; then
+  fatal "status network '$STATUS_NETWORK' does not match requested network '$NETWORK'"
+fi
+
+FINALITY_LAG=$(( STATUS_HEAD_HEIGHT - STATUS_FINALIZED_HEIGHT ))
+if (( FINALITY_LAG < 0 )); then
+  FINALITY_LAG=$(( -1 * FINALITY_LAG ))
+fi
+
+ROLLBACK_DETECTED=0
+ROLLBACK_REASON=""
+DEGRADED_FINALITY=0
+INITIALIZED_CHECKPOINT=0
+UPDATED_CHECKPOINT=0
+
+if [[ ! -f "$CHECKPOINT_FILE" ]]; then
+  log "INFO" "no checkpoint found; initializing at finalized height ${STATUS_FINALIZED_HEIGHT}"
+  write_checkpoint "$CHECKPOINT_FILE" "$NETWORK" "$STATUS_HEAD_HEIGHT" "$STATUS_HEAD_HASH" "$STATUS_FINALIZED_HEIGHT" "$STATUS_FINALIZED_HASH"
+  UPDATED_CHECKPOINT=1
+  INITIALIZED_CHECKPOINT=1
+  emit_metrics "$METRICS_FILE" "$NETWORK" "$STATUS_HEAD_HEIGHT" "$STATUS_HEAD_HASH" "$STATUS_FINALIZED_HEIGHT" "$STATUS_FINALIZED_HASH" "$STATUS_FINALIZED_HEIGHT" "$STATUS_FINALIZED_HASH" "$ROLLBACK_DETECTED" "$MITIGATION_ACTION" "$DRY_RUN" "$UPDATED_CHECKPOINT" "$DEGRADED_FINALITY" "$INITIALIZED_CHECKPOINT"
+  log "INFO" "checkpoint initialized at height ${STATUS_FINALIZED_HEIGHT}"
+  run_hook "ok"
+  printf 'CHECKPOINT_PATH=%s\n' "$CHECKPOINT_FILE"
   exit 0
 fi
 
-echo "$(basename "$0") is not yet implemented." >&2
-exit 1
+parse_json_file "$CHECKPOINT_FILE" "CHECKPOINT_"
+
+if [[ "$CHECKPOINT_NETWORK" != "$NETWORK" ]]; then
+  fatal "checkpoint network '$CHECKPOINT_NETWORK' does not match requested network '$NETWORK'"
+fi
+
+CHECKPOINT_FINALIZED_HEIGHT=${CHECKPOINT_FINALIZED_HEIGHT}
+CHECKPOINT_FINALIZED_HASH=${CHECKPOINT_FINALIZED_HASH}
+
+if (( STATUS_FINALIZED_HEIGHT + ALLOW_FINALITY_DRIFT < CHECKPOINT_FINALIZED_HEIGHT )); then
+  ROLLBACK_DETECTED=1
+  ROLLBACK_REASON="finalized height ${STATUS_FINALIZED_HEIGHT} behind checkpoint ${CHECKPOINT_FINALIZED_HEIGHT}"
+elif (( STATUS_FINALIZED_HEIGHT == CHECKPOINT_FINALIZED_HEIGHT )) && [[ "$STATUS_FINALIZED_HASH" != "$CHECKPOINT_FINALIZED_HASH" ]]; then
+  ROLLBACK_DETECTED=1
+  ROLLBACK_REASON="finalized hash mismatch at height ${STATUS_FINALIZED_HEIGHT}"
+fi
+
+if (( FINALITY_LAG > MAX_FINALITY_LAG )); then
+  DEGRADED_FINALITY=1
+fi
+
+if (( ROLLBACK_DETECTED == 1 )); then
+  log "ERROR" "rollback detected: ${ROLLBACK_REASON}"
+  emit_metrics "$METRICS_FILE" "$NETWORK" "$STATUS_HEAD_HEIGHT" "$STATUS_HEAD_HASH" "$STATUS_FINALIZED_HEIGHT" "$STATUS_FINALIZED_HASH" "$CHECKPOINT_FINALIZED_HEIGHT" "$CHECKPOINT_FINALIZED_HASH" "$ROLLBACK_DETECTED" "$MITIGATION_ACTION" "$DRY_RUN" "$UPDATED_CHECKPOINT" "$DEGRADED_FINALITY" "$INITIALIZED_CHECKPOINT"
+  run_hook "rollback"
+  case "$MITIGATION_ACTION" in
+    none)
+      log "WARN" "mitigation disabled; manual intervention required"
+      ;;
+    quarantine)
+      CLI_BINARY=$(resolve_cli "$CLI_BINARY")
+      invoke_cli "$DRY_RUN" "$CLI_BINARY" "consensus" "quarantine" "--network" "$NETWORK" "--reason" "rollback-detected"
+      ;;
+    halt)
+      CLI_BINARY=$(resolve_cli "$CLI_BINARY")
+      invoke_cli "$DRY_RUN" "$CLI_BINARY" "consensus" "halt" "--network" "$NETWORK" "--reason" "rollback-detected"
+      ;;
+    *)
+      fatal "unknown mitigation action: $MITIGATION_ACTION"
+      ;;
+  esac
+  exit 3
+fi
+
+if (( DEGRADED_FINALITY == 1 )); then
+  log "WARN" "finality lag ${FINALITY_LAG} exceeds threshold ${MAX_FINALITY_LAG}"
+  run_hook "degraded"
+fi
+
+if (( UPDATE_CHECKPOINT == 1 )); then
+  write_checkpoint "$CHECKPOINT_FILE" "$NETWORK" "$STATUS_HEAD_HEIGHT" "$STATUS_HEAD_HASH" "$STATUS_FINALIZED_HEIGHT" "$STATUS_FINALIZED_HASH"
+  UPDATED_CHECKPOINT=1
+  log "INFO" "checkpoint updated to finalized height ${STATUS_FINALIZED_HEIGHT}"
+fi
+
+emit_metrics "$METRICS_FILE" "$NETWORK" "$STATUS_HEAD_HEIGHT" "$STATUS_HEAD_HASH" "$STATUS_FINALIZED_HEIGHT" "$STATUS_FINALIZED_HASH" "$CHECKPOINT_FINALIZED_HEIGHT" "$CHECKPOINT_FINALIZED_HASH" "$ROLLBACK_DETECTED" "$MITIGATION_ACTION" "$DRY_RUN" "$UPDATED_CHECKPOINT" "$DEGRADED_FINALITY" "$INITIALIZED_CHECKPOINT"
+run_hook "ok"
+
+printf 'STATUS_FINALIZED_HEIGHT=%s\n' "$STATUS_FINALIZED_HEIGHT"
+printf 'STATUS_FINALIZED_HASH=%s\n' "$STATUS_FINALIZED_HASH"
+printf 'CHECKPOINT_PATH=%s\n' "$CHECKPOINT_FILE"
+
+exit 0

--- a/scripts/chain_state_snapshot.sh
+++ b/scripts/chain_state_snapshot.sh
@@ -1,17 +1,519 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME=$(basename "$0")
 
 usage() {
   cat <<'USAGE'
-Usage: $(basename "$0") [options]
-Placeholder script. Implementation pending.
+Usage: chain_state_snapshot.sh --network <name> --output-dir <path> [options]
+
+Capture a tamper-evident snapshot of the Synnergy Network chain state for
+regulatory, audit, and disaster-recovery workflows. The snapshot integrates
+with the Synnergy CLI or recorded telemetry, emits metrics, and enforces
+retention/locking policies so that infrastructure automation can safely invoke
+it in parallel with consensus and VM operations.
+
+Required arguments:
+  --network NAME            Logical network name (e.g., mainnet, stage98).
+  --output-dir PATH         Directory where snapshots are persisted.
+
+Optional arguments:
+  --status-file PATH        Pre-fetched status JSON (used for dry-runs/tests).
+  --cli PATH                Explicit Synnergy CLI binary. Defaults to $SYN_CLI,
+                             then synnergy, then synnergy-cli.
+  --endpoint URL            Override RPC endpoint for CLI queries.
+  --profile NAME            CLI profile to use (default: production).
+  --format TYPE             Snapshot format: json or archive (default: json).
+  --snapshot-prefix PREFIX  File prefix for generated snapshots (default:
+                             snapshot-).
+  --retain COUNT            Retain the newest COUNT snapshots (default: 5).
+  --tag VALUE               Include an additional descriptor in the snapshot
+                             metadata (e.g., nightly, compliance).
+  --timestamp VALUE         Override the snapshot timestamp. Primarily used for
+                             testing; must follow YYYYMMDDTHHMMSSZ format.
+  --lock-file PATH          Path to a flock-based mutex to prevent concurrent
+                             executions.
+  --metrics-file PATH       Emit JSON metrics describing the capture.
+  --dry-run                 Skip CLI execution and filesystem mutations. Must
+                             be combined with --status-file.
+  --no-retention            Disable retention pruning for this invocation.
+  --help, -h                Display this help message.
+
+Examples:
+  # Capture a snapshot from live CLI telemetry and keep the last 10 artifacts
+  chain_state_snapshot.sh --network mainnet --output-dir /var/lib/synnergy/snaps \
+    --retain 10 --metrics-file /var/lib/synnergy/metrics/snapshot.json
+
+  # Idempotent CI validation using recorded status
+  chain_state_snapshot.sh --network stage98 --output-dir ./tmp/snaps \
+    --status-file ./fixtures/status.json --dry-run
 USAGE
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+log() {
+  local level=$1
+  local message=$2
+  printf '%s [%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$level" "$message" >&2
+}
+
+fatal() {
+  local message=$1
+  local code=${2:-1}
+  log "ERROR" "$message"
+  exit "$code"
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${TMP_STATUS_FILE:-}" && -f "${TMP_STATUS_FILE}" ]]; then
+    rm -f "$TMP_STATUS_FILE"
+  fi
+  if [[ -n "${LOCK_FD:-}" ]]; then
+    eval "exec ${LOCK_FD}>&-"
+  fi
+  if [[ $status -ne 0 ]]; then
+    log "ERROR" "${SCRIPT_NAME} terminated with status $status"
+  fi
+}
+trap cleanup EXIT
+trap 'fatal "${SCRIPT_NAME} interrupted" 2' INT TERM
+
+resolve_cli() {
+  local candidate=$1
+  if [[ -n "$candidate" ]]; then
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+    fatal "CLI binary '$candidate' not found"
+  fi
+
+  if [[ -n "${SYN_CLI:-}" ]]; then
+    candidate=$SYN_CLI
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  fi
+
+  if command -v synnergy >/dev/null 2>&1; then
+    command -v synnergy
+    return 0
+  fi
+  if command -v synnergy-cli >/dev/null 2>&1; then
+    command -v synnergy-cli
+    return 0
+  fi
+
+  fatal "CLI binary not found. Provide --cli or set SYN_CLI"
+}
+
+acquire_lock() {
+  local path=$1
+  if [[ -z "$path" ]]; then
+    return
+  fi
+  mkdir -p "$(dirname "$path")"
+  LOCK_FD=213
+  eval "exec ${LOCK_FD}>\"$path\""
+  if ! flock -n "$LOCK_FD"; then
+    fatal "another snapshot capture already holds the lock at $path"
+  fi
+}
+
+validate_timestamp() {
+  local value=$1
+  if [[ ! $value =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
+    fatal "invalid --timestamp '$value'; expected YYYYMMDDTHHMMSSZ format"
+  fi
+}
+
+parse_status() {
+  local file=$1
+  local prefix=$2
+  local stdout
+  local stderr
+  stderr=$(mktemp)
+  if ! stdout=$(python3 - "$file" "$prefix" <<'PY' 2>"$stderr"
+import json
+import sys
+import shlex
+
+file_path = sys.argv[1]
+prefix = sys.argv[2]
+required = ["network", "height", "hash", "finalized_height", "finalized_hash"]
+try:
+    with open(file_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception as exc:  # pragma: no cover
+    print(f"unable to read {file_path}: {exc}", file=sys.stderr)
+    sys.exit(2)
+missing = [key for key in required if key not in data]
+if missing:
+    print(f"{file_path} missing required keys: {', '.join(missing)}", file=sys.stderr)
+    sys.exit(3)
+if data["height"] < 0 or data["finalized_height"] < 0:
+    print("heights must be non-negative", file=sys.stderr)
+    sys.exit(4)
+if data["finalized_height"] > data["height"]:
+    print("finalized height cannot exceed head height", file=sys.stderr)
+    sys.exit(5)
+for key in required:
+    value = data[key]
+    print(f"{prefix}{key.upper()}={shlex.quote(str(value))}")
+optional = ["timestamp", "finality_threshold", "finalized_by", "validators"]
+for key in optional:
+    if key in data:
+        value = data[key]
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, separators=(",", ":"))
+        print(f"{prefix}{key.upper()}={shlex.quote(str(value))}")
+PY
+  ); then
+    local message
+    message=$(<"$stderr")
+    rm -f "$stderr"
+    fatal "failed to parse $file: ${message:-unknown error}"
+  fi
+  rm -f "$stderr"
+  eval "$stdout"
+}
+
+fetch_status() {
+  local destination=$1
+  local cli=$2
+  local network=$3
+  local endpoint=$4
+  local profile=$5
+  local tmp
+  tmp=$(mktemp)
+  local cmd=("$cli" chain status --network "$network" --output json)
+  if [[ -n "$endpoint" ]]; then
+    cmd+=(--endpoint "$endpoint")
+  fi
+  if [[ -n "$profile" ]]; then
+    cmd+=(--profile "$profile")
+  fi
+  if ! "${cmd[@]}" >"$tmp" 2>"${tmp}.err"; then
+    local message
+    message=$(<"${tmp}.err")
+    rm -f "$tmp" "${tmp}.err"
+    fatal "CLI status query failed: ${message:-unknown error}"
+  fi
+  mv "$tmp" "$destination"
+  rm -f "${tmp}.err"
+}
+
+write_snapshot() {
+  local file=$1
+  local network=$2
+  local status_file=$3
+  local source=$4
+  local tag=$5
+  local timestamp=$6
+  python3 - "$file" "$network" "$status_file" "$source" "$tag" "$timestamp" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+file_path, network, status_file, source, tag, timestamp = sys.argv[1:7]
+with open(status_file, "r", encoding="utf-8") as fh:
+    status = json.load(fh)
+status.setdefault("timestamp", timestamp)
+snapshot = {
+    "network": network,
+    "captured_at": timestamp,
+    "source": source,
+    "height": status["height"],
+    "hash": status["hash"],
+    "finalized_height": status["finalized_height"],
+    "finalized_hash": status["finalized_hash"],
+    "metadata": {
+        "input_timestamp": status.get("timestamp", timestamp),
+        "finality_threshold": status.get("finality_threshold"),
+        "finalized_by": status.get("finalized_by"),
+        "validators": status.get("validators"),
+        "tag": tag or None,
+    },
+}
+Path(file_path).write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+prune_retention() {
+  local directory=$1
+  local prefix=$2
+  local keep=$3
+  local dry_run=$4
+  local deleted
+  deleted=$(python3 - "$directory" "$prefix" "$keep" "$dry_run" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+directory, prefix, keep_str, dry_run_flag = sys.argv[1:5]
+keep = int(keep_str)
+if keep <= 0:
+    print(json.dumps({"deleted": []}))
+    sys.exit(0)
+root = Path(directory)
+patterns = [f"{prefix}*.json", f"{prefix}*.tar.gz"]
+files = []
+for pattern in patterns:
+    files.extend(sorted(root.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True))
+seen = set()
+ordered = []
+for path in files:
+    if path in seen:
+        continue
+    seen.add(path)
+    ordered.append(path)
+if len(ordered) <= keep:
+    print(json.dumps({"deleted": []}))
+    sys.exit(0)
+to_delete = ordered[keep:]
+if dry_run_flag == "1":
+    deleted_paths = [str(p) for p in to_delete]
+else:
+    deleted_paths = []
+    for path in to_delete:
+        try:
+            path.unlink()
+            deleted_paths.append(str(path))
+        except FileNotFoundError:
+            pass
+print(json.dumps({"deleted": deleted_paths}))
+PY
+  )
+  echo "$deleted"
+}
+
+write_metrics() {
+  local file=$1
+  local network=$2
+  local path=$3
+  local height=$4
+  local finalized_height=$5
+  local start_ns=$6
+  local deleted_json=$7
+  local timestamp
+  timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  python3 - "$file" "$network" "$path" "$height" "$finalized_height" "$start_ns" "$timestamp" "$deleted_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+import time
+
+(
+    file_path,
+    network,
+    snapshot_path,
+    height,
+    finalized_height,
+    start_ns,
+    emitted_at,
+    deleted_json,
+) = sys.argv[1:9]
+height = int(height)
+finalized_height = int(finalized_height)
+start_ns = int(start_ns)
+summary = json.loads(deleted_json)
+deleted = summary.get("deleted", [])
+metrics = {
+    "network": network,
+    "snapshot_path": snapshot_path,
+    "height": height,
+    "finalized_height": finalized_height,
+    "emitted_at": emitted_at,
+    "duration_ms": max(0, (int(time.time_ns()) - start_ns) // 1_000_000),
+    "deleted": deleted,
+}
+Path(file_path).write_text(json.dumps(metrics, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+NETWORK=""
+OUTPUT_DIR=""
+STATUS_FILE=""
+CLI=""
+ENDPOINT=""
+PROFILE="production"
+FORMAT="json"
+RETAIN=5
+SNAPSHOT_PREFIX="snapshot-"
+TAG=""
+TIMESTAMP_OVERRIDE=""
+LOCK_FILE=""
+METRICS_FILE=""
+DRY_RUN=0
+DISABLE_RETENTION=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --network)
+      NETWORK=${2:-}
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR=${2:-}
+      shift 2
+      ;;
+    --status-file)
+      STATUS_FILE=${2:-}
+      shift 2
+      ;;
+    --cli)
+      CLI=${2:-}
+      shift 2
+      ;;
+    --endpoint)
+      ENDPOINT=${2:-}
+      shift 2
+      ;;
+    --profile)
+      PROFILE=${2:-}
+      shift 2
+      ;;
+    --format)
+      FORMAT=${2:-}
+      shift 2
+      ;;
+    --snapshot-prefix)
+      SNAPSHOT_PREFIX=${2:-}
+      shift 2
+      ;;
+    --retain)
+      RETAIN=${2:-}
+      shift 2
+      ;;
+    --tag)
+      TAG=${2:-}
+      shift 2
+      ;;
+    --timestamp)
+      TIMESTAMP_OVERRIDE=${2:-}
+      shift 2
+      ;;
+    --lock-file)
+      LOCK_FILE=${2:-}
+      shift 2
+      ;;
+    --metrics-file)
+      METRICS_FILE=${2:-}
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-retention)
+      DISABLE_RETENTION=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      log "ERROR" "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$NETWORK" || -z "$OUTPUT_DIR" ]]; then
   usage
-  exit 0
+  fatal "--network and --output-dir are required"
 fi
 
-echo "$(basename "$0") is not yet implemented." >&2
-exit 1
+if [[ $FORMAT != "json" && $FORMAT != "archive" ]]; then
+  fatal "--format must be json or archive"
+fi
+
+if [[ -n "$TIMESTAMP_OVERRIDE" ]]; then
+  validate_timestamp "$TIMESTAMP_OVERRIDE"
+fi
+
+if ! [[ $RETAIN =~ ^[0-9]+$ ]]; then
+  fatal "--retain must be a non-negative integer"
+fi
+
+if [[ $DRY_RUN -eq 1 && -z "$STATUS_FILE" ]]; then
+  fatal "--dry-run requires --status-file"
+fi
+
+acquire_lock "$LOCK_FILE"
+
+START_NS=$(python3 -c 'import time; print(time.time_ns())')
+
+if [[ -n "$STATUS_FILE" ]]; then
+  if [[ ! -f "$STATUS_FILE" ]]; then
+    fatal "status file $STATUS_FILE does not exist"
+  fi
+  parse_status "$STATUS_FILE" "STATUS_"
+  SOURCE="file:${STATUS_FILE}"
+else
+  CLI=$(resolve_cli "$CLI")
+  TMP_STATUS_FILE=$(mktemp)
+  if [[ $DRY_RUN -eq 1 ]]; then
+    fatal "dry-run requested but no status-file provided"
+  fi
+  fetch_status "$TMP_STATUS_FILE" "$CLI" "$NETWORK" "$ENDPOINT" "$PROFILE"
+  parse_status "$TMP_STATUS_FILE" "STATUS_"
+  SOURCE="cli:${CLI}"
+fi
+
+if [[ "${STATUS_NETWORK}" != "$NETWORK" ]]; then
+  fatal "status network '${STATUS_NETWORK}' does not match requested network '$NETWORK'"
+fi
+
+TIMESTAMP=${TIMESTAMP_OVERRIDE:-$(date -u +'%Y%m%dT%H%M%SZ')}
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  mkdir -p "$OUTPUT_DIR"
+fi
+
+SNAPSHOT_BASENAME="${SNAPSHOT_PREFIX}${NETWORK}-${TIMESTAMP}"
+SNAPSHOT_PATH_JSON="${OUTPUT_DIR%/}/${SNAPSHOT_BASENAME}.json"
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  write_snapshot "$SNAPSHOT_PATH_JSON" "$NETWORK" "${STATUS_FILE:-$TMP_STATUS_FILE}" "$SOURCE" "$TAG" "$TIMESTAMP"
+  CREATED_PATH="$SNAPSHOT_PATH_JSON"
+  if [[ $FORMAT == "archive" ]]; then
+    local_archive="${SNAPSHOT_PATH_JSON%.json}.tar.gz"
+    tar -czf "$local_archive" -C "$(dirname "$SNAPSHOT_PATH_JSON")" "$(basename "$SNAPSHOT_PATH_JSON")"
+    rm -f "$SNAPSHOT_PATH_JSON"
+    CREATED_PATH="$local_archive"
+  fi
+else
+  CREATED_PATH="$SNAPSHOT_PATH_JSON"
+  log "INFO" "dry-run: would write snapshot to $CREATED_PATH"
+fi
+
+DELETED_INFO='{"deleted": []}'
+if [[ $DISABLE_RETENTION -eq 0 && $RETAIN -gt 0 ]]; then
+  if [[ $DRY_RUN -eq 0 ]]; then
+    DELETED_INFO=$(prune_retention "$OUTPUT_DIR" "${SNAPSHOT_PREFIX}${NETWORK}-" "$RETAIN" 0)
+  else
+    DELETED_INFO=$(prune_retention "$OUTPUT_DIR" "${SNAPSHOT_PREFIX}${NETWORK}-" "$RETAIN" 1)
+  fi
+fi
+
+if [[ -n "$METRICS_FILE" ]]; then
+  write_metrics "$METRICS_FILE" "$NETWORK" "$CREATED_PATH" "${STATUS_HEIGHT}" "${STATUS_FINALIZED_HEIGHT}" "$START_NS" "$DELETED_INFO"
+fi
+
+log "INFO" "snapshot captured for $NETWORK at height ${STATUS_HEIGHT} -> $CREATED_PATH"
+
+exit 0

--- a/scripts/ci_setup.sh
+++ b/scripts/ci_setup.sh
@@ -1,37 +1,398 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME=$(basename "$0")
 
 usage() {
   cat <<'USAGE'
-Usage: $(basename "$0")
-Prepares the repository for continuous integration by tidying modules,
-verifying dependencies, linting, testing and building binaries.
+Usage: ci_setup.sh [options]
+
+Enterprise continuous integration bootstrapper for the Synnergy Network
+repository. The workflow aligns CLI automation, consensus builds, VM
+regressions, wallet/node toolchains, and JavaScript UI bundles with a single
+command that can run locally or inside CI runners.
+
+Optional arguments:
+  --project-root PATH       Repository root (default: auto-detected via git).
+  --profile NAME            Execution profile: full, verify, lint, or build-only
+                             (default: full).
+  --toolchain LIST          Comma-separated toolchains to initialize. Supported
+                             entries: go, node, docs (default: go,node).
+  --skip-tests              Skip unit/integration tests even in profiles that
+                             usually run them.
+  --skip-build              Skip binary bundling steps.
+  --ci-config PATH          Validate that the CI configuration file exists.
+  --cache-dir PATH          Ensure cache directory is initialized.
+  --lock-file PATH          Use flock-based locking to prevent parallel runs.
+  --report PATH             Write JSON execution report for downstream
+                             observability.
+  --log-file PATH           Append structured logs to the provided file.
+  --dry-run                 Print tasks without executing them.
+  --no-fail-fast            Continue executing tasks even if one fails.
+  --help, -h                Display this help message.
+
+Examples:
+  # Full pipeline bootstrap with reporting
+  ci_setup.sh --project-root /srv/synnergy --report /var/log/ci/report.json
+
+  # Developer sanity check without build/test steps
+  ci_setup.sh --profile lint --dry-run
 USAGE
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-  usage
-  exit 0
+LOG_FILE=""
+REPORT_FILE=""
+LOCK_FILE=""
+DRY_RUN=0
+FAIL_FAST=1
+PROJECT_ROOT=""
+PROFILE="full"
+TOOLCHAIN="go,node"
+SKIP_TESTS=0
+SKIP_BUILD=0
+CI_CONFIG=""
+CACHE_DIR=""
+OVERALL_FAILURE=0
+
+log() {
+  local level=$1
+  local message=$2
+  local timestamp
+  timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  printf '%s [%s] %s\n' "$timestamp" "$level" "$message" >&2
+  if [[ -n "$LOG_FILE" ]]; then
+    printf '%s [%s] %s\n' "$timestamp" "$level" "$message" >>"$LOG_FILE"
+  fi
+}
+
+fatal() {
+  local message=$1
+  local code=${2:-1}
+  log "ERROR" "$message"
+  exit "$code"
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${LOCK_FD:-}" ]]; then
+    eval "exec ${LOCK_FD}>&-"
+  fi
+  if [[ $status -ne 0 ]]; then
+    log "ERROR" "${SCRIPT_NAME} terminated with status $status"
+  fi
+}
+trap cleanup EXIT
+trap 'fatal "${SCRIPT_NAME} interrupted" 2' INT TERM
+
+acquire_lock() {
+  local path=$1
+  if [[ -z "$path" ]]; then
+    return
+  fi
+  mkdir -p "$(dirname "$path")"
+  LOCK_FD=214
+  eval "exec ${LOCK_FD}>\"$path\""
+  if ! flock -n "$LOCK_FD"; then
+    fatal "another ci_setup.sh invocation already holds the lock at $path"
+  fi
+}
+
+require_command() {
+  local cmd=$1
+  local description=${2:-$1}
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fatal "$description is required but not installed"
+  fi
+}
+
+RESULT_ROWS=()
+TASK_IDS=()
+TASK_DESCS=()
+TASK_CMDS=()
+
+add_task() {
+  local id=$1
+  local description=$2
+  local command=$3
+  TASK_IDS+=("$id")
+  TASK_DESCS+=("$description")
+  TASK_CMDS+=("$command")
+}
+
+run_tasks() {
+  local count=${#TASK_IDS[@]}
+  local idx=0
+  while [[ $idx -lt $count ]]; do
+    local id=${TASK_IDS[$idx]}
+    local description=${TASK_DESCS[$idx]}
+    local command=${TASK_CMDS[$idx]}
+    local start_ns end_ns duration status exit_code
+    start_ns=$(python3 -c 'import time; print(time.time_ns())')
+    if [[ $DRY_RUN -eq 1 ]]; then
+      status="skipped"
+      exit_code=0
+      log "INFO" "dry-run: [$id] $command"
+    else
+      log "INFO" "executing [$id] $command"
+      if eval "$command"; then
+        status="success"
+        exit_code=0
+      else
+        exit_code=$?
+        status="failed"
+        log "ERROR" "task $id failed with exit code $exit_code"
+        OVERALL_FAILURE=1
+        if [[ $FAIL_FAST -eq 1 ]]; then
+          end_ns=$(python3 -c 'import time; print(time.time_ns())')
+          duration=$(( (end_ns - start_ns) / 1000000 ))
+          RESULT_ROWS+=("$id|$description|$status|$exit_code|$duration|$command")
+          return
+        fi
+      fi
+    fi
+    end_ns=$(python3 -c 'import time; print(time.time_ns())')
+    duration=$(( (end_ns - start_ns) / 1000000 ))
+    RESULT_ROWS+=("$id|$description|$status|$exit_code|$duration|$command")
+    idx=$((idx + 1))
+  done
+}
+
+write_report() {
+  local file=$1
+  shift
+  if [[ -z "$file" ]]; then
+    return
+  fi
+  mkdir -p "$(dirname "$file")"
+  if [[ $# -eq 0 ]]; then
+    printf '{"tasks": []}\n' >"$file"
+    return
+  fi
+  python3 - "$file" "$@" <<'PY'
+import json
+import sys
+
+file_path = sys.argv[1]
+rows = []
+for raw in sys.argv[2:]:
+    if not raw:
+        continue
+    parts = raw.split('|', 5)
+    if len(parts) != 6:
+        continue
+    task = {
+        "id": parts[0],
+        "description": parts[1],
+        "status": parts[2],
+        "exit_code": int(parts[3]),
+        "duration_ms": int(parts[4]),
+        "command": parts[5],
+    }
+    rows.append(task)
+with open(file_path, 'w', encoding='utf-8') as fh:
+    json.dump({"tasks": rows}, fh, indent=2)
+    fh.write('\n')
+PY
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-root)
+      PROJECT_ROOT=${2:-}
+      shift 2
+      ;;
+    --profile)
+      PROFILE=${2:-}
+      shift 2
+      ;;
+    --toolchain)
+      TOOLCHAIN=${2:-}
+      shift 2
+      ;;
+    --skip-tests)
+      SKIP_TESTS=1
+      shift
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
+      ;;
+    --ci-config)
+      CI_CONFIG=${2:-}
+      shift 2
+      ;;
+    --cache-dir)
+      CACHE_DIR=${2:-}
+      shift 2
+      ;;
+    --lock-file)
+      LOCK_FILE=${2:-}
+      shift 2
+      ;;
+    --report)
+      REPORT_FILE=${2:-}
+      shift 2
+      ;;
+    --log-file)
+      LOG_FILE=${2:-}
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-fail-fast)
+      FAIL_FAST=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      log "ERROR" "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PROJECT_ROOT" ]]; then
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    PROJECT_ROOT=$(git rev-parse --show-toplevel)
+  else
+    PROJECT_ROOT=$(pwd)
+  fi
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$SCRIPT_DIR/.."
-cd "$ROOT_DIR"
+if [[ ! -d "$PROJECT_ROOT" ]]; then
+  fatal "project root $PROJECT_ROOT does not exist"
+fi
 
-echo "Tidying modules..."
-go mod tidy
+PROJECT_ROOT=$(cd "$PROJECT_ROOT" && pwd)
 
-echo "Verifying modules..."
-go mod verify
+if [[ -n "$LOG_FILE" ]]; then
+  mkdir -p "$(dirname "$LOG_FILE")"
+  : >"$LOG_FILE"
+fi
 
-echo "Linting source..."
-"$SCRIPT_DIR/lint.sh"
+if [[ -n "$CACHE_DIR" ]]; then
+  if [[ $DRY_RUN -eq 0 ]]; then
+    mkdir -p "$CACHE_DIR"
+  else
+    log "INFO" "dry-run: would create cache directory at $CACHE_DIR"
+  fi
+fi
 
-echo "Running tests..."
-"$SCRIPT_DIR/run_tests.sh"
+if [[ -n "$CI_CONFIG" && ! -f "$CI_CONFIG" ]]; then
+  fatal "CI config $CI_CONFIG not found"
+fi
 
-echo "Building binaries..."
-"$SCRIPT_DIR/build_all.sh"
+IFS=',' read -r -a TOOLCHAIN_ENTRIES <<<"$TOOLCHAIN"
+VALID_TOOLCHAINS=(go node docs)
+for entry in "${TOOLCHAIN_ENTRIES[@]}"; do
+  case "$entry" in
+    go|node|docs)
+      ;;
+    "")
+      ;;
+    *)
+      fatal "unsupported toolchain '$entry'"
+      ;;
+  esac
+done
 
-echo "CI setup complete"
+case "$PROFILE" in
+  full)
+    ;;
+  verify)
+    SKIP_BUILD=1
+    ;;
+  lint)
+    SKIP_TESTS=1
+    SKIP_BUILD=1
+    ;;
+  build-only)
+    SKIP_TESTS=1
+    ;;
+  *)
+    fatal "unknown profile '$PROFILE'"
+    ;;
+esac
 
+acquire_lock "$LOCK_FILE"
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  require_command bash "bash"
+  if printf '%s\n' "${TOOLCHAIN_ENTRIES[@]}" | grep -q 'go'; then
+    require_command go "Go toolchain"
+  fi
+  if printf '%s\n' "${TOOLCHAIN_ENTRIES[@]}" | grep -q 'node'; then
+    require_command npm "Node/npm toolchain"
+  fi
+fi
+
+add_go_tasks() {
+  if printf '%s\n' "${TOOLCHAIN_ENTRIES[@]}" | grep -q '^go$'; then
+    add_task "go-mod-tidy" "Go modules tidy" "cd \"$PROJECT_ROOT\" && go mod tidy"
+    add_task "go-mod-verify" "Verify Go modules" "cd \"$PROJECT_ROOT\" && go mod verify"
+    if [[ $SKIP_TESTS -eq 0 ]]; then
+      add_task "go-test" "Run Go tests" "cd \"$PROJECT_ROOT\" && go test ./..."
+      if [[ -f \"$PROJECT_ROOT/scripts/run_tests.sh\" ]]; then
+        add_task "syn-tests" "Synnergy scripted tests" "cd \"$PROJECT_ROOT\" && bash scripts/run_tests.sh"
+      fi
+    fi
+    if [[ $SKIP_BUILD -eq 0 ]]; then
+      if [[ -f \"$PROJECT_ROOT/scripts/build_all.sh\" ]]; then
+        add_task "syn-build" "Build Synnergy binaries" "cd \"$PROJECT_ROOT\" && bash scripts/build_all.sh"
+      fi
+    fi
+    if [[ -f \"$PROJECT_ROOT/scripts/lint.sh\" && $PROFILE != build-only ]]; then
+      add_task "syn-lint" "Run Synnergy linters" "cd \"$PROJECT_ROOT\" && bash scripts/lint.sh"
+    fi
+  fi
+}
+
+add_node_tasks() {
+  if printf '%s\n' "${TOOLCHAIN_ENTRIES[@]}" | grep -q '^node$'; then
+    local web_dir="$PROJECT_ROOT/web"
+    if [[ -d "$web_dir" ]]; then
+      add_task "node-install" "Install Node dependencies" "cd \"$web_dir\" && npm ci"
+      if [[ $SKIP_BUILD -eq 0 ]]; then
+        add_task "node-build" "Build web assets" "cd \"$web_dir\" && npm run build"
+      fi
+      if [[ $SKIP_TESTS -eq 0 ]]; then
+        add_task "node-test" "Run web unit tests" "cd \"$web_dir\" && npm test -- --watch=false"
+      fi
+    else
+      log "INFO" "web directory not present; skipping node toolchain"
+    fi
+  fi
+}
+
+add_docs_tasks() {
+  if printf '%s\n' "${TOOLCHAIN_ENTRIES[@]}" | grep -q '^docs$'; then
+    if [[ -f "$PROJECT_ROOT/mkdocs.yml" ]]; then
+      add_task "docs-build" "Build documentation site" "cd \"$PROJECT_ROOT\" && mkdocs build"
+    else
+      log "INFO" "mkdocs.yml missing; skipping docs toolchain"
+    fi
+  fi
+}
+
+add_go_tasks
+add_node_tasks
+add_docs_tasks
+
+run_tasks
+
+write_report "$REPORT_FILE" "${RESULT_ROWS[@]}"
+
+if [[ $OVERALL_FAILURE -eq 1 ]]; then
+  fatal "CI setup encountered failures" 1
+fi
+
+log "INFO" "ci_setup.sh completed successfully"
+exit 0

--- a/scripts/cleanup_artifacts.sh
+++ b/scripts/cleanup_artifacts.sh
@@ -1,17 +1,344 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME=$(basename "$0")
 
 usage() {
   cat <<'USAGE'
-Usage: $(basename "$0") [options]
-Placeholder script. Implementation pending.
+Usage: cleanup_artifacts.sh [options]
+
+Enterprise artifact cleanup utility that protects consensus-critical data while
+reclaiming build caches, coverage dumps, CLI sandboxes, and UI bundles. The
+cleanup integrates with CI/CD, operator workflows, and air-gapped rotations by
+supporting retention windows, pattern filtering, metrics emission, and
+idempotent dry-runs.
+
+Optional arguments:
+  --workspace PATH          Base directory (default: current working directory).
+  --target NAME             Logical target to purge: build, cache, logs, or tmp.
+                             Can be specified multiple times.
+  --path PATH               Additional path to purge (relative to workspace by
+                             default).
+  --include PATTERN         Glob pattern to include when pruning directories.
+  --exclude PATTERN         Glob pattern to exclude from pruning.
+  --max-age HOURS           Only remove files older than the given age.
+  --metrics-file PATH       Write JSON metrics describing the cleanup.
+  --lock-file PATH          Flock-based mutex to avoid concurrent runs.
+  --dry-run                 Report actions without deleting files.
+  --force                   Allow deleting paths outside the workspace.
+  --help, -h                Display this help message.
+
+Examples:
+  # Dry-run of build/cache cleanup for nightly job
+  cleanup_artifacts.sh --workspace /srv/synnergy --target build --target cache --dry-run
+
+  # Remove log archives older than 72 hours and emit metrics
+  cleanup_artifacts.sh --workspace /srv/synnergy --target logs --max-age 72 \
+    --metrics-file /var/log/synnergy/cleanup.json
 USAGE
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-  usage
+log() {
+  local level=$1
+  local message=$2
+  printf '%s [%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$level" "$message" >&2
+}
+
+fatal() {
+  local message=$1
+  local code=${2:-1}
+  log "ERROR" "$message"
+  exit "$code"
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${LOCK_FD:-}" ]]; then
+    eval "exec ${LOCK_FD}>&-"
+  fi
+  if [[ $status -ne 0 ]]; then
+    log "ERROR" "${SCRIPT_NAME} terminated with status $status"
+  fi
+}
+trap cleanup EXIT
+trap 'fatal "${SCRIPT_NAME} interrupted" 2' INT TERM
+
+acquire_lock() {
+  local path=$1
+  if [[ -z "$path" ]]; then
+    return
+  fi
+  mkdir -p "$(dirname "$path")"
+  LOCK_FD=215
+  eval "exec ${LOCK_FD}>\"$path\""
+  if ! flock -n "$LOCK_FD"; then
+    fatal "another cleanup_artifacts.sh invocation already holds the lock at $path"
+  fi
+}
+
+WORKSPACE="$(pwd)"
+METRICS_FILE=""
+LOCK_FILE=""
+DRY_RUN=0
+FORCE=0
+MAX_AGE_HOURS=-1
+TARGETS=()
+CUSTOM_PATHS=()
+INCLUDE_PATTERNS=()
+EXCLUDE_PATTERNS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace)
+      WORKSPACE=${2:-}
+      shift 2
+      ;;
+    --target)
+      TARGETS+=("${2:-}")
+      shift 2
+      ;;
+    --path)
+      CUSTOM_PATHS+=("${2:-}")
+      shift 2
+      ;;
+    --include)
+      INCLUDE_PATTERNS+=("${2:-}")
+      shift 2
+      ;;
+    --exclude)
+      EXCLUDE_PATTERNS+=("${2:-}")
+      shift 2
+      ;;
+    --max-age)
+      MAX_AGE_HOURS=${2:-}
+      shift 2
+      ;;
+    --metrics-file)
+      METRICS_FILE=${2:-}
+      shift 2
+      ;;
+    --lock-file)
+      LOCK_FILE=${2:-}
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      log "ERROR" "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$WORKSPACE" ]]; then
+  fatal "workspace $WORKSPACE does not exist"
+fi
+
+WORKSPACE=$(cd "$WORKSPACE" && pwd)
+
+if [[ ${#TARGETS[@]} -eq 0 && ${#CUSTOM_PATHS[@]} -eq 0 ]]; then
+  TARGETS+=(build)
+fi
+
+if [[ -n "$METRICS_FILE" ]]; then
+  mkdir -p "$(dirname "$METRICS_FILE")"
+fi
+
+if [[ $MAX_AGE_HOURS != -1 && ! $MAX_AGE_HOURS =~ ^[0-9]+$ ]]; then
+  fatal "--max-age must be a non-negative integer"
+fi
+
+acquire_lock "$LOCK_FILE"
+
+collect_targets() {
+  local target=$1
+  case "$target" in
+    build)
+      printf '%s\n' "build" "dist" "out" "bin" "artifacts" "deploy"
+      ;;
+    cache)
+      printf '%s\n' ".cache" "cache" "tmp/cache" "node_modules/.cache" "web/node_modules/.cache" "web/.next"
+      ;;
+    logs)
+      printf '%s\n' "logs" "var/log" "*.log" "log/*.log" "logs/*.log"
+      ;;
+    tmp|temp)
+      printf '%s\n' "tmp" "temp" "sandbox" "run/tmp"
+      ;;
+    *)
+      fatal "unsupported target '$target'"
+      ;;
+  esac
+}
+
+CANDIDATES=()
+for target in "${TARGETS[@]}"; do
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    CANDIDATES+=("$entry")
+  done < <(collect_targets "$target")
+done
+
+for path in "${CUSTOM_PATHS[@]}"; do
+  CANDIDATES+=("$path")
+done
+
+if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
+  log "INFO" "no candidate paths resolved; exiting"
   exit 0
 fi
 
-echo "$(basename "$0") is not yet implemented." >&2
-exit 1
+python_args=("${METRICS_FILE}" "$WORKSPACE" "$MAX_AGE_HOURS" "$DRY_RUN" "$FORCE")
+python_args+=("${CANDIDATES[@]}")
+python_args+=("--")
+python_args+=("${INCLUDE_PATTERNS[@]}")
+python_args+=("--")
+python_args+=("${EXCLUDE_PATTERNS[@]}")
+
+python3 - "$SCRIPT_NAME" "${python_args[@]}" <<'PY'
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+SCRIPT_NAME = sys.argv[1]
+metrics_path = sys.argv[2]
+workspace = Path(sys.argv[3]).resolve()
+max_age_hours = int(sys.argv[4])
+dry_run = sys.argv[5] == "1"
+force = sys.argv[6] == "1"
+args = sys.argv[7:]
+
+if "--" not in args:
+    print("invalid argument layout", file=sys.stderr)
+    sys.exit(2)
+divider_one = args.index("--")
+candidate_args = args[:divider_one]
+rest = args[divider_one + 1:]
+if "--" in rest:
+    divider_two = rest.index("--")
+    include_args = rest[:divider_two]
+    exclude_args = rest[divider_two + 1:]
+else:
+    include_args = rest
+    exclude_args = []
+
+includes = [pattern for pattern in include_args if pattern]
+excludes = [pattern for pattern in exclude_args if pattern]
+max_age_seconds = -1 if max_age_hours < 0 else max_age_hours * 3600
+now = time.time()
+removed = []
+
+def within_workspace(path: Path) -> bool:
+    try:
+        path.relative_to(workspace)
+        return True
+    except ValueError:
+        return False
+
+candidates: list[tuple[Path, str]] = []
+for raw in candidate_args:
+    if not raw:
+        continue
+    if any(ch in raw for ch in "*?["):
+        for match in workspace.glob(raw):
+            candidates.append((match.resolve(), raw))
+    else:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = (workspace / raw).resolve()
+        candidates.append((path, raw))
+
+def should_keep(path: Path) -> bool:
+    relative = str(path.relative_to(workspace)) if within_workspace(path) else str(path)
+    if includes and not any(Path(relative).match(pattern) for pattern in includes):
+        return True
+    if excludes and any(Path(relative).match(pattern) for pattern in excludes):
+        return True
+    if max_age_seconds >= 0 and path.exists():
+        age = now - path.stat().st_mtime
+        if age < max_age_seconds:
+            return True
+    return False
+
+for path, source in candidates:
+    if not force and not within_workspace(path):
+        print(f"Skipping {path} (outside workspace)")
+        continue
+    if not path.exists():
+        continue
+    if path.is_dir():
+        if includes:
+            for child in sorted(path.rglob("*")):
+                if not child.exists():
+                    continue
+                if should_keep(child):
+                    continue
+                size = child.stat().st_size if child.is_file() else 0
+                action = "Would remove" if dry_run else "Removing"
+                print(f"{action} {child}")
+                if not dry_run:
+                    if child.is_file() or child.is_symlink():
+                        child.unlink(missing_ok=True)
+                    else:
+                        shutil.rmtree(child, ignore_errors=True)
+                removed.append({"path": str(child), "bytes": size, "type": "dir" if child.is_dir() else "file"})
+        else:
+            size = 0
+            for child in path.rglob("*"):
+                if child.is_file():
+                    size += child.stat().st_size
+            action = "Would remove" if dry_run else "Removing"
+            print(f"{action} {path}")
+            if not dry_run:
+                shutil.rmtree(path, ignore_errors=True)
+            removed.append({"path": str(path), "bytes": size, "type": "dir"})
+    else:
+        if should_keep(path):
+            continue
+        size = path.stat().st_size
+        action = "Would remove" if dry_run else "Removing"
+        print(f"{action} {path}")
+        if not dry_run:
+            path.unlink(missing_ok=True)
+        removed.append({"path": str(path), "bytes": size, "type": "file"})
+
+metrics = {
+    "script": SCRIPT_NAME,
+    "workspace": str(workspace),
+    "dry_run": dry_run,
+    "removed": removed,
+    "count": len(removed),
+    "bytes": sum(item["bytes"] for item in removed),
+    "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+}
+if metrics_path:
+    with open(metrics_path, "w", encoding="utf-8") as fh:
+        json.dump(metrics, fh, indent=2)
+        fh.write("\n")
+print(f"Summary: {metrics['count']} items, {metrics['bytes']} bytes", flush=True)
+PY
+
+status=$?
+if [[ $status -ne 0 ]]; then
+  exit $status
+fi
+
+log "INFO" "cleanup_artifacts.sh completed"
+exit 0

--- a/scripts/cli_help_generator.sh
+++ b/scripts/cli_help_generator.sh
@@ -1,17 +1,321 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME=$(basename "$0")
 
 usage() {
   cat <<'USAGE'
-Usage: $(basename "$0") [options]
-Placeholder script. Implementation pending.
+Usage: cli_help_generator.sh --output <path> [options]
+
+Generate consolidated CLI documentation for the Synnergy toolchain. The
+generator can source definitions from recorded fixtures or query live binaries
+and produces Markdown or JSON for integration with docs, web portals, and
+regulatory submissions.
+
+Required arguments:
+  --output PATH             Destination file.
+
+Optional arguments:
+  --cli PATH                Explicit CLI binary (default: resolve synnergy/synnergy-cli).
+  --commands LIST           Comma-separated commands/subcommands to document.
+  --command-file PATH       File containing one command per line.
+  --definition-file PATH    JSON file with pre-rendered help output.
+  --format FORMAT           Output format: markdown or json (default: markdown).
+  --title TEXT              Title for generated documentation (default: Synnergy CLI Reference).
+  --metrics-file PATH       Write JSON metrics about generated commands.
+  --lock-file PATH          Flock-based mutex to prevent concurrent generation.
+  --dry-run                 Skip CLI invocations and generation (requires definition file).
+  --help, -h                Display this help message.
+
+Examples:
+  cli_help_generator.sh --output docs/cli.md --commands "status,ledger sync"
+  cli_help_generator.sh --output docs/cli.json --format json --definition-file fixtures/help.json
 USAGE
 }
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+log() {
+  local level=$1
+  local message=$2
+  printf '%s [%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$level" "$message" >&2
+}
+
+fatal() {
+  local message=$1
+  local code=${2:-1}
+  log "ERROR" "$message"
+  exit "$code"
+}
+
+cleanup() {
+  local status=$?
+  if [[ -n "${CMD_FILE:-}" && -f "$CMD_FILE" ]]; then
+    rm -f "$CMD_FILE"
+  fi
+  if [[ -n "${LOCK_FD:-}" ]]; then
+    eval "exec ${LOCK_FD}>&-"
+  fi
+  if [[ $status -ne 0 ]]; then
+    log "ERROR" "${SCRIPT_NAME} terminated with status $status"
+  fi
+}
+trap cleanup EXIT
+trap 'fatal "${SCRIPT_NAME} interrupted" 2' INT TERM
+
+resolve_cli() {
+  local candidate=$1
+  if [[ -n "$candidate" ]]; then
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+    fatal "CLI binary '$candidate' not found"
+  fi
+  if command -v synnergy >/dev/null 2>&1; then
+    command -v synnergy
+    return 0
+  fi
+  if command -v synnergy-cli >/dev/null 2>&1; then
+    command -v synnergy-cli
+    return 0
+  fi
+  fatal "CLI binary not found. Provide --cli or set SYN_CLI"
+}
+
+acquire_lock() {
+  local path=$1
+  if [[ -z "$path" ]]; then
+    return
+  fi
+  mkdir -p "$(dirname "$path")"
+  LOCK_FD=216
+  eval "exec ${LOCK_FD}>\"$path\""
+  if ! flock -n "$LOCK_FD"; then
+    fatal "another cli_help_generator.sh invocation holds the lock at $path"
+  fi
+}
+
+OUTPUT=""
+CLI=""
+COMMANDS=()
+COMMAND_FILE=""
+DEFINITION_FILE=""
+FORMAT="markdown"
+TITLE="Synnergy CLI Reference"
+METRICS_FILE=""
+LOCK_FILE=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      OUTPUT=${2:-}
+      shift 2
+      ;;
+    --cli)
+      CLI=${2:-}
+      shift 2
+      ;;
+    --commands)
+      IFS=',' read -r -a tmp <<<"${2:-}"
+      for entry in "${tmp[@]}"; do
+        entry=$(echo "$entry" | xargs)
+        [[ -n "$entry" ]] && COMMANDS+=("$entry")
+      done
+      shift 2
+      ;;
+    --command-file)
+      COMMAND_FILE=${2:-}
+      shift 2
+      ;;
+    --definition-file)
+      DEFINITION_FILE=${2:-}
+      shift 2
+      ;;
+    --format)
+      FORMAT=${2:-}
+      shift 2
+      ;;
+    --title)
+      TITLE=${2:-}
+      shift 2
+      ;;
+    --metrics-file)
+      METRICS_FILE=${2:-}
+      shift 2
+      ;;
+    --lock-file)
+      LOCK_FILE=${2:-}
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      log "ERROR" "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$OUTPUT" ]]; then
   usage
-  exit 0
+  fatal "--output is required"
 fi
 
-echo "$(basename "$0") is not yet implemented." >&2
-exit 1
+if [[ $FORMAT != "markdown" && $FORMAT != "json" ]]; then
+  fatal "--format must be markdown or json"
+fi
+
+if [[ -n "$COMMAND_FILE" ]]; then
+  if [[ ! -f "$COMMAND_FILE" ]]; then
+    fatal "command file $COMMAND_FILE does not exist"
+  fi
+  while IFS= read -r line; do
+    line=$(echo "$line" | xargs)
+    [[ -z "$line" || $line == \#* ]] && continue
+    COMMANDS+=("$line")
+  done <"$COMMAND_FILE"
+fi
+
+if [[ ${#COMMANDS[@]} -eq 0 && -z "$DEFINITION_FILE" ]]; then
+  fatal "no commands specified; provide --commands, --command-file, or --definition-file"
+fi
+
+if [[ $DRY_RUN -eq 1 && -z "$DEFINITION_FILE" ]]; then
+  fatal "--dry-run requires --definition-file"
+fi
+
+acquire_lock "$LOCK_FILE"
+
+if [[ -n "$METRICS_FILE" ]]; then
+  mkdir -p "$(dirname "$METRICS_FILE")"
+fi
+
+if [[ $DRY_RUN -eq 0 || -z "$DEFINITION_FILE" ]]; then
+  CLI=$(resolve_cli "$CLI")
+fi
+
+CMD_FILE=$(mktemp)
+if [[ ${#COMMANDS[@]} -gt 0 ]]; then
+  printf '%s\n' "${COMMANDS[@]}" >"$CMD_FILE"
+fi
+
+python3 - "$OUTPUT" "$FORMAT" "$TITLE" "$CLI" "$DEFINITION_FILE" "$CMD_FILE" "$METRICS_FILE" "$DRY_RUN" <<'PY'
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+output_format = sys.argv[2]
+title = sys.argv[3]
+cli = sys.argv[4]
+definition_file = sys.argv[5]
+command_file = Path(sys.argv[6])
+metrics_file = sys.argv[7]
+dry_run = sys.argv[8] == "1"
+
+commands = []
+if command_file.exists():
+    commands = [line.strip() for line in command_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+help_entries = []
+
+def load_definitions(path: str):
+    data = Path(path).read_text(encoding="utf-8")
+    parsed = json.loads(data)
+    entries = []
+    if isinstance(parsed, list):
+        for item in parsed:
+            if isinstance(item, dict) and "command" in item and "help" in item:
+                entries.append({"command": item["command"], "help": item["help"], "source": "definition"})
+    elif isinstance(parsed, dict) and "commands" in parsed:
+        for item in parsed["commands"]:
+            if isinstance(item, dict) and "command" in item and "help" in item:
+                entries.append({"command": item["command"], "help": item["help"], "source": "definition"})
+    return entries
+
+if definition_file:
+    if not Path(definition_file).is_file():
+        print(f"definition file {definition_file} does not exist", file=sys.stderr)
+        sys.exit(3)
+    help_entries.extend(load_definitions(definition_file))
+    if not commands:
+        commands = [entry["command"] for entry in help_entries]
+
+captured_commands = {entry["command"] for entry in help_entries}
+
+if not dry_run:
+    for command in commands:
+        if command in captured_commands:
+            continue
+        tokens = command.split()
+        try:
+            result = subprocess.run([cli, *tokens, "--help"], check=True, capture_output=True, text=True)
+            help_entries.append({"command": command, "help": result.stdout.strip(), "source": "cli"})
+        except subprocess.CalledProcessError as exc:
+            print(f"failed to capture help for {command}: {exc.stderr}", file=sys.stderr)
+            sys.exit(exc.returncode or 4)
+else:
+    if not help_entries:
+        print("dry-run with no definitions has nothing to do", file=sys.stderr)
+        sys.exit(0)
+
+def emit_markdown(entries):
+    lines = [f"# {title}", "", f"_Generated at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}_", ""]
+    for entry in sorted(entries, key=lambda e: e["command"]):
+        lines.append(f"## {entry['command']}")
+        lines.append("")
+        lines.append("```text")
+        lines.append(entry["help"])
+        lines.append("```")
+        lines.append("")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def emit_json(entries):
+    payload = {
+        "title": title,
+        "generated_at": time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+        "commands": sorted(entries, key=lambda e: e["command"]),
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+if output_format == "markdown":
+    emit_markdown(help_entries)
+else:
+    emit_json(help_entries)
+
+if metrics_file:
+    summary = {
+        "output": str(output_path),
+        "format": output_format,
+        "title": title,
+        "command_count": len(help_entries),
+        "sources": sorted({entry["source"] for entry in help_entries}),
+    }
+    Path(metrics_file).parent.mkdir(parents=True, exist_ok=True)
+    Path(metrics_file).write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+PY
+
+status=$?
+if [[ $status -ne 0 ]]; then
+  exit $status
+fi
+
+log "INFO" "cli_help_generator.sh wrote documentation to $OUTPUT"
+exit 0

--- a/tests/scripts/certificate_renew_test.go
+++ b/tests/scripts/certificate_renew_test.go
@@ -1,0 +1,144 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runCommand(t *testing.T, name string, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	return cmd.CombinedOutput()
+}
+
+func ensureOpenSSL(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("openssl"); err != nil {
+		t.Skip("openssl not available: " + err.Error())
+	}
+}
+
+func generateKeyAndCert(t *testing.T) (string, string) {
+	t.Helper()
+	ensureOpenSSL(t)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "node.key")
+	certPath := filepath.Join(dir, "node.pem")
+
+	cmd := exec.Command("openssl", "genrsa", "-out", keyPath, "2048")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to generate key: %v (%s)", err, out)
+	}
+
+	cmd = exec.Command("openssl", "req", "-x509", "-new", "-key", keyPath, "-out", certPath, "-days", "1", "-subj", "/CN=test.synnergy")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to generate certificate: %v (%s)", err, out)
+	}
+
+	return keyPath, certPath
+}
+
+func TestCertificateRenewUsage(t *testing.T) {
+	out, err := runCommand(t, "bash", "../../scripts/certificate_renew.sh")
+	if err == nil {
+		t.Fatalf("expected error when no arguments provided")
+	}
+	if !strings.Contains(string(out), "Usage: certificate_renew.sh") {
+		t.Fatalf("expected usage output, got: %s", out)
+	}
+}
+
+func TestCertificateRenewMissingCertificate(t *testing.T) {
+	ensureOpenSSL(t)
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "node.key")
+
+	cmd := exec.Command("openssl", "genrsa", "-out", keyPath, "2048")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to generate key: %v (%s)", err, out)
+	}
+
+	missingCert := filepath.Join(dir, "missing.pem")
+	out, err := runCommand(t, "bash", "../../scripts/certificate_renew.sh",
+		"--cert", missingCert,
+		"--key", keyPath,
+		"--output-dir", filepath.Join(dir, "out"),
+		"--dry-run",
+		"--force",
+	)
+	if err == nil {
+		t.Fatalf("expected failure when certificate is missing")
+	}
+	if !strings.Contains(string(out), "certificate '") {
+		t.Fatalf("expected certificate missing message, got: %s", out)
+	}
+}
+
+func TestCertificateRenewMissingCLI(t *testing.T) {
+	keyPath, certPath := generateKeyAndCert(t)
+	outDir := t.TempDir()
+
+	out, err := runCommand(t, "bash", "../../scripts/certificate_renew.sh",
+		"--cert", certPath,
+		"--key", keyPath,
+		"--output-dir", outDir,
+		"--force",
+		"--cli", "/nonexistent/synnergy",
+	)
+	if err == nil {
+		t.Fatalf("expected failure when CLI binary is missing")
+	}
+	if !strings.Contains(string(out), "CLI binary") {
+		t.Fatalf("expected CLI missing message, got: %s", out)
+	}
+}
+
+func TestCertificateRenewDryRunSuccess(t *testing.T) {
+	keyPath, certPath := generateKeyAndCert(t)
+	outDir := t.TempDir()
+	metricsPath := filepath.Join(outDir, "metrics", "renewal.json")
+
+	out, err := runCommand(t, "bash", "../../scripts/certificate_renew.sh",
+		"--cert", certPath,
+		"--key", keyPath,
+		"--output-dir", outDir,
+		"--dry-run",
+		"--force",
+		"--metrics-file", metricsPath,
+	)
+	if err != nil {
+		t.Fatalf("expected dry-run to succeed, got error: %v (%s)", err, out)
+	}
+
+	lines := strings.Split(string(out), "\n")
+	var csrPath string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "CSR_PATH=") {
+			csrPath = strings.TrimPrefix(line, "CSR_PATH=")
+			break
+		}
+	}
+	if csrPath == "" {
+		t.Fatalf("expected CSR_PATH in output, got: %s", out)
+	}
+
+	data, err := os.ReadFile(csrPath)
+	if err != nil {
+		t.Fatalf("expected CSR file, failed to read: %v", err)
+	}
+	if !strings.Contains(string(data), "BEGIN CERTIFICATE REQUEST") {
+		t.Fatalf("unexpected CSR content: %s", data)
+	}
+
+	metricsData, err := os.ReadFile(metricsPath)
+	if err != nil {
+		t.Fatalf("expected metrics file, failed to read: %v", err)
+	}
+	if !strings.Contains(string(metricsData), "\"dry_run\": 1") {
+		t.Fatalf("expected dry_run flag in metrics, got: %s", metricsData)
+	}
+}

--- a/tests/scripts/chain_rollback_prevention_test.go
+++ b/tests/scripts/chain_rollback_prevention_test.go
@@ -1,0 +1,177 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type statusPayload struct {
+	Network         string `json:"network"`
+	Height          int    `json:"height"`
+	Hash            string `json:"hash"`
+	FinalizedHeight int    `json:"finalized_height"`
+	FinalizedHash   string `json:"finalized_hash"`
+}
+
+func runScript(t *testing.T, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{"../../scripts/chain_rollback_prevention.sh"}, args...)...)
+	return cmd.CombinedOutput()
+}
+
+func writeStatus(t *testing.T, dir string, payload statusPayload) string {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+	path := filepath.Join(dir, "status.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write status file: %v", err)
+	}
+	return path
+}
+
+func writeCheckpoint(t *testing.T, dir string, payload statusPayload) string {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal checkpoint: %v", err)
+	}
+	path := filepath.Join(dir, "checkpoint.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write checkpoint file: %v", err)
+	}
+	return path
+}
+
+func TestChainRollbackPreventionUsage(t *testing.T) {
+	out, err := runScript(t)
+	if err == nil {
+		t.Fatalf("expected error when no arguments provided")
+	}
+	if !strings.Contains(string(out), "Usage: chain_rollback_prevention.sh") {
+		t.Fatalf("expected usage output, got: %s", out)
+	}
+}
+
+func TestChainRollbackInitializationCreatesCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	status := writeStatus(t, dir, statusPayload{
+		Network:         "stage98",
+		Height:          1200,
+		Hash:            "0xaaa",
+		FinalizedHeight: 1180,
+		FinalizedHash:   "0xbbb",
+	})
+
+	checkpoint := filepath.Join(dir, "checkpoint.json")
+	out, err := runScript(t,
+		"--network", "stage98",
+		"--checkpoint-file", checkpoint,
+		"--status-file", status,
+		"--mitigation-action", "none",
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("expected initialization to succeed, got error: %v (%s)", err, out)
+	}
+
+	if _, err := os.Stat(checkpoint); err != nil {
+		t.Fatalf("expected checkpoint file to exist: %v", err)
+	}
+	data, err := os.ReadFile(checkpoint)
+	if err != nil {
+		t.Fatalf("failed reading checkpoint: %v", err)
+	}
+	if !strings.Contains(string(data), "\"finalized_height\": 1180") {
+		t.Fatalf("expected finalized height in checkpoint, got: %s", data)
+	}
+}
+
+func TestChainRollbackPreventionDetectsRollback(t *testing.T) {
+	dir := t.TempDir()
+	status := writeStatus(t, dir, statusPayload{
+		Network:         "stage98",
+		Height:          1110,
+		Hash:            "0xccc",
+		FinalizedHeight: 1000,
+		FinalizedHash:   "0xddd",
+	})
+
+	checkpoint := writeCheckpoint(t, dir, statusPayload{
+		Network:         "stage98",
+		Height:          1200,
+		Hash:            "0xffff",
+		FinalizedHeight: 1100,
+		FinalizedHash:   "0xeeee",
+	})
+
+	out, err := runScript(t,
+		"--network", "stage98",
+		"--checkpoint-file", checkpoint,
+		"--status-file", status,
+		"--mitigation-action", "none",
+		"--dry-run",
+	)
+	if err == nil {
+		t.Fatalf("expected rollback detection to fail")
+	}
+	if !strings.Contains(string(out), "rollback detected") {
+		t.Fatalf("expected rollback warning, got: %s", out)
+	}
+}
+
+func TestChainRollbackPreventionMetricsAndUpdate(t *testing.T) {
+	dir := t.TempDir()
+	status := writeStatus(t, dir, statusPayload{
+		Network:         "stage98",
+		Height:          2100,
+		Hash:            "0xabc123",
+		FinalizedHeight: 2000,
+		FinalizedHash:   "0xabc777",
+	})
+
+	checkpoint := writeCheckpoint(t, dir, statusPayload{
+		Network:         "stage98",
+		Height:          1900,
+		Hash:            "0xold",
+		FinalizedHeight: 1850,
+		FinalizedHash:   "0xoldhash",
+	})
+
+	metrics := filepath.Join(dir, "metrics.json")
+	out, err := runScript(t,
+		"--network", "stage98",
+		"--checkpoint-file", checkpoint,
+		"--status-file", status,
+		"--metrics-file", metrics,
+		"--mitigation-action", "none",
+	)
+	if err != nil {
+		t.Fatalf("expected successful evaluation, got error: %v (%s)", err, out)
+	}
+
+	data, err := os.ReadFile(metrics)
+	if err != nil {
+		t.Fatalf("failed reading metrics: %v", err)
+	}
+	if !strings.Contains(string(data), "\"rollback_detected\": 0") {
+		t.Fatalf("expected rollback_detected flag to be 0, got: %s", data)
+	}
+	if !strings.Contains(string(data), "\"updated_checkpoint\": 1") {
+		t.Fatalf("expected checkpoint update flag, got: %s", data)
+	}
+
+	newCheckpoint, err := os.ReadFile(checkpoint)
+	if err != nil {
+		t.Fatalf("failed reading updated checkpoint: %v", err)
+	}
+	if !strings.Contains(string(newCheckpoint), "\"finalized_height\": 2000") {
+		t.Fatalf("expected checkpoint to reflect new finalized height, got: %s", newCheckpoint)
+	}
+}

--- a/tests/scripts/chain_state_snapshot_test.go
+++ b/tests/scripts/chain_state_snapshot_test.go
@@ -1,0 +1,99 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type snapshotStatus struct {
+	Network         string `json:"network"`
+	Height          int    `json:"height"`
+	Hash            string `json:"hash"`
+	FinalizedHeight int    `json:"finalized_height"`
+	FinalizedHash   string `json:"finalized_hash"`
+}
+
+func runSnapshot(t *testing.T, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{"../../scripts/chain_state_snapshot.sh"}, args...)...)
+	return cmd.CombinedOutput()
+}
+
+func writeSnapshotStatus(t *testing.T, dir string, status snapshotStatus) string {
+	t.Helper()
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("failed to marshal status: %v", err)
+	}
+	path := filepath.Join(dir, "status.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write status file: %v", err)
+	}
+	return path
+}
+
+func TestChainStateSnapshotUsage(t *testing.T) {
+	out, err := runSnapshot(t)
+	if err == nil {
+		t.Fatalf("expected failure without required arguments")
+	}
+	if !strings.Contains(string(out), "Usage: chain_state_snapshot.sh") {
+		t.Fatalf("expected usage output, got: %s", out)
+	}
+}
+
+func TestChainStateSnapshotCaptureAndRetention(t *testing.T) {
+	dir := t.TempDir()
+	status := writeSnapshotStatus(t, dir, snapshotStatus{
+		Network:         "stage98",
+		Height:          1280,
+		Hash:            "0x123",
+		FinalizedHeight: 1270,
+		FinalizedHash:   "0x122",
+	})
+
+	metrics := filepath.Join(dir, "metrics.json")
+	args := []string{
+		"--network", "stage98",
+		"--output-dir", dir,
+		"--status-file", status,
+		"--retain", "1",
+		"--metrics-file", metrics,
+		"--timestamp", "20240101T000000Z",
+	}
+	if out, err := runSnapshot(t, args...); err != nil {
+		t.Fatalf("snapshot capture failed: %v (%s)", err, out)
+	}
+
+	firstSnapshot := filepath.Join(dir, "snapshot-stage98-20240101T000000Z.json")
+	if _, err := os.Stat(firstSnapshot); err != nil {
+		t.Fatalf("expected snapshot file %s: %v", firstSnapshot, err)
+	}
+
+	// Second capture with new timestamp should prune the previous snapshot due to retain=1
+	args[len(args)-1] = "20240101T010000Z"
+	if out, err := runSnapshot(t, args...); err != nil {
+		t.Fatalf("second snapshot capture failed: %v (%s)", err, out)
+	}
+
+	files, err := filepath.Glob(filepath.Join(dir, "snapshot-stage98-*.json"))
+	if err != nil {
+		t.Fatalf("failed to glob snapshots: %v", err)
+	}
+	if len(files) != 1 || !strings.Contains(files[0], "20240101T010000Z") {
+		t.Fatalf("expected only the latest snapshot to remain, got: %v", files)
+	}
+
+	data, err := os.ReadFile(metrics)
+	if err != nil {
+		t.Fatalf("failed to read metrics: %v", err)
+	}
+	if !strings.Contains(string(data), "\"command\":") && !strings.Contains(string(data), "snapshot_path") {
+		// metrics include snapshot_path; ensure data is non-empty and structured
+		t.Fatalf("unexpected metrics payload: %s", data)
+	}
+}

--- a/tests/scripts/ci_setup_test.go
+++ b/tests/scripts/ci_setup_test.go
@@ -1,0 +1,82 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runCISetup(t *testing.T, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{"../../scripts/ci_setup.sh"}, args...)...)
+	return cmd.CombinedOutput()
+}
+
+func TestCISetupHelp(t *testing.T) {
+	out, err := runCISetup(t, "--help")
+	if err != nil {
+		t.Fatalf("expected help invocation to succeed: %v", err)
+	}
+	if !strings.Contains(string(out), "Usage: ci_setup.sh") {
+		t.Fatalf("expected usage information, got: %s", out)
+	}
+}
+
+func TestCISetupDryRunReport(t *testing.T) {
+	dir := t.TempDir()
+	report := filepath.Join(dir, "report.json")
+	cache := filepath.Join(dir, "cache")
+	logFile := filepath.Join(dir, "ci.log")
+	out, err := runCISetup(t,
+		"--profile", "verify",
+		"--project-root", dir,
+		"--dry-run",
+		"--report", report,
+		"--cache-dir", cache,
+		"--log-file", logFile,
+		"--toolchain", "go",
+	)
+	if err != nil {
+		t.Fatalf("expected dry-run to succeed: %v (%s)", err, out)
+	}
+	data, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatalf("failed to read report: %v", err)
+	}
+	var payload struct {
+		Tasks []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"tasks"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid report json: %v", err)
+	}
+	if len(payload.Tasks) == 0 {
+		t.Fatalf("expected at least one task in report")
+	}
+	for _, task := range payload.Tasks {
+		if task.Status != "skipped" {
+			t.Fatalf("expected dry-run tasks to be skipped, got: %#v", task)
+		}
+	}
+	if _, err := os.Stat(cache); err == nil {
+		t.Fatalf("cache directory should not be created during dry-run")
+	}
+	if _, err := os.Stat(logFile); err != nil {
+		t.Fatalf("expected log file to be created: %v", err)
+	}
+}
+
+func TestCISetupUnknownProfile(t *testing.T) {
+	out, err := runCISetup(t, "--profile", "mystery", "--dry-run")
+	if err == nil {
+		t.Fatalf("expected failure for unknown profile")
+	}
+	if !strings.Contains(string(out), "unknown profile") {
+		t.Fatalf("expected unknown profile error, got: %s", out)
+	}
+}

--- a/tests/scripts/cleanup_artifacts_test.go
+++ b/tests/scripts/cleanup_artifacts_test.go
@@ -1,0 +1,77 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func runCleanup(t *testing.T, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{"../../scripts/cleanup_artifacts.sh"}, args...)...)
+	return cmd.CombinedOutput()
+}
+
+func TestCleanupArtifactsDryRun(t *testing.T) {
+	workspace := t.TempDir()
+	buildDir := filepath.Join(workspace, "build")
+	if err := os.Mkdir(buildDir, 0o755); err != nil {
+		t.Fatalf("failed to create build dir: %v", err)
+	}
+	artifact := filepath.Join(buildDir, "artifact.bin")
+	if err := os.WriteFile(artifact, []byte("payload"), 0o600); err != nil {
+		t.Fatalf("failed to write artifact: %v", err)
+	}
+	metrics := filepath.Join(workspace, "metrics.json")
+	out, err := runCleanup(t,
+		"--workspace", workspace,
+		"--target", "build",
+		"--dry-run",
+		"--metrics-file", metrics,
+	)
+	if err != nil {
+		t.Fatalf("expected dry-run to succeed: %v (%s)", err, out)
+	}
+	if _, err := os.Stat(artifact); err != nil {
+		t.Fatalf("artifact should remain after dry-run: %v", err)
+	}
+	data, err := os.ReadFile(metrics)
+	if err != nil {
+		t.Fatalf("failed to read metrics: %v", err)
+	}
+	if !strings.Contains(string(data), "\"dry_run\": true") {
+		t.Fatalf("expected dry-run flag in metrics: %s", data)
+	}
+}
+
+func TestCleanupArtifactsDeletion(t *testing.T) {
+	workspace := t.TempDir()
+	logsDir := filepath.Join(workspace, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	logFile := filepath.Join(logsDir, "old.log")
+	if err := os.WriteFile(logFile, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+	// Ensure the file is older than the threshold we will use
+	past := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(logFile, past, past); err != nil {
+		t.Fatalf("failed to update timestamps: %v", err)
+	}
+
+	out, err := runCleanup(t,
+		"--workspace", workspace,
+		"--target", "logs",
+		"--max-age", "1",
+	)
+	if err != nil {
+		t.Fatalf("expected cleanup to succeed: %v (%s)", err, out)
+	}
+	if _, err := os.Stat(logFile); !os.IsNotExist(err) {
+		t.Fatalf("expected log file to be removed, got err: %v", err)
+	}
+}

--- a/tests/scripts/cli_help_generator_test.go
+++ b/tests/scripts/cli_help_generator_test.go
@@ -1,0 +1,73 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runHelpGenerator(t *testing.T, args ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{"../../scripts/cli_help_generator.sh"}, args...)...)
+	return cmd.CombinedOutput()
+}
+
+func TestCliHelpGeneratorDryRunRequiresDefinition(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "cli.md")
+	out, err := runHelpGenerator(t, "--output", output, "--dry-run")
+	if err == nil {
+		t.Fatalf("expected dry-run without definitions to fail")
+	}
+	if !strings.Contains(string(out), "no commands specified") {
+		t.Fatalf("expected missing definition message, got: %s", out)
+	}
+}
+
+func TestCliHelpGeneratorMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "cli.md")
+	metrics := filepath.Join(dir, "metrics.json")
+	definition := filepath.Join(dir, "defs.json")
+	entries := []map[string]string{{
+		"command": "status",
+		"help":    "Display network status",
+	}, {
+		"command": "ledger sync",
+		"help":    "Synchronize ledger state",
+	}}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("failed to marshal definitions: %v", err)
+	}
+	if err := os.WriteFile(definition, data, 0o600); err != nil {
+		t.Fatalf("failed to write definition file: %v", err)
+	}
+	out, err := runHelpGenerator(t,
+		"--output", output,
+		"--definition-file", definition,
+		"--format", "markdown",
+		"--metrics-file", metrics,
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("expected markdown generation to succeed: %v (%s)", err, out)
+	}
+	content, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("failed to read generated output: %v", err)
+	}
+	if !strings.Contains(string(content), "## status") || !strings.Contains(string(content), "ledger sync") {
+		t.Fatalf("expected command sections in output, got: %s", content)
+	}
+	metricsData, err := os.ReadFile(metrics)
+	if err != nil {
+		t.Fatalf("failed to read metrics: %v", err)
+	}
+	if !strings.Contains(string(metricsData), "\"command_count\": 2") {
+		t.Fatalf("expected command count in metrics: %s", metricsData)
+	}
+}


### PR DESCRIPTION
## Summary
- Harden the Stage 98 chain snapshot capture with retention-aware locking, metrics, and CLI/fixture parity
- Replace the CI bootstrapper, artifact cleanup utility, and CLI help generator with enterprise-grade implementations plus documentation updates
- Add regression tests covering snapshot retention, CI dry runs, artifact deletion safeguards, and CLI help generation fixtures while advancing the Stage 98 tracker

## Testing
- go test ./tests/scripts

------
https://chatgpt.com/codex/tasks/task_e_68d09dcfe7408320a5b2f917f854cfde