### PR TITLE
Improve consensus mining resiliency and fork choice

### DIFF
--- a/cli/consensus.go
+++ b/cli/consensus.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -27,7 +28,10 @@ func init() {
 			}
 			sb := core.NewSubBlock([]*core.Transaction{}, "validator")
 			b := core.NewBlock([]*core.SubBlock{sb}, "")
-			consensus.MineBlock(b, uint8(diff))
+			if err := consensus.MineBlock(context.Background(), b, uint8(diff)); err != nil {
+				printOutput(map[string]any{"error": err.Error()})
+				return
+			}
 			ilog.Info("cli_mine", "nonce", b.Nonce)
 			gasPrint("MineBlock")
 			printOutput(map[string]any{"nonce": b.Nonce})

--- a/cli/consensus_specific_node.go
+++ b/cli/consensus_specific_node.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -50,7 +51,11 @@ func init() {
 				fmt.Println("no node")
 				return
 			}
-			b := csNode.MineBlock()
+			b, err := csNode.MineBlock(context.Background())
+			if err != nil {
+				fmt.Printf("mining error: %v\n", err)
+				return
+			}
 			if b != nil {
 				fmt.Printf("mined block %s with nonce %d\n", b.Hash, b.Nonce)
 			}

--- a/cli/node.go
+++ b/cli/node.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -114,7 +115,10 @@ func init() {
 		Short: "Mine a block from the current mempool",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gasPrint("NodeMine")
-			block := currentNode.MineBlock()
+			block, err := currentNode.MineBlock(context.Background())
+			if err != nil {
+				return err
+			}
 			if block == nil {
 				printOutput("no transactions to mine")
 				return nil

--- a/core/consensus_start.go
+++ b/core/consensus_start.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	ilog "synnergy/internal/log"
 	"synnergy/internal/telemetry"
 )
 
@@ -34,7 +35,9 @@ func (s *ConsensusService) Start(ctx context.Context, interval time.Duration) {
 		for {
 			select {
 			case <-ticker.C:
-				s.node.MineBlock()
+				if _, err := s.node.MineBlock(ctx); err != nil {
+					ilog.Info("consensus_mine_error", "err", err)
+				}
 			case <-s.quit:
 				return
 			case <-ctx.Done():

--- a/core/genesis_block.go
+++ b/core/genesis_block.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 
 	ilog "synnergy/internal/log"
@@ -29,7 +30,9 @@ func (n *Node) InitGenesis(wallets GenesisWallets) (GenesisStats, *Block, error)
 	n.Ledger.Credit(wallets.CreatorWallet, GenesisAllocation)
 	sb := NewSubBlock(nil, wallets.Genesis)
 	block := NewBlock([]*SubBlock{sb}, "")
-	n.Consensus.MineBlock(block, 1)
+	if err := n.Consensus.MineBlock(context.Background(), block, 1); err != nil {
+		return GenesisStats{}, nil, err
+	}
 	n.Blockchain = append(n.Blockchain, block)
 	if err := n.Ledger.AddBlock(block); err != nil {
 		return GenesisStats{}, nil, err

--- a/core/node_test.go
+++ b/core/node_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"sync"
 	"testing"
 )
@@ -15,7 +16,10 @@ func TestMineBlockFeeDistribution(t *testing.T) {
 	if err := node.AddTransaction(tx); err != nil {
 		t.Fatalf("add tx: %v", err)
 	}
-	block := node.MineBlock()
+	block, err := node.MineBlock(context.Background())
+	if err != nil {
+		t.Fatalf("mine block: %v", err)
+	}
 	if block == nil {
 		t.Fatalf("block not mined")
 	}

--- a/core/swarm.go
+++ b/core/swarm.go
@@ -1,6 +1,9 @@
 package core
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // Swarm groups nodes to enable coordinated operations and simplified message
 // broadcasting among related participants.
@@ -64,7 +67,7 @@ func (s *Swarm) StartConsensus() []*Block {
 	members := s.Members()
 	blocks := make([]*Block, 0, len(members))
 	for _, n := range members {
-		if b := n.MineBlock(); b != nil {
+		if b, err := n.MineBlock(context.Background()); err == nil && b != nil {
 			blocks = append(blocks, b)
 		}
 	}


### PR DESCRIPTION
## Summary
- add context-aware PoW with configurable timeout and stronger fork-choice scoring in the consensus engine
- update node mining flow, genesis bootstrapping, and swarm/service wrappers to surface mining errors and preserve mempool state
- adjust CLI mining commands and unit tests to cover cancellation behaviour and the new APIs

## Testing
- `go test ./core/...`
- `go test ./cli/...` *(fails in existing DAO/data resource CLI tests that predate this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b95e28108320a64845f421704c83