### PR TITLE
Improve network, loan pool, and consensus robustness

### DIFF
--- a/cli/consensus.go
+++ b/cli/consensus.go
@@ -39,8 +39,9 @@ func init() {
 		Short: "Show current consensus weights",
 		Run: func(cmd *cobra.Command, args []string) {
 			gasPrint("Weights")
-			ilog.Info("cli_weights", "pow", consensus.Weights.PoW, "pos", consensus.Weights.PoS, "poh", consensus.Weights.PoH)
-			printOutput(map[string]float64{"pow": consensus.Weights.PoW, "pos": consensus.Weights.PoS, "poh": consensus.Weights.PoH})
+			weights := consensus.WeightsSnapshot()
+			ilog.Info("cli_weights", "pow", weights.PoW, "pos", weights.PoS, "poh", weights.PoH)
+			printOutput(map[string]float64{"pow": weights.PoW, "pos": weights.PoS, "poh": weights.PoH})
 		},
 	}
 
@@ -60,9 +61,10 @@ func init() {
 				return
 			}
 			consensus.AdjustWeights(d, s)
-			ilog.Info("cli_adjust", "pow", consensus.Weights.PoW, "pos", consensus.Weights.PoS, "poh", consensus.Weights.PoH)
+			weights := consensus.WeightsSnapshot()
+			ilog.Info("cli_adjust", "pow", weights.PoW, "pos", weights.PoS, "poh", weights.PoH)
 			gasPrint("AdjustWeights")
-			printOutput(map[string]float64{"pow": consensus.Weights.PoW, "pos": consensus.Weights.PoS, "poh": consensus.Weights.PoH})
+			printOutput(map[string]float64{"pow": weights.PoW, "pos": weights.PoS, "poh": weights.PoH})
 		},
 	}
 

--- a/core/consensus_adaptive_management.go
+++ b/core/consensus_adaptive_management.go
@@ -56,7 +56,7 @@ func (am *AdaptiveManager) Adjust(demand, stake float64) ConsensusWeights {
 	am.record(demand, stake)
 	d, s := am.averages()
 	am.engine.AdjustWeights(d, s)
-	return am.engine.Weights
+	return am.engine.WeightsSnapshot()
 }
 
 // Threshold computes the consensus threshold for switching modes using the
@@ -79,7 +79,7 @@ func (am *AdaptiveManager) Weights() ConsensusWeights {
 	if am.engine == nil {
 		return ConsensusWeights{}
 	}
-	return am.engine.Weights
+	return am.engine.WeightsSnapshot()
 }
 
 // RecordMetrics allows external components to feed network demand and stake

