### PR TITLE
Improve wallet GUI service and tests

### DIFF
--- a/GUI/wallet/jest.config.js
+++ b/GUI/wallet/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,tsx}'],
   coverageDirectory: 'coverage',

--- a/GUI/wallet/package-lock.json
+++ b/GUI/wallet/package-lock.json
@@ -7,8 +7,12 @@
     "": {
       "name": "synnergy-wallet",
       "version": "1.0.1",
+      "dependencies": {
+        "zod": "^3.22.4"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.3",
+        "@types/node": "^20.11.24",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
         "prettier": "^3.1.0",
@@ -1287,13 +1291,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4678,9 +4682,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4896,6 +4900,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/GUI/wallet/package.json
+++ b/GUI/wallet/package.json
@@ -10,9 +10,12 @@
     "lint": "eslint .",
     "format": "prettier --write ."
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.22.4"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.3",
+    "@types/node": "^20.11.24",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "prettier": "^3.1.0",

--- a/GUI/wallet/src/components/WalletBalance.ts
+++ b/GUI/wallet/src/components/WalletBalance.ts
@@ -1,3 +1,32 @@
-export function renderBalance(balance: number): string {
-  return `Current balance: ${balance}`;
+import { BalanceSummary } from '../services/walletService';
+
+const numberFormatters = new Map<string, Intl.NumberFormat>();
+
+function formatCurrency(value: number, currency: string): string {
+  const key = currency.toUpperCase();
+  if (!numberFormatters.has(key)) {
+    numberFormatters.set(
+      key,
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: key,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 8
+      })
+    );
+  }
+
+  return numberFormatters.get(key)!.format(value);
+}
+
+export function renderBalance(summary: BalanceSummary): string {
+  const lines = [
+    `Address        : ${summary.address}`,
+    `Available      : ${formatCurrency(summary.available, summary.currency)}`,
+    `Total Balance  : ${formatCurrency(summary.balance, summary.currency)}`,
+    `Pending Amount : ${formatCurrency(summary.pending, summary.currency)}`,
+    `Last Updated   : ${summary.updatedAt.toISOString()}`
+  ];
+
+  return lines.join('\n');
 }

--- a/GUI/wallet/src/config.ts
+++ b/GUI/wallet/src/config.ts
@@ -1,0 +1,43 @@
+export interface WalletGuiConfig {
+  apiUrl: string;
+  requestTimeoutMs: number;
+  maxRetries: number;
+  defaultCurrency: string;
+}
+
+const DEFAULT_CONFIG: WalletGuiConfig = {
+  apiUrl: 'http://127.0.0.1:4000',
+  requestTimeoutMs: 5000,
+  maxRetries: 2,
+  defaultCurrency: 'SYN'
+};
+
+function toPositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed);
+  }
+
+  return fallback;
+}
+
+export function resolveConfig(overrides: Partial<WalletGuiConfig> = {}): WalletGuiConfig {
+  const fromEnv: Partial<WalletGuiConfig> = {
+    apiUrl: process.env.WALLET_API_URL || process.env.API_URL,
+    requestTimeoutMs: toPositiveInteger(process.env.WALLET_REQUEST_TIMEOUT_MS, DEFAULT_CONFIG.requestTimeoutMs),
+    maxRetries: toPositiveInteger(process.env.WALLET_REQUEST_RETRIES, DEFAULT_CONFIG.maxRetries),
+    defaultCurrency: process.env.WALLET_CURRENCY
+  };
+
+  return {
+    ...DEFAULT_CONFIG,
+    ...fromEnv,
+    ...overrides
+  };
+}
+
+export const walletConfig = resolveConfig();

--- a/GUI/wallet/src/hooks/useBalance.test.ts
+++ b/GUI/wallet/src/hooks/useBalance.test.ts
@@ -1,7 +1,50 @@
 import { useBalance } from './useBalance';
-import * as api from '../services/api';
+import type { BalanceProvider } from '../state/walletStore';
+import type { BalanceSummary } from '../services/walletService';
 
