### PR TITLE
Improve network broadcast reliability and telemetry

### DIFF
--- a/cli/network.go
+++ b/cli/network.go
@@ -63,7 +63,8 @@ func init() {
 		Short: "Subscribe and print messages for a topic",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gasPrint("NetworkSubscribe")
-			ch := network.Subscribe(args[0])
+			ch, cancel := network.Subscribe(args[0])
+			defer cancel()
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 			for {

--- a/cli/network_test.go
+++ b/cli/network_test.go
@@ -46,7 +46,7 @@ func TestNetworkCLIPeersAndBroadcast(t *testing.T) {
 		t.Fatalf("expected peer in output: %s", out)
 	}
 
-	ch := network.Subscribe("topic")
+	ch, cancel := network.Subscribe("topic")
 	if _, err := execNetCLI("network", "broadcast", "topic", "hi"); err != nil {
 		t.Fatalf("broadcast failed: %v", err)
 	}
@@ -59,6 +59,7 @@ func TestNetworkCLIPeersAndBroadcast(t *testing.T) {
 		t.Fatal("no message received")
 	}
 
+	cancel()
 	network.Stop()
 }
 

--- a/core/network_test.go
+++ b/core/network_test.go
@@ -49,13 +49,39 @@ func TestNetworkBroadcast(t *testing.T) {
 	if len(n1.Mempool) != 1 || len(n2.Mempool) != 1 || len(relay.Mempool) != 1 {
 		t.Fatalf("expected transaction to be broadcast to all nodes and relay")
 	}
+
+	// ensure telemetry recorded successful deliveries
+	want := map[string]string{"n1": "node", "n2": "node", "r1": "relay"}
+	deadline := time.After(200 * time.Millisecond)
+	for len(want) > 0 {
+		select {
+		case event := <-network.BroadcastEvents():
+			if event.TransactionID != tx.ID {
+				continue
+			}
+			role, ok := want[event.Target]
+			if !ok {
+				continue
+			}
+			if role != event.Role {
+				t.Fatalf("unexpected role for %s: %s", event.Target, event.Role)
+			}
+			if !event.Success {
+				t.Fatalf("expected success for %s: %s", event.Target, event.Error)
+			}
+			delete(want, event.Target)
+		case <-deadline:
+			t.Fatalf("missing telemetry for: %v", want)
+		}
+	}
 }
 
 // TestNetworkPubSub ensures the lightweight publish/subscribe system delivers
 // messages to all subscribed listeners.
 func TestNetworkPubSub(t *testing.T) {
 	net := NewNetwork(NewBiometricService())
-	sub := net.Subscribe("demo")
+	sub, cancel := net.Subscribe("demo")
+	defer cancel()
 	msg := []byte("ping")
 	net.Publish("demo", msg)
 	select {
@@ -65,5 +91,67 @@ func TestNetworkPubSub(t *testing.T) {
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("did not receive published message")
+	}
+}
+
+// TestNetworkBroadcastTelemetry verifies that validation failures are surfaced
+// through broadcast events instead of being silently dropped.
+func TestNetworkBroadcastTelemetry(t *testing.T) {
+	svc := NewBiometricService()
+	network := NewNetwork(svc)
+
+	good := NewNode("good", "addr", NewLedger())
+	bad := NewNode("bad", "addr2", NewLedger())
+	good.Ledger.Credit("alice", 200)
+	// bad node intentionally lacks balance for alice
+
+	network.AddNode(good)
+	network.AddNode(bad)
+
+	bio := []byte("finger")
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	if err := svc.Enroll("alice", bio, pub); err != nil {
+		t.Fatalf("enroll: %v", err)
+	}
+	h := sha256.Sum256(bio)
+	sig := ed25519.Sign(priv, h[:])
+	tx := NewTransaction("alice", "bob", 50, 10, 1)
+	if err := network.Broadcast(tx, "alice", bio, sig); err != nil {
+		t.Fatalf("broadcast failed: %v", err)
+	}
+
+	// allow goroutine to process queue
+	time.Sleep(50 * time.Millisecond)
+
+	if len(good.Mempool) != 1 {
+		t.Fatalf("expected transaction to reach good node")
+	}
+	if len(bad.Mempool) != 0 {
+		t.Fatalf("expected failing node to reject transaction")
+	}
+
+	var badErr string
+	deadline := time.After(200 * time.Millisecond)
+	for badErr == "" {
+		select {
+		case event := <-network.BroadcastEvents():
+			if event.TransactionID != tx.ID {
+				continue
+			}
+			if event.Target == "bad" {
+				badErr = event.Error
+				if event.Success {
+					t.Fatalf("expected bad node to report failure")
+				}
+			}
+		case <-deadline:
+			t.Fatal("did not observe failure telemetry")
+		}
+	}
+	if badErr == "" {
+		t.Fatal("expected non-empty error message")
 	}
 }

--- a/docs/reference/functions_list.md
+++ b/docs/reference/functions_list.md
@@ -564,8 +564,8 @@ This catalogue lists exported functions across the repository for quick navigati
 | `core/network.go` | `17` | `func NewNetwork(auth *BiometricService) *Network {` |
 | `core/network.go` | `29` | `func (n *Network) AddNode(node *Node) { n.nodes[node.ID] = node }` |
 | `core/network.go` | `32` | `func (n *Network) AddRelay(node *Node) { n.relays[node.ID] = node }` |
-| `core/network.go` | `35` | `func (n *Network) EnqueueTransaction(tx *Transaction) { n.queue <- tx }` |
-| `core/network.go` | `40` | `func (n *Network) Broadcast(tx *Transaction, userID string, biometric []byte) error {` |
+| `core/network.go` | `35` | `func (n *Network) EnqueueTransaction(tx *Transaction) error {` |
+| `core/network.go` | `40` | `func (n *Network) Broadcast(tx *Transaction, userID string, biometric []byte, sig []byte) error {` |
 | `core/network.go` | `51` | `func (n *Network) processQueue() {` |
 | `core/network.go` | `58` | `func (n *Network) broadcast(tx *Transaction) {` |
 | `core/bank_institutional_node.go` | `19` | `func NewBankInstitutionalNode(id, addr string, ledger *Ledger) *BankInstitutionalNode {` |


### PR DESCRIPTION
## Summary
- capture per-peer broadcast outcomes, surface them as telemetry events, and expose a cancellable pub/sub API
- ensure the CLI subscription command cleans up subscriptions and document the updated network signatures
- expand unit coverage to assert success telemetry and validation failures during broadcast fan-out

## Testing
- go test ./core -run TestNetwork
- go test ./cli -run TestNetworkCLI

------
https://chatgpt.com/codex/tasks/task_e_68d0c0e7a6bc8320b44b2f7654c39a27