--- a/core/consensus_specific.go
+++ b/core/consensus_specific.go
@@ -28,10 +28,11 @@ func (cs *ConsensusSwitcher) Evaluate(sc *SynnergyConsensus) ConsensusMode {
 	if sc == nil {
 		return cs.mode
 	}
+	snapshot := sc.WeightsSnapshot()
 	weights := map[ConsensusMode]float64{
-		ModePoW: sc.Weights.PoW,
-		ModePoS: sc.Weights.PoS,
-		ModePoH: sc.Weights.PoH,
+		ModePoW: snapshot.PoW,
+		ModePoS: snapshot.PoS,
+		ModePoH: snapshot.PoH,
 	}
 	var maxMode ConsensusMode
 	maxWeight := -1.0

--- a/core/consensus_specific_node.go
+++ b/core/consensus_specific_node.go
@@ -20,12 +20,12 @@ func (n *ConsensusSpecificNode) configure() {
 	switch n.Mode {
 	case ModePoW:
 		n.Consensus.SetAvailability(true, false, false)
-		n.Consensus.Weights = ConsensusWeights{PoW: 1}
+		n.Consensus.SetWeights(ConsensusWeights{PoW: 1})
 	case ModePoS:
 		n.Consensus.SetAvailability(false, true, false)
-		n.Consensus.Weights = ConsensusWeights{PoS: 1}
+		n.Consensus.SetWeights(ConsensusWeights{PoS: 1})
 	case ModePoH:
 		n.Consensus.SetAvailability(false, false, true)
-		n.Consensus.Weights = ConsensusWeights{PoH: 1}
+		n.Consensus.SetWeights(ConsensusWeights{PoH: 1})
 	}
 }

--- a/core/consensus_specific_node_test.go
+++ b/core/consensus_specific_node_test.go
@@ -7,7 +7,8 @@ import "testing"
 func TestNewConsensusSpecificNode(t *testing.T) {
 	ledger := NewLedger()
 	n := NewConsensusSpecificNode(ModePoS, "n1", "addr", ledger)
-	if !n.Consensus.PoSAvailable || n.Consensus.Weights.PoS != 1 {
+	weights := n.Consensus.WeightsSnapshot()
+	if !n.Consensus.PoSAvailable || weights.PoS != 1 {
 		t.Fatalf("expected PoS only mode")
 	}
 	if n.Consensus.PoWAvailable || n.Consensus.PoHAvailable {

--- a/core/consensus_specific_test.go
+++ b/core/consensus_specific_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestConsensusSwitcher(t *testing.T) {
 	sc := NewSynnergyConsensus()
 	cs := NewConsensusSwitcher(ModePoW)
-	sc.Weights = ConsensusWeights{PoW: 0.2, PoS: 0.6, PoH: 0.2}
+	sc.SetWeights(ConsensusWeights{PoW: 0.2, PoS: 0.6, PoH: 0.2})
 	mode := cs.Evaluate(sc)
 	if mode != ModePoS {
 		t.Fatalf("expected ModePoS, got %s", mode)

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -18,10 +18,11 @@ func TestAdjustWeightsAndAvailability(t *testing.T) {
 	sc := NewSynnergyConsensus()
 	sc.SetAvailability(true, false, true)
 	sc.AdjustWeights(0.5, 0.5)
-	if sc.Weights.PoS != 0 {
+	weights := sc.WeightsSnapshot()
+	if weights.PoS != 0 {
 		t.Fatalf("PoS weight should be zero when unavailable")
 	}
-	total := sc.Weights.PoW + sc.Weights.PoS + sc.Weights.PoH
+	total := weights.PoW + weights.PoS + weights.PoH
 	if math.Abs(total-1) > 1e-9 {
 		t.Fatalf("weights not normalized")
 	}

--- a/core/genesis_block.go
+++ b/core/genesis_block.go
@@ -39,7 +39,7 @@ func (n *Node) InitGenesis(wallets GenesisWallets) (GenesisStats, *Block, error)
 		Hash:        block.Hash,
 		Circulating: CirculatingSupply(0),
 		Remaining:   RemainingSupply(0),
-		Weights:     n.Consensus.Weights,
+		Weights:     n.Consensus.WeightsSnapshot(),
 	}
 	ilog.Info("genesis_init", "hash", block.Hash, "circulating", stats.Circulating, "remaining", stats.Remaining)
 	return stats, block, nil

--- a/core/loanpool.go
+++ b/core/loanpool.go
@@ -3,7 +3,15 @@ package core
 import (
 	"errors"
 	"sort"
+	"sync"
 	"time"
+)
+
+var (
+	ErrLoanPoolPaused        = errors.New("loan pool is paused")
+	ErrInvalidProposal       = errors.New("invalid proposal")
+	errLoanProposalNotFound  = errors.New("proposal not found")
+	errLoanProposalCancelled = errors.New("cannot cancel proposal")
 )
 
 // LoanPool manages loan proposals and disbursements.
@@ -12,6 +20,8 @@ type LoanPool struct {
 	Proposals map[uint64]*LoanProposal
 	nextID    uint64
 	Paused    bool
+
+	mu sync.RWMutex
 }
 
 // NewLoanPool creates a new loan pool with the given treasury balance.
@@ -23,22 +33,36 @@ func NewLoanPool(treasury uint64) *LoanPool {
 	}
 }
 
+// SetPaused toggles whether new proposals may be submitted.
+func (lp *LoanPool) SetPaused(paused bool) {
+	lp.mu.Lock()
+	lp.Paused = paused
+	lp.mu.Unlock()
+}
+
 // SubmitProposal adds a new loan proposal to the pool.
 func (lp *LoanPool) SubmitProposal(creator, recipient, typ string, amount uint64, desc string) (uint64, error) {
+	if amount == 0 || recipient == "" || creator == "" {
+		return 0, ErrInvalidProposal
+	}
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
 	if lp.Paused {
-		return 0, errors.New("loan pool is paused")
+		return 0, ErrLoanPoolPaused
 	}
 	id := lp.nextID
 	lp.nextID++
-	lp.Proposals[id] = NewLoanProposal(id, creator, recipient, typ, amount, desc, time.Hour*24)
+	lp.Proposals[id] = NewLoanProposal(id, creator, recipient, typ, amount, desc, 24*time.Hour)
 	return id, nil
 }
 
 // VoteProposal records a vote for a proposal.
 func (lp *LoanPool) VoteProposal(voter string, id uint64) error {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
 	p, ok := lp.Proposals[id]
 	if !ok {
-		return errors.New("proposal not found")
+		return errLoanProposalNotFound
 	}
 	if p.IsExpired(time.Now()) {
 		return errors.New("voting closed")
@@ -49,6 +73,8 @@ func (lp *LoanPool) VoteProposal(voter string, id uint64) error {
 
 // Tick evaluates proposals for approval based on votes and deadlines.
 func (lp *LoanPool) Tick() {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
 	now := time.Now()
 	for _, p := range lp.Proposals {
 		if !p.Approved && p.VoteCount() > 0 && !p.IsExpired(now) {
@@ -59,9 +85,11 @@ func (lp *LoanPool) Tick() {
 
 // Disburse sends funds for an approved proposal if treasury allows.
 func (lp *LoanPool) Disburse(id uint64) error {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
 	p, ok := lp.Proposals[id]
 	if !ok {
-		return errors.New("proposal not found")
+		return errLoanProposalNotFound
 	}
 	if !p.Approved || p.Disbursed {
 		return errors.New("proposal not approved or already disbursed")
@@ -76,12 +104,19 @@ func (lp *LoanPool) Disburse(id uint64) error {
 
 // GetProposal returns a proposal by ID.
 func (lp *LoanPool) GetProposal(id uint64) (*LoanProposal, bool) {
+	lp.mu.RLock()
+	defer lp.mu.RUnlock()
 	p, ok := lp.Proposals[id]
-	return p, ok
+	if !ok {
+		return nil, false
+	}
+	return p, true
 }
 
 // ListProposals returns proposals sorted by ID.
 func (lp *LoanPool) ListProposals() []*LoanProposal {
+	lp.mu.RLock()
+	defer lp.mu.RUnlock()
 	res := make([]*LoanProposal, 0, len(lp.Proposals))
 	for _, p := range lp.Proposals {
 		res = append(res, p)
@@ -92,12 +127,14 @@ func (lp *LoanPool) ListProposals() []*LoanProposal {
 
 // CancelProposal removes an active proposal if requested by the creator.
 func (lp *LoanPool) CancelProposal(creator string, id uint64) error {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
 	p, ok := lp.Proposals[id]
 	if !ok {
-		return errors.New("proposal not found")
+		return errLoanProposalNotFound
 	}
 	if p.Creator != creator || p.Disbursed {
-		return errors.New("cannot cancel proposal")
+		return errLoanProposalCancelled
 	}
 	delete(lp.Proposals, id)
 	return nil
@@ -105,13 +142,35 @@ func (lp *LoanPool) CancelProposal(creator string, id uint64) error {
 
 // ExtendProposal extends the voting deadline for a proposal.
 func (lp *LoanPool) ExtendProposal(creator string, id uint64, hrs int) error {
+	if hrs <= 0 {
+		return errors.New("extension must be positive")
+	}
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
 	p, ok := lp.Proposals[id]
 	if !ok {
-		return errors.New("proposal not found")
+		return errLoanProposalNotFound
 	}
 	if p.Creator != creator {
 		return errors.New("unauthorised")
 	}
 	p.Deadline = p.Deadline.Add(time.Duration(hrs) * time.Hour)
+	return nil
+}
+
+// TreasuryBalance returns the current treasury funds.
+func (lp *LoanPool) TreasuryBalance() uint64 {
+	lp.mu.RLock()
+	defer lp.mu.RUnlock()
+	return lp.Treasury
+}
+
+func (lp *LoanPool) withdraw(amount uint64) error {
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+	if lp.Treasury < amount {
+		return errors.New("insufficient treasury")
+	}
+	lp.Treasury -= amount
 	return nil
 }

--- a/core/loanpool_management.go
+++ b/core/loanpool_management.go
@@ -20,16 +20,25 @@ func NewLoanPoolManager(p *LoanPool) *LoanPoolManager {
 
 // Pause stops new proposals from being submitted.
 func (m *LoanPoolManager) Pause() {
-	m.Pool.Paused = true
+	if m.Pool != nil {
+		m.Pool.SetPaused(true)
+	}
 }
 
 // Resume allows proposal submissions again.
 func (m *LoanPoolManager) Resume() {
-	m.Pool.Paused = false
+	if m.Pool != nil {
+		m.Pool.SetPaused(false)
+	}
 }
 
 // Stats returns a summary of the pool's state.
 func (m *LoanPoolManager) Stats() LoanPoolStats {
+	if m.Pool == nil {
+		return LoanPoolStats{}
+	}
+	m.Pool.mu.RLock()
+	defer m.Pool.mu.RUnlock()
 	stats := LoanPoolStats{Treasury: m.Pool.Treasury}
 	for _, p := range m.Pool.Proposals {
 		stats.ProposalCount++

--- a/core/loanpool_views.go
+++ b/core/loanpool_views.go
@@ -34,7 +34,9 @@ func NewLoanProposalView(p *LoanProposal) LoanProposalView {
 
 // ProposalInfo returns a view for a proposal by ID if it exists.
 func (lp *LoanPool) ProposalInfo(id uint64) (LoanProposalView, bool) {
-	p, ok := lp.GetProposal(id)
+	lp.mu.RLock()
+	defer lp.mu.RUnlock()
+	p, ok := lp.Proposals[id]
 	if !ok {
 		return LoanProposalView{}, false
 	}
@@ -43,9 +45,10 @@ func (lp *LoanPool) ProposalInfo(id uint64) (LoanProposalView, bool) {
 
 // ProposalViews lists all proposals in view form.
 func (lp *LoanPool) ProposalViews() []LoanProposalView {
-	proposals := lp.ListProposals()
-	views := make([]LoanProposalView, 0, len(proposals))
-	for _, p := range proposals {
+	lp.mu.RLock()
+	defer lp.mu.RUnlock()
+	views := make([]LoanProposalView, 0, len(lp.Proposals))
+	for _, p := range lp.Proposals {
 		views = append(views, NewLoanProposalView(p))
 	}
 	return views
@@ -79,7 +82,9 @@ func NewLoanApplicationView(a *LoanApplication) LoanApplicationView {
 
 // ApplicationInfo returns a view for an application by ID if it exists.
 func (l *LoanPoolApply) ApplicationInfo(id uint64) (LoanApplicationView, bool) {
-	app, ok := l.Get(id)
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	app, ok := l.Applications[id]
 	if !ok {
 		return LoanApplicationView{}, false
 	}
@@ -88,9 +93,10 @@ func (l *LoanPoolApply) ApplicationInfo(id uint64) (LoanApplicationView, bool) {
 
 // ApplicationViews lists all applications in view form.
 func (l *LoanPoolApply) ApplicationViews() []LoanApplicationView {
-	apps := l.List()
-	views := make([]LoanApplicationView, 0, len(apps))
-	for _, a := range apps {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	views := make([]LoanApplicationView, 0, len(l.Applications))
+	for _, a := range l.Applications {
 		views = append(views, NewLoanApplicationView(a))
 	}
 	return views

--- a/core/warfare_node.go
+++ b/core/warfare_node.go
@@ -308,7 +308,7 @@ func (w *WarfareNode) snapshotConsensus() ConsensusSnapshot {
 	if w.Node == nil || w.Node.Consensus == nil {
 		return ConsensusSnapshot{}
 	}
-	weights := w.Node.Consensus.Weights
+	weights := w.Node.Consensus.WeightsSnapshot()
 	return ConsensusSnapshot{PoW: weights.PoW, PoS: weights.PoS, PoH: weights.PoH}
 }
 

--- a/core/watchtower_node.go
+++ b/core/watchtower_node.go
@@ -265,7 +265,7 @@ func (w *Watchtower) RunIntegritySweep(ctx context.Context, maxMempool int) ([]W
 		events = append(events, ev)
 	}
 	if node.Consensus != nil {
-		weights := node.Consensus.Weights
+		weights := node.Consensus.WeightsSnapshot()
 		payload := map[string]string{
 			"pow": formatFloat(weights.PoW),
 			"pos": formatFloat(weights.PoS),


### PR DESCRIPTION
## Summary
- harden the network broadcast pipeline with bounded queues, lifecycle guards, and stricter validation
- add thread-safe state management and validation helpers to the loan pool, application manager, and derived views
- make the consensus engine concurrency-safe with weight snapshot/setter helpers and update CLI consumers accordingly

## Testing
- `go test ./core -run 'TestNetworkBroadcast|TestLoanPoolProposalLifecycle|TestAdjustWeightsAndAvailability' -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68d0bf04c9ac8320969f296eb3370c92