-test('useBalance returns balance from service', async () => {
-  jest.spyOn(api, 'getBalance').mockResolvedValue(10);
-  await expect(useBalance('addr')).resolves.toBe(10);
+const summary: BalanceSummary = {
+  address: 'syn1cache',
+  balance: 100,
+  pending: 25,
+  currency: 'SYN',
+  updatedAt: new Date('2024-01-01T00:00:00Z'),
+  available: 75
+};
+
+class StubStore implements BalanceProvider {
+  constructor(private cached?: BalanceSummary, private refreshed?: BalanceSummary) {}
+
+  getBalance = jest.fn((address: string) => {
+    return this.cached && this.cached.address === address ? this.cached : undefined;
+  });
+
+  refreshBalance = jest.fn(async () => {
+    if (!this.refreshed) {
+      throw new Error('No refreshed value provided');
+    }
+
+    return this.refreshed;
+  });
+}
+
+describe('useBalance', () => {
+  it('returns cached balance when available', async () => {
+    const store = new StubStore(summary);
+    await expect(useBalance('syn1cache', { store })).resolves.toEqual(summary);
+    expect(store.getBalance).toHaveBeenCalledTimes(1);
+    expect(store.refreshBalance).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when forced', async () => {
+    const refreshed: BalanceSummary = { ...summary, available: 60, balance: 110, pending: 50 };
+    const store = new StubStore(summary, refreshed);
+
+    await expect(useBalance('syn1cache', { store, refresh: true })).resolves.toEqual(refreshed);
+    expect(store.refreshBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws for empty addresses', async () => {
+    const store = new StubStore();
+    await expect(useBalance('  ', { store })).rejects.toThrow('Wallet address cannot be empty');
+  });
 });

--- a/GUI/wallet/src/hooks/useBalance.ts
+++ b/GUI/wallet/src/hooks/useBalance.ts
@@ -1,9 +1,22 @@
-import { getBalance } from '../services/api';
+import { walletStore, BalanceProvider } from '../state/walletStore';
+import { BalanceSummary } from '../services/walletService';
+import { normalizeAddress } from '../utils/address';
 
-export async function useBalance(address: string): Promise<number> {
-  try {
-    return await getBalance(address);
-  } catch {
-    return 0;
+export interface UseBalanceOptions {
+  refresh?: boolean;
+  store?: BalanceProvider;
+}
+
+export async function useBalance(address: string, options: UseBalanceOptions = {}): Promise<BalanceSummary> {
+  const provider = options.store ?? walletStore;
+  const normalized = normalizeAddress(address);
+
+  if (!options.refresh) {
+    const cached = provider.getBalance(normalized);
+    if (cached) {
+      return cached;
+    }
   }
+
+  return provider.refreshBalance(normalized);
 }

--- a/GUI/wallet/src/main.test.ts
+++ b/GUI/wallet/src/main.test.ts
@@ -1,5 +1,38 @@
 import { main } from './main';
+import { useBalance } from './hooks/useBalance';
+import type { BalanceSummary } from './services/walletService';
 
-test('main renders home with balance', () => {
-  expect(main(5)).toContain('Current balance: 5');
+jest.mock('./hooks/useBalance');
+
+describe('main', () => {
+  const summary: BalanceSummary = {
+    address: 'syn1example',
+    balance: 125.5,
+    pending: 10,
+    currency: 'SYN',
+    updatedAt: new Date('2024-01-01T00:00:00Z'),
+    available: 115.5
+  };
+
+  beforeEach(() => {
+    (useBalance as jest.Mock).mockResolvedValue(summary);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the home view with resolved balance data', async () => {
+    const output = await main('syn1example');
+    expect(output).toContain('Synnergy Wallet Overview');
+    expect(output).toContain('syn1example');
+    expect(useBalance).toHaveBeenCalledWith(
+      'syn1example',
+      expect.objectContaining({ refresh: true, store: expect.anything() })
+    );
+  });
+
+  it('throws when no wallet address is provided', async () => {
+    await expect(main('')).rejects.toThrow('wallet address');
+  });
 });

--- a/GUI/wallet/src/main.ts
+++ b/GUI/wallet/src/main.ts
@@ -1,9 +1,34 @@
 import { renderHome } from './pages/Home';
+import { useBalance } from './hooks/useBalance';
+import { WalletStore, BalanceProvider } from './state/walletStore';
+import { WalletService } from './services/walletService';
 
-export function main(balance = 0): string {
-  return renderHome(balance);
+export interface MainOptions {
+  store?: BalanceProvider;
+}
+
+export async function main(addressInput?: string, options: MainOptions = {}): Promise<string> {
+  const candidate = addressInput ?? process.env.WALLET_ADDRESS ?? '';
+  const address = candidate.trim();
+
+  if (!address) {
+    throw new Error('A wallet address must be provided via an argument or the WALLET_ADDRESS environment variable.');
+  }
+
+  const provider = options.store ?? new WalletStore(new WalletService());
+  const summary = await useBalance(address, { refresh: true, store: provider });
+  return renderHome(summary);
 }
 
 if (require.main === module) {
-  console.log(main());
+  const argumentAddress = process.argv[2];
+  main(argumentAddress)
+    .then((output) => {
+      console.log(output);
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`Wallet CLI failed: ${message}`);
+      process.exitCode = 1;
+    });
 }

--- a/GUI/wallet/src/pages/Home.ts
+++ b/GUI/wallet/src/pages/Home.ts
@@ -1,5 +1,12 @@
 import { renderBalance } from '../components/WalletBalance';
+import { BalanceSummary } from '../services/walletService';
 
-export function renderHome(balance: number): string {
-  return `Wallet Home\n${renderBalance(balance)}`;
+export function renderHome(summary: BalanceSummary): string {
+  const sections = [
+    '=== Synnergy Wallet Overview ===',
+    renderBalance(summary),
+    'Use `wallet --help` for available commands.'
+  ];
+
+  return sections.join('\n\n');
 }

--- a/GUI/wallet/src/services/api.ts
+++ b/GUI/wallet/src/services/api.ts
@@ -1,4 +1,17 @@
-export async function getBalance(_address: string): Promise<number> {
-  // Placeholder for API call
-  return Promise.resolve(0);
+import { WalletService, BalanceSummary, Transaction, TransferReceipt, TransferRequest } from './walletService';
+
+export const walletService = new WalletService();
+
+export async function getBalance(address: string): Promise<BalanceSummary> {
+  return walletService.getBalance(address);
 }
+
+export async function getTransactions(address: string): Promise<Transaction[]> {
+  return walletService.getTransactions(address);
+}
+
+export async function transfer(from: string, request: TransferRequest): Promise<TransferReceipt> {
+  return walletService.submitTransfer(from, request);
+}
+
+export type { BalanceSummary, Transaction, TransferReceipt, TransferRequest };

--- a/GUI/wallet/src/services/httpClient.test.ts
+++ b/GUI/wallet/src/services/httpClient.test.ts
@@ -1,0 +1,60 @@
+import { HttpClient, HttpError } from './httpClient';
+
+describe('HttpClient', () => {
+  const fetchMock = jest.fn();
+  let originalFetch: typeof fetch | undefined;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    (global as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      (global as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    } else {
+      // @ts-expect-error cleanup mock fetch when not present
+      delete global.fetch;
+    }
+  });
+
+  function createResponse(body: unknown, init?: Partial<Response>): Response {
+    return {
+      ok: init?.ok ?? true,
+      status: init?.status ?? 200,
+      statusText: init?.statusText ?? 'OK',
+      text: async () => (body === undefined ? '' : JSON.stringify(body))
+    } as unknown as Response;
+  }
+
+  it('performs GET requests and parses JSON', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse({ value: 1 }));
+
+    const client = new HttpClient({ baseUrl: 'http://example.com', timeoutMs: 100, maxRetries: 0 });
+    const result = await client.get<{ value: number }>('/wallet');
+
+    expect(fetchMock).toHaveBeenCalledWith('http://example.com/wallet', expect.objectContaining({ method: 'GET' }));
+    expect(result.value).toBe(1);
+  });
+
+  it('retries failed requests before succeeding', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(createResponse({ ok: true }));
+
+    const client = new HttpClient({ baseUrl: 'http://example.com', timeoutMs: 10, maxRetries: 1 });
+    const result = await client.get<{ ok: boolean }>('/retry');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.ok).toBe(true);
+  });
+
+  it('throws HttpError for non-OK responses', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse('boom', { ok: false, status: 500, statusText: 'Server Error' }));
+
+    const client = new HttpClient({ baseUrl: 'http://example.com', timeoutMs: 10, maxRetries: 0 });
+
+    await expect(client.get('/fail')).rejects.toBeInstanceOf(HttpError);
+  });
+});

--- a/GUI/wallet/src/services/httpClient.ts
+++ b/GUI/wallet/src/services/httpClient.ts
@@ -1,0 +1,89 @@
+export interface HttpClientOptions {
+  baseUrl: string;
+  timeoutMs: number;
+  maxRetries: number;
+  headers?: Record<string, string>;
+}
+
+export class HttpError extends Error {
+  constructor(public readonly status: number, public readonly body: string) {
+    super(`HTTP ${status}: ${body || 'Request failed'}`);
+    this.name = 'HttpError';
+  }
+}
+
+const DEFAULT_HEADERS = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json'
+} as const;
+
+export class HttpClient {
+  private readonly headers: Record<string, string>;
+
+  constructor(private readonly options: HttpClientOptions) {
+    this.headers = {
+      ...DEFAULT_HEADERS,
+      ...(options.headers ?? {})
+    };
+  }
+
+  async get<T>(path: string): Promise<T> {
+    return this.request<T>('GET', path);
+  }
+
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>('POST', path, body);
+  }
+
+  private buildUrl(path: string): string {
+    return new URL(path, this.options.baseUrl).toString();
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown, attempt = 0): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
+
+    try {
+      const response = await fetch(this.buildUrl(path), {
+        method,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers: this.headers,
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new HttpError(response.status, errorBody || response.statusText);
+      }
+
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const text = await response.text();
+      if (!text) {
+        return undefined as T;
+      }
+
+      return JSON.parse(text) as T;
+    } catch (error) {
+      if (error instanceof HttpError) {
+        throw error;
+      }
+
+      if (attempt < this.options.maxRetries) {
+        const backoffMs = Math.min(this.options.timeoutMs, 1000) * (attempt + 1);
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        return this.request<T>(method, path, body, attempt + 1);
+      }
+
+      if (error instanceof Error) {
+        throw new Error(`HTTP request failed: ${error.message}`);
+      }
+
+      throw new Error('HTTP request failed due to an unknown error');
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/GUI/wallet/src/services/walletService.test.ts
+++ b/GUI/wallet/src/services/walletService.test.ts
@@ -1,0 +1,78 @@
+import { WalletService, TransferRequest } from './walletService';
+import type { HttpLike } from './walletService';
+
+class StubHttpClient implements HttpLike {
+  getMock = jest.fn<Promise<unknown>, [string]>();
+  postMock = jest.fn<Promise<unknown>, [string, unknown]>();
+
+  get<T>(path: string): Promise<T> {
+    return this.getMock(path) as Promise<T>;
+  }
+
+  post<T>(path: string, body?: unknown): Promise<T> {
+    return this.postMock(path, body) as Promise<T>;
+  }
+}
+
+describe('WalletService', () => {
+  const baseResponse = {
+    address: 'SYN1ABC',
+    balance: 100,
+    pending: 5,
+    currency: 'SYN',
+    updatedAt: '2024-01-01T00:00:00Z'
+  };
+
+  it('normalizes addresses and computes available balances', async () => {
+    const client = new StubHttpClient();
+    client.getMock.mockResolvedValueOnce(baseResponse);
+    const service = new WalletService(client);
+
+    const result = await service.getBalance('  SYN1ABC  ');
+
+    expect(client.getMock).toHaveBeenCalledWith('/wallets/syn1abc/balance');
+    expect(result.address).toBe('syn1abc');
+    expect(result.available).toBe(95);
+    expect(result.updatedAt.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('fetches transactions for an address', async () => {
+    const client = new StubHttpClient();
+    client.getMock.mockResolvedValueOnce([
+      {
+        id: 'tx-1',
+        from: 'syn1abc',
+        to: 'syn1def',
+        amount: 10,
+        timestamp: '2024-01-01T00:00:00Z'
+      }
+    ]);
+
+    const service = new WalletService(client);
+    const transactions = await service.getTransactions('syn1abc');
+
+    expect(client.getMock).toHaveBeenCalledWith('/wallets/syn1abc/transactions');
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].id).toBe('tx-1');
+  });
+
+  it('submits transfers with normalized addresses', async () => {
+    const client = new StubHttpClient();
+    client.postMock.mockResolvedValueOnce({
+      txId: 'tx-2',
+      accepted: true,
+      broadcastAt: '2024-01-01T01:00:00Z'
+    });
+
+    const service = new WalletService(client);
+    const request: TransferRequest = { to: 'SYN1DEF', amount: 42 };
+
+    const receipt = await service.submitTransfer(' SYN1ABC ', request);
+
+    expect(client.postMock).toHaveBeenCalledWith('/wallets/syn1abc/transfer', {
+      ...request,
+      to: 'syn1def'
+    });
+    expect(receipt.txId).toBe('tx-2');
+  });
+});

--- a/GUI/wallet/src/services/walletService.ts
+++ b/GUI/wallet/src/services/walletService.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import { walletConfig, WalletGuiConfig, resolveConfig } from '../config';
+import { normalizeAddress } from '../utils/address';
+import { HttpClient, HttpClientOptions } from './httpClient';
+
+export interface HttpLike {
+  get<T>(path: string): Promise<T>;
+  post<T>(path: string, body?: unknown): Promise<T>;
+}
+
+const BalanceSchema = z.object({
+  address: z.string().min(1),
+  balance: z.number(),
+  pending: z.number().min(0).default(0),
+  currency: z.string().min(1).default(walletConfig.defaultCurrency),
+  updatedAt: z.preprocess((value) => {
+    if (value instanceof Date) {
+      return value;
+    }
+
+    const date = new Date(value as string | number | Date);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }, z.date())
+});
+
+type BalancePayload = z.infer<typeof BalanceSchema>;
+
+const BalanceResponseSchema = z.union([
+  BalanceSchema,
+  z.object({ data: BalanceSchema })
+]);
+
+const TransactionSchema = z.object({
+  id: z.string().min(1),
+  from: z.string().min(1),
+  to: z.string().min(1),
+  amount: z.number(),
+  timestamp: z.preprocess((value) => {
+    const date = new Date(value as string | number | Date);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }, z.date())
+});
+
+export type Transaction = z.infer<typeof TransactionSchema>;
+
+const TransactionListSchema = z.array(TransactionSchema);
+
+const TransferReceiptSchema = z.object({
+  txId: z.string().min(1),
+  accepted: z.boolean(),
+  broadcastAt: z.preprocess((value) => {
+    const date = new Date(value as string | number | Date);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }, z.date())
+});
+
+export type TransferReceipt = z.infer<typeof TransferReceiptSchema>;
+
+export interface TransferRequest {
+  to: string;
+  amount: number;
+  memo?: string;
+}
+
+export interface BalanceSummary {
+  address: string;
+  balance: number;
+  pending: number;
+  currency: string;
+  updatedAt: Date;
+  available: number;
+}
+
+function createHttpClient(config: WalletGuiConfig): HttpClient {
+  const options: HttpClientOptions = {
+    baseUrl: config.apiUrl,
+    timeoutMs: config.requestTimeoutMs,
+    maxRetries: config.maxRetries
+  };
+
+  return new HttpClient(options);
+}
+
+export class WalletService {
+  private readonly client: HttpLike;
+  private readonly config: WalletGuiConfig;
+
+  constructor(client?: HttpLike, overrides?: Partial<WalletGuiConfig>) {
+    this.config = resolveConfig(overrides);
+    this.client = client ?? createHttpClient(this.config);
+  }
+
+  async getBalance(address: string): Promise<BalanceSummary> {
+    const normalized = normalizeAddress(address);
+    const payload = await this.client.get<unknown>(`/wallets/${normalized}/balance`);
+    const parsed = BalanceResponseSchema.parse(payload);
+    const balance: BalancePayload = 'data' in parsed ? parsed.data : parsed;
+
+    return {
+      ...balance,
+      currency: balance.currency || this.config.defaultCurrency,
+      address: balance.address.toLowerCase(),
+      available: Number(balance.balance - balance.pending),
+      updatedAt: balance.updatedAt
+    };
+  }
+
+  async getTransactions(address: string): Promise<Transaction[]> {
+    const normalized = normalizeAddress(address);
+    const payload = await this.client.get<unknown>(`/wallets/${normalized}/transactions`);
+    return TransactionListSchema.parse(payload);
+  }
+
+  async submitTransfer(from: string, request: TransferRequest): Promise<TransferReceipt> {
+    const normalizedFrom = normalizeAddress(from);
+    const normalizedTo = normalizeAddress(request.to);
+
+    const payload = await this.client.post<unknown>(`/wallets/${normalizedFrom}/transfer`, {
+      ...request,
+      to: normalizedTo
+    });
+
+    return TransferReceiptSchema.parse(payload);
+  }
+}

--- a/GUI/wallet/src/state/walletStore.test.ts
+++ b/GUI/wallet/src/state/walletStore.test.ts
@@ -1,0 +1,41 @@
+import { WalletStore } from './walletStore';
+import type { BalanceSummary } from '../services/walletService';
+
+class FakeService {
+  constructor(private readonly summary: BalanceSummary) {}
+  getBalance = jest.fn(async (_address: string) => this.summary);
+}
+
+describe('WalletStore', () => {
+  const summary: BalanceSummary = {
+    address: 'syn1abc',
+    balance: 100,
+    pending: 20,
+    currency: 'SYN',
+    updatedAt: new Date('2024-01-01T00:00:00Z'),
+    available: 80
+  };
+
+  it('caches balances after refresh', async () => {
+    const service = new FakeService(summary);
+    const store = new WalletStore(service);
+
+    await store.refreshBalance('syn1abc');
+    const cached = store.getBalance('syn1abc');
+
+    expect(service.getBalance).toHaveBeenCalledTimes(1);
+    expect(cached).toEqual(summary);
+  });
+
+  it('notifies subscribers on refresh', async () => {
+    const service = new FakeService(summary);
+    const store = new WalletStore(service);
+
+    const listener = jest.fn();
+    const unsubscribe = store.subscribe('syn1abc', listener);
+    await store.refreshBalance('syn1abc');
+
+    expect(listener).toHaveBeenCalledWith(summary);
+    unsubscribe();
+  });
+});

--- a/GUI/wallet/src/state/walletStore.ts
+++ b/GUI/wallet/src/state/walletStore.ts
@@ -1,0 +1,45 @@
+import { EventEmitter } from 'events';
+import { WalletService, BalanceSummary } from '../services/walletService';
+
+export type BalanceListener = (summary: BalanceSummary) => void;
+
+export interface BalanceProvider {
+  getBalance(address: string): BalanceSummary | undefined;
+  refreshBalance(address: string): Promise<BalanceSummary>;
+}
+
+function eventName(address: string): string {
+  return `balance:${address}`;
+}
+
+type WalletBalanceService = {
+  getBalance(address: string): Promise<BalanceSummary>;
+};
+
+export class WalletStore extends EventEmitter implements BalanceProvider {
+  private readonly balances = new Map<string, BalanceSummary>();
+
+  constructor(private readonly service: WalletBalanceService = new WalletService()) {
+    super();
+  }
+
+  getBalance(address: string): BalanceSummary | undefined {
+    return this.balances.get(address);
+  }
+
+  async refreshBalance(address: string): Promise<BalanceSummary> {
+    const summary = await this.service.getBalance(address);
+    this.balances.set(address, summary);
+    this.emit('balance', summary);
+    this.emit(eventName(address), summary);
+    return summary;
+  }
+
+  subscribe(address: string, listener: BalanceListener): () => void {
+    const key = eventName(address);
+    this.on(key, listener);
+    return () => this.off(key, listener);
+  }
+}
+
+export const walletStore = new WalletStore();

--- a/GUI/wallet/src/utils/address.test.ts
+++ b/GUI/wallet/src/utils/address.test.ts
@@ -1,0 +1,11 @@
+import { normalizeAddress } from './address';
+
+describe('normalizeAddress', () => {
+  it('lowercases and trims addresses', () => {
+    expect(normalizeAddress('  SYN1ABC ')).toBe('syn1abc');
+  });
+
+  it('throws for empty strings', () => {
+    expect(() => normalizeAddress('   ')).toThrow('Wallet address cannot be empty');
+  });
+});

--- a/GUI/wallet/src/utils/address.ts
+++ b/GUI/wallet/src/utils/address.ts
@@ -1,0 +1,9 @@
+export function normalizeAddress(address: string): string {
+  const trimmed = address.trim();
+
+  if (!trimmed) {
+    throw new Error('Wallet address cannot be empty.');
+  }
+
+  return trimmed.toLowerCase();
+}

--- a/GUI/wallet/tests/e2e/example.e2e.test.ts
+++ b/GUI/wallet/tests/e2e/example.e2e.test.ts
@@ -1,3 +1,53 @@
-test('e2e placeholder', () => {
-  expect(true).toBe(true);
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { main } from '../../src/main';
+
+async function withTestServer(handler: (server: http.Server) => Promise<void>) {
+  const server = http.createServer((req, res) => {
+    if (!req.url) {
+      res.statusCode = 400;
+      res.end('missing url');
+      return;
+    }
+
+    if (req.url.endsWith('/balance')) {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          address: 'syn1e2e',
+          balance: 200,
+          pending: 20,
+          currency: 'SYN',
+          updatedAt: new Date('2024-01-01T00:00:00Z').toISOString()
+        })
+      );
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+
+  try {
+    await handler(server);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('wallet CLI e2e', () => {
+  it('renders formatted balance output from a live server', async () => {
+    await withTestServer(async (server) => {
+      const { port } = server.address() as AddressInfo;
+      process.env.WALLET_API_URL = `http://127.0.0.1:${port}`;
+
+      const output = await main('syn1e2e');
+
+      expect(output).toContain('syn1e2e');
+      expect(output).toContain('Available');
+      expect(output).toContain('Synnergy Wallet Overview');
+    });
+  });
 });

--- a/GUI/wallet/tests/setup.ts
+++ b/GUI/wallet/tests/setup.ts
@@ -1,1 +1,11 @@
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+  delete process.env.WALLET_API_URL;
+  delete process.env.API_URL;
+  delete process.env.WALLET_REQUEST_TIMEOUT_MS;
+  delete process.env.WALLET_REQUEST_RETRIES;
+  delete process.env.WALLET_CURRENCY;
+});
+
 export {};

--- a/GUI/wallet/tests/unit/example.test.ts
+++ b/GUI/wallet/tests/unit/example.test.ts
@@ -1,3 +1,14 @@
-test('placeholder', () => {
-  expect(true).toBe(true);
+import { resolveConfig } from '../../src/config';
+
+describe('resolveConfig', () => {
+  it('prefers explicit overrides over environment defaults', () => {
+    process.env.API_URL = 'http://env-host';
+    process.env.WALLET_REQUEST_TIMEOUT_MS = '2000';
+
+    const config = resolveConfig({ apiUrl: 'http://override', maxRetries: 5 });
+
+    expect(config.apiUrl).toBe('http://override');
+    expect(config.requestTimeoutMs).toBe(2000);
+    expect(config.maxRetries).toBe(5);
+  });
 });

--- a/GUI/wallet/tsconfig.json
+++ b/GUI/wallet/tsconfig.json
@@ -1,11 +1,18 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
-    "module": "commonjs",
+    "target": "ES2021",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"],
+    "lib": ["ES2021"],
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- add a configurable wallet service with an HTTP client, caching store, and CLI integration improvements
- format wallet output with richer balance details and environment-aware main entrypoint
- expand TypeScript configuration and dependencies for Node support and add thorough unit/e2e coverage

## Testing
- npx jest --runInBand
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0bc12322c8320903f648f0388ee14