### PR TITLE
Harden VM lifecycle and sandbox safety

### DIFF
--- a/core/virtual_machine_test.go
+++ b/core/virtual_machine_test.go
@@ -47,24 +47,112 @@ func TestSimpleVM(t *testing.T) {
 func TestVMVariants(t *testing.T) {
 	heavy := NewSimpleVM(VMHeavy)
 	super := NewSimpleVM(VMSuperLight)
-	_ = heavy.Start()
-	_ = super.Start()
+	if err := heavy.Start(); err != nil {
+		t.Fatalf("heavy start: %v", err)
+	}
+	defer heavy.Stop()
+	if err := super.Start(); err != nil {
+		t.Fatalf("super start: %v", err)
+	}
+	defer super.Stop()
 
 	if _, _, err := heavy.Execute([]byte{0, 0, 0}, "", nil, 5); err != nil {
 		t.Fatalf("heavy execute: %v", err)
 	}
 
-	// occupy the only slot in super light VM
-	super.limiter <- struct{}{}
-	if _, _, err := super.Execute([]byte{0, 0, 0}, "", nil, 5); err == nil || err.Error() != "vm busy" {
-		t.Fatalf("expected busy error from super light VM")
+	slowOpcode := uint32(0x010203)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	super.RegisterHandler(slowOpcode, func(in []byte) ([]byte, error) {
+		once.Do(func() { close(started) })
+		<-release
+		return in, nil
+	})
+
+	bytecode := []byte{0x01, 0x02, 0x03}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, _, err := super.Execute(bytecode, "", nil, 5); err != nil {
+			t.Errorf("first execution failed: %v", err)
+		}
+	}()
+
+	<-started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, _, err := super.ExecuteContext(ctx, bytecode, "", nil, 5)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
 	}
-	<-super.limiter
+
+	close(release)
+	wg.Wait()
+}
+
+func TestVMStopCancelsQueuedExecutions(t *testing.T) {
+	vm := NewSimpleVM(VMSuperLight)
+	slowOpcode := uint32(0x020304)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	vm.RegisterHandler(slowOpcode, func(in []byte) ([]byte, error) {
+		once.Do(func() { close(started) })
+		<-release
+		return in, nil
+	})
+
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	bytecode := []byte{0x02, 0x03, 0x04}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := vm.Execute(bytecode, "", nil, 5)
+		firstDone <- err
+	}()
+
+	<-started
+
+	secondResult := make(chan error, 1)
+	go func() {
+		_, _, err := vm.Execute(bytecode, "", nil, 5)
+		secondResult <- err
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+
+	stopErr := make(chan error, 1)
+	go func() { stopErr <- vm.Stop() }()
+
+	select {
+	case err := <-secondResult:
+		if !errors.Is(err, errVMNotRunning) {
+			t.Fatalf("expected errVMNotRunning, got %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timed out waiting for queued execution to abort")
+	}
+
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first execution failed: %v", err)
+	}
+	if err := <-stopErr; err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
 }
 
 func TestVMContextCancel(t *testing.T) {
 	vm := NewSimpleVM()
-	_ = vm.Start()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer vm.Stop()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	if _, _, err := vm.ExecuteContext(ctx, []byte{0, 0, 0}, "", nil, 5); err == nil {
@@ -76,7 +164,10 @@ func TestVMContextCancel(t *testing.T) {
 // correctly and override existing entries.
 func TestVMCustomHandler(t *testing.T) {
 	vm := NewSimpleVM()
-	_ = vm.Start()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer vm.Stop()
 	vm.RegisterHandler(0xFFFFFF, func(in []byte) ([]byte, error) { return append(in, 0xAA), nil })
 	out, _, err := vm.Execute([]byte{0xFF, 0xFF, 0xFF}, "", []byte{0x01}, 10)
 	if err != nil {
@@ -89,7 +180,10 @@ func TestVMCustomHandler(t *testing.T) {
 
 func TestVMGasLimitEnforced(t *testing.T) {
 	vm := NewSimpleVM()
-	_ = vm.Start()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer vm.Stop()
 	_, _, err := vm.Execute([]byte{0, 0, 0, 0, 0, 0}, "", nil, 1)
 	if err == nil {
 		t.Fatalf("expected gas limit error")
@@ -101,7 +195,10 @@ func TestVMGasLimitEnforced(t *testing.T) {
 
 func TestVMHooksCaptureTraces(t *testing.T) {
 	vm := NewSimpleVM()
-	_ = vm.Start()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer vm.Stop()
 	defer vm.ResetHooks()
 
 	var (

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -3,7 +3,10 @@ package synnergy
 import (
 	"bytes"
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestSimpleVMLifecycle(t *testing.T) {
@@ -33,6 +36,7 @@ func TestSNVMOpcodeExecution(t *testing.T) {
 	if err := vm.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
+	defer vm.Stop()
 	opcode := SNVMOpcodes[0]
 	code := opcode.Code
 	wasm := []byte{byte(code >> 16), byte(code >> 8), byte(code)}
@@ -58,6 +62,7 @@ func TestVMContextCancel(t *testing.T) {
 	if err := vm.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
+	defer vm.Stop()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, _, err := vm.ExecuteContext(ctx, []byte{0, 0, 0}, "", nil, 10)
@@ -74,6 +79,7 @@ func TestSimpleVMCustomGasResolver(t *testing.T) {
 	if err := vm.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
+	defer vm.Stop()
 	wasm := []byte{0, 0, 0}
 	if _, gasUsed, err := vm.Execute(wasm, "", nil, 10); err != nil {
 		t.Fatalf("execute: %v", err)
@@ -82,5 +88,174 @@ func TestSimpleVMCustomGasResolver(t *testing.T) {
 	}
 	if _, _, err := vm.Execute(wasm, "", nil, 4); err == nil {
 		t.Fatalf("expected gas limit error")
+	}
+}
+
+func TestSimpleVMAllowsPartialOpcodePadding(t *testing.T) {
+	vm := NewSimpleVM()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer vm.Stop()
+
+	observed := make(chan ExecutionStats, 1)
+	vm.SetObserver(func(stats ExecutionStats) {
+		observed <- stats
+	})
+
+	if out, gasUsed, err := vm.Execute([]byte{0xAA}, "", []byte{0x01}, 10); err != nil {
+		t.Fatalf("execute: %v", err)
+	} else if len(out) != 1 || out[0] != 0x01 {
+		t.Fatalf("unexpected output: %v", out)
+	} else if gasUsed == 0 {
+		t.Fatalf("expected gas usage")
+	}
+
+	select {
+	case stats := <-observed:
+		if stats.PaddedOpcodes == 0 {
+			t.Fatalf("expected padding to be recorded")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("observer not invoked")
+	}
+}
+
+func TestSimpleVMBusyWaitsForSlot(t *testing.T) {
+	vm := NewSimpleVM(VMSuperLight)
+	slowOpcode := uint32(0x010203)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	vm.RegisterOpcode(slowOpcode, func(in []byte) ([]byte, error) {
+		once.Do(func() {
+			close(started)
+			<-release
+		})
+		return in, nil
+	})
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer vm.Stop()
+
+	bytecode := []byte{0x01, 0x02, 0x03}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, _, err := vm.Execute(bytecode, "", nil, 10); err != nil {
+			t.Errorf("first execution failed: %v", err)
+		}
+	}()
+
+	<-started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := vm.ExecuteContext(ctx, bytecode, "", nil, 10)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected immediate error: %v", err)
+		}
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("second execution failed: %v", err)
+	}
+	wg.Wait()
+}
+
+func TestSimpleVMStopCancelsQueuedExecutions(t *testing.T) {
+	vm := NewSimpleVM(VMSuperLight)
+	slowOpcode := uint32(0x0A0B0C)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	vm.RegisterOpcode(slowOpcode, func(in []byte) ([]byte, error) {
+		once.Do(func() { close(started) })
+		<-release
+		return in, nil
+	})
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	bytecode := []byte{0x0A, 0x0B, 0x0C}
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := vm.Execute(bytecode, "", nil, 10)
+		firstDone <- err
+	}()
+
+	<-started
+
+	secondResult := make(chan error, 1)
+	go func() {
+		_, _, err := vm.Execute(bytecode, "", nil, 10)
+		secondResult <- err
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+
+	stopErr := make(chan error, 1)
+	go func() { stopErr <- vm.Stop() }()
+
+	select {
+	case err := <-secondResult:
+		if !errors.Is(err, errVMNotRunning) {
+			t.Fatalf("expected errVMNotRunning, got %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timed out waiting for queued execution cancellation")
+	}
+
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first execution failed: %v", err)
+	}
+	if err := <-stopErr; err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
+}
+
+func TestSimpleVMObserverReceivesStats(t *testing.T) {
+	vm := NewSimpleVM()
+	if err := vm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer vm.Stop()
+
+	bytecode := []byte{0, 0, 0}
+	observed := make(chan ExecutionStats, 1)
+	vm.SetObserver(func(stats ExecutionStats) {
+		observed <- stats
+	})
+
+	if _, _, err := vm.Execute(bytecode, "method", []byte{0xAA}, 10); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	select {
+	case stats := <-observed:
+		if stats.Method != "method" {
+			t.Fatalf("unexpected method: %s", stats.Method)
+		}
+		if stats.GasUsed == 0 {
+			t.Fatalf("expected gas usage")
+		}
+		if stats.Opcodes != 1 {
+			t.Fatalf("expected 1 opcode, got %d", stats.Opcodes)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("observer not invoked")
 	}
 }

--- a/vm_sandbox_management.go
+++ b/vm_sandbox_management.go
@@ -25,6 +25,14 @@ type SandboxManager struct {
 	sandboxes map[string]*SandboxInfo
 }
 
+func cloneSandbox(sb *SandboxInfo) *SandboxInfo {
+	if sb == nil {
+		return nil
+	}
+	copy := *sb
+	return &copy
+}
+
 // NewSandboxManager returns an empty manager.
 func NewSandboxManager() *SandboxManager {
 	return &SandboxManager{sandboxes: make(map[string]*SandboxInfo)}
@@ -47,7 +55,7 @@ func (m *SandboxManager) StartSandbox(id, contractAddr string, gasLimit, memoryL
 		LastReset:    time.Now(),
 	}
 	m.sandboxes[id] = sb
-	return sb, nil
+	return cloneSandbox(sb), nil
 }
 
 // StopSandbox deactivates a sandbox.
@@ -90,7 +98,10 @@ func (m *SandboxManager) SandboxStatus(id string) (*SandboxInfo, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	sb, ok := m.sandboxes[id]
-	return sb, ok
+	if !ok {
+		return nil, false
+	}
+	return cloneSandbox(sb), true
 }
 
 // ListSandboxes returns all sandboxes managed by this instance.
@@ -99,7 +110,7 @@ func (m *SandboxManager) ListSandboxes() []*SandboxInfo {
 	defer m.mu.RUnlock()
 	out := make([]*SandboxInfo, 0, len(m.sandboxes))
 	for _, sb := range m.sandboxes {
-		out = append(out, sb)
+		out = append(out, cloneSandbox(sb))
 	}
 	return out
 }

--- a/vm_sandbox_management_test.go
+++ b/vm_sandbox_management_test.go
@@ -17,8 +17,26 @@ func TestSandboxManager(t *testing.T) {
 	if err := m.StopSandbox("sb1"); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
-	if sb.Active {
+	status, ok := m.SandboxStatus("sb1")
+	if !ok {
+		t.Fatalf("sandbox should exist")
+	}
+	if status.Active {
 		t.Fatalf("sandbox should be inactive")
+	}
+	status.Active = true
+	fresh, ok := m.SandboxStatus("sb1")
+	if !ok || fresh.Active {
+		t.Fatalf("sandbox mutation should not leak")
+	}
+	listed := m.ListSandboxes()
+	if len(listed) != 1 {
+		t.Fatalf("expected one sandbox, got %d", len(listed))
+	}
+	listed[0].Active = true
+	fresh, _ = m.SandboxStatus("sb1")
+	if fresh.Active {
+		t.Fatalf("list mutation should not leak")
 	}
 	if err := m.DeleteSandbox("sb1"); err != nil {
 		t.Fatalf("delete: %v", err)


### PR DESCRIPTION
## Summary
- coordinate SimpleVM shutdown with lifecycle cancellation, slot acquisition guarding, and configurable gas observer handling
- rework core SimpleVM to use copy-on-write handlers, async hooks, lifecycle-aware execution with panic recovery, and safer defaults for unknown opcodes
- extend VM and sandbox tests to cover queued-stop cancellation, limiter fairness, and defensive copying of sandbox state

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d0bf2a6108832093564e55b77781fd