### PR TITLE
Integrate ledger adapters into contract tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pkg/          Reusable libraries and experimental modules
 5. Warm caches by calling `synnergy.LoadGasTable()`, synchronising the Stage 78 enterprise schedule with `synnergy.EnsureGasSchedule()` and registering contextual metadata with `synnergy.RegisterGasMetadata()` for core operations like `MineBlock`, `OpenConnection`, `MintNFT` and the enterprise orchestrator opcodes. Stage 79 extends this bootstrap to the enterprise special node gas schedule so combined-node attach, broadcast, snapshot and ledger queries remain deterministic across the CLI and GUI.
 6. Pre-load modules used by the CLI:
    - `core.NewNetwork` for pub‑sub networking
-   - `core.NewContractRegistry` backed by `core.NewSimpleVM`
+   - `core.NewContractRegistry` backed by `core.NewSimpleVM` and a shared `core.Ledger`
    - DAO managers (`core.NewDAOManager`, `core.NewProposalManager`, …)
    - Wallet, watchtower and warfare nodes (`core.NewWallet`, `core.NewWatchtowerNode`, `core.NewWarfareNode`)
    - Token constructors in `internal/tokens` (`tokens.NewSYN223Token`, etc.)

--- a/adapters/coreledger/coreledger.go
+++ b/adapters/coreledger/coreledger.go
@@ -1,0 +1,51 @@
+package coreledger
+
+import (
+	"synnergy"
+	"synnergy/core"
+)
+
+// Wrap adapts a core ledger to the synnergy contract registry interface.
+func Wrap(l *core.Ledger) synnergy.Ledger {
+	if l == nil {
+		return nil
+	}
+	return &adapter{ledger: l}
+}
+
+type adapter struct {
+	ledger *core.Ledger
+}
+
+func (a *adapter) Transfer(from, to string, amount, fee uint64) error {
+	return a.ledger.Transfer(from, to, amount, fee)
+}
+
+func (a *adapter) StoreContract(rec synnergy.LedgerContractRecord) {
+	stored := make([]byte, len(rec.WASM))
+	copy(stored, rec.WASM)
+	a.ledger.RegisterContract(core.LedgerContract{
+		Address:  rec.Address,
+		Owner:    rec.Owner,
+		Manifest: rec.Manifest,
+		GasLimit: rec.GasLimit,
+		WASM:     stored,
+	})
+}
+
+func (a *adapter) Contracts() []synnergy.LedgerContractRecord {
+	records := a.ledger.Contracts()
+	out := make([]synnergy.LedgerContractRecord, 0, len(records))
+	for _, rec := range records {
+		wasm := make([]byte, len(rec.WASM))
+		copy(wasm, rec.WASM)
+		out = append(out, synnergy.LedgerContractRecord{
+			Address:  rec.Address,
+			Owner:    rec.Owner,
+			Manifest: rec.Manifest,
+			GasLimit: rec.GasLimit,
+			WASM:     wasm,
+		})
+	}
+	return out
+}

--- a/ai_enhanced_contract_test.go
+++ b/ai_enhanced_contract_test.go
@@ -1,11 +1,63 @@
 package synnergy
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
+
+type testLedger struct {
+	balances  map[string]uint64
+	contracts map[string]LedgerContractRecord
+}
+
+func newTestLedger() *testLedger {
+	return &testLedger{
+		balances:  make(map[string]uint64),
+		contracts: make(map[string]LedgerContractRecord),
+	}
+}
+
+func (l *testLedger) Transfer(from, to string, amount, fee uint64) error {
+	total := amount + fee
+	if from != "" {
+		if l.balances[from] < total {
+			return errors.New("insufficient funds")
+		}
+		l.balances[from] -= total
+	}
+	l.balances[to] += amount
+	return nil
+}
+
+func (l *testLedger) StoreContract(rec LedgerContractRecord) {
+	stored := make([]byte, len(rec.WASM))
+	copy(stored, rec.WASM)
+	rec.WASM = stored
+	l.contracts[rec.Address] = rec
+}
+
+func (l *testLedger) Contracts() []LedgerContractRecord {
+	out := make([]LedgerContractRecord, 0, len(l.contracts))
+	for _, rec := range l.contracts {
+		wasm := make([]byte, len(rec.WASM))
+		copy(wasm, rec.WASM)
+		out = append(out, LedgerContractRecord{
+			Address:  rec.Address,
+			Owner:    rec.Owner,
+			Manifest: rec.Manifest,
+			GasLimit: rec.GasLimit,
+			WASM:     wasm,
+		})
+	}
+	return out
+}
 
 func TestAIContractRegistry(t *testing.T) {
 	vm := NewSimpleVM()
 	_ = vm.Start()
-	reg := NewContractRegistry(vm)
+	ledger := newTestLedger()
+	ledger.balances["owner"] = 1_000
+	reg := NewContractRegistry(vm, ledger)
 	aiReg := NewAIContractRegistry(reg)
 	addr, err := aiReg.DeployAIContract([]byte{0x01}, "model", "", 5, "owner")
 	if err != nil {

--- a/cli/ai_contract.go
+++ b/cli/ai_contract.go
@@ -14,11 +14,21 @@ import (
 // Stage 38 validates the AI contract registry through the CLI with secure invocation paths.
 var (
 	aiVM       = core.NewSimpleVM()
-	baseReg    = core.NewContractRegistry(aiVM)
-	aiRegistry = core.NewAIContractRegistry(baseReg)
+	baseReg    *core.ContractRegistry
+	aiRegistry *core.AIContractRegistry
 )
 
+func ensureAIRegistry() {
+	if baseReg == nil {
+		baseReg = core.NewContractRegistry(aiVM, ledger)
+	}
+	if aiRegistry == nil {
+		aiRegistry = core.NewAIContractRegistry(baseReg)
+	}
+}
+
 func init() {
+	ensureAIRegistry()
 	aiVM.Start()
 
 	aiCmd := &cobra.Command{Use: "ai_contract", Short: "AI enhanced contract operations"}

--- a/cli/authority_apply.go
+++ b/cli/authority_apply.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	authorityRegistry = core.NewAuthorityNodeRegistry()
+	authorityRegistry = authorityReg
 	applyManager      = core.NewAuthorityApplicationManager(authorityRegistry, time.Hour)
 )
 

--- a/cli/authority_apply_test.go
+++ b/cli/authority_apply_test.go
@@ -15,7 +15,10 @@ import (
 // to ensure candidates can be submitted and subsequently listed.
 func TestAuthorityApplySubmit(t *testing.T) {
 	// reset global state used by the CLI commands
-	authorityRegistry = core.NewAuthorityNodeRegistry()
+	ledger = core.NewLedger()
+	authorityValidators = core.NewValidatorManager(core.MinStake)
+	authorityReg = core.NewAuthorityNodeRegistry(ledger, authorityValidators, 1)
+	authorityRegistry = authorityReg
 	applyManager = core.NewAuthorityApplicationManager(authorityRegistry, time.Hour)
 
 	// submit an application
@@ -36,6 +39,7 @@ func TestAuthorityApplySubmit(t *testing.T) {
 	voter := hex.EncodeToString(pub)
 	msg := fmt.Sprintf("%s:%t", apps[0].ID, true)
 	sig := ed25519.Sign(priv, []byte(msg))
+	ledger.Mint(voter, 10)
 	rootCmd.SetOut(new(bytes.Buffer))
 	rootCmd.SetArgs([]string{"authority_apply", "vote", voter, apps[0].ID, "true", "--pub", hex.EncodeToString(pub), "--sig", hex.EncodeToString(sig)})
 	if err := rootCmd.Execute(); err != nil {

--- a/cli/authority_nodes.go
+++ b/cli/authority_nodes.go
@@ -11,7 +11,10 @@ import (
 	"synnergy/core"
 )
 
-var authorityReg = core.NewAuthorityNodeRegistry()
+var (
+	authorityValidators = core.NewValidatorManager(core.MinStake)
+	authorityReg        = core.NewAuthorityNodeRegistry(ledger, authorityValidators, 1)
+)
 
 func init() {
 	authCmd := &cobra.Command{

--- a/cli/authority_nodes_test.go
+++ b/cli/authority_nodes_test.go
@@ -11,7 +11,9 @@ import (
 
 // TestAuthorityRegister verifies authority node registration through the CLI.
 func TestAuthorityRegister(t *testing.T) {
-	authorityReg = core.NewAuthorityNodeRegistry()
+	ledger = core.NewLedger()
+	authorityValidators = core.NewValidatorManager(core.MinStake)
+	authorityReg = core.NewAuthorityNodeRegistry(ledger, authorityValidators, 1)
 
 	rootCmd.SetOut(new(bytes.Buffer))
 	rootCmd.SetArgs([]string{"authority", "register", "addr1", "validator"})
@@ -26,7 +28,9 @@ func TestAuthorityRegister(t *testing.T) {
 
 // TestAuthorityVote verifies signature-based voting through the CLI.
 func TestAuthorityVote(t *testing.T) {
-	authorityReg = core.NewAuthorityNodeRegistry()
+	ledger = core.NewLedger()
+	authorityValidators = core.NewValidatorManager(core.MinStake)
+	authorityReg = core.NewAuthorityNodeRegistry(ledger, authorityValidators, 1)
 	// register candidate
 	rootCmd.SetOut(new(bytes.Buffer))
 	rootCmd.SetArgs([]string{"authority", "register", "addr1", "validator"})
@@ -38,6 +42,7 @@ func TestAuthorityVote(t *testing.T) {
 	voter := hex.EncodeToString(pub)
 	sig := ed25519.Sign(priv, []byte("addr1"))
 	sigHex := hex.EncodeToString(sig)
+	ledger.Mint(voter, 10)
 	rootCmd.SetOut(new(bytes.Buffer))
 	rootCmd.SetArgs([]string{"authority", "vote", voter, "addr1", "--pub", voter, "--sig", sigHex})
 	if err := rootCmd.Execute(); err != nil {

--- a/cli/contract_management.go
+++ b/cli/contract_management.go
@@ -6,16 +6,12 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"synnergy/core"
 	ierr "synnergy/internal/errors"
 )
 
-var (
-	contractMgr = core.NewContractManager(contractRegistry)
-)
-
 func init() {
-	contractVM.Start()
+	ensureContractComponents()
+	_ = contractVM.Start()
 	cmd := &cobra.Command{
 		Use:   "contract-mgr",
 		Short: "Administrative contract management",

--- a/cli/contracts.go
+++ b/cli/contracts.go
@@ -12,10 +12,21 @@ import (
 
 var (
 	contractVM       = core.NewSimpleVM()
-	contractRegistry = core.NewContractRegistry(contractVM)
+	contractRegistry *core.ContractRegistry
+	contractMgr      *core.ContractManager
 )
 
+func ensureContractComponents() {
+	if contractRegistry == nil {
+		contractRegistry = core.NewContractRegistry(contractVM, ledger)
+	}
+	if contractMgr == nil {
+		contractMgr = core.NewContractManager(contractRegistry)
+	}
+}
+
 func init() {
+	ensureContractComponents()
 	// start VM to allow contract execution
 	_ = contractVM.Start()
 
@@ -51,6 +62,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if wasmPath == "" {
 				return fmt.Errorf("--wasm required")
+			}
+			if owner == "" {
+				return fmt.Errorf("--owner required")
 			}
 			wasm, err := os.ReadFile(wasmPath)
 			if err != nil {
@@ -130,6 +144,9 @@ func init() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if templateName == "" {
 				return fmt.Errorf("--name required")
+			}
+			if templateOwner == "" {
+				return fmt.Errorf("--owner required")
 			}
 			path := filepath.Join("smart-contracts", templateName+".wasm")
 			wasm, err := os.ReadFile(path)

--- a/cli/dao_staking.go
+++ b/cli/dao_staking.go
@@ -9,7 +9,7 @@ import (
 	"synnergy/core"
 )
 
-var daoStaking = core.NewDAOStaking(daoMgr)
+var daoStaking = core.NewDAOStaking(daoMgr, ledger)
 
 func init() {
 	stakingCmd := &cobra.Command{

--- a/cli/dao_staking_test.go
+++ b/cli/dao_staking_test.go
@@ -16,7 +16,9 @@ import (
 // TestDAOStakingStakeJSON verifies staking with JSON output and signature verification.
 func TestDAOStakingStakeJSON(t *testing.T) {
 	daoMgr = core.NewDAOManager()
-	daoStaking = core.NewDAOStaking(daoMgr)
+	ledger = core.NewLedger()
+	ledger.Mint("addr1", 100)
+	daoStaking = core.NewDAOStaking(daoMgr, ledger)
 	daoMgr.AuthorizeRelayer("addr1")
 	dao, err := daoMgr.Create("dao", "addr1")
 	if err != nil {

--- a/cli/dao_token.go
+++ b/cli/dao_token.go
@@ -9,7 +9,7 @@ import (
 	"synnergy/core"
 )
 
-var daoTokenLedger = core.NewDAOTokenLedger(daoMgr)
+var daoTokenLedger = core.NewDAOTokenLedger(daoMgr, ledger)
 
 func init() {
 	tokenCmd := &cobra.Command{

--- a/cli/dao_token_test.go
+++ b/cli/dao_token_test.go
@@ -16,7 +16,9 @@ import (
 // TestDAOTokenMintJSON verifies mint command JSON output and signature.
 func TestDAOTokenMintJSON(t *testing.T) {
 	daoMgr = core.NewDAOManager()
-	daoTokenLedger = core.NewDAOTokenLedger(daoMgr)
+	ledger = core.NewLedger()
+	ledger.Mint("admin", 100)
+	daoTokenLedger = core.NewDAOTokenLedger(daoMgr, ledger)
 
 	daoMgr.AuthorizeRelayer("admin")
 	dao, err := daoMgr.Create("d1", "admin")

--- a/cli/smart_contract_marketplace.go
+++ b/cli/smart_contract_marketplace.go
@@ -10,9 +10,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var marketplace = core.NewSmartContractMarketplace(core.NewSimpleVM())
+var marketplace *core.SmartContractMarketplace
+
+func ensureMarketplace() {
+	if marketplace == nil {
+		marketplace = core.NewSmartContractMarketplace(core.NewSimpleVM(), ledger)
+	}
+}
 
 func init() {
+	ensureMarketplace()
 	cmd := &cobra.Command{
 		Use:   "marketplace",
 		Short: "Deploy and trade smart contracts",

--- a/cli/smart_contract_marketplace_test.go
+++ b/cli/smart_contract_marketplace_test.go
@@ -5,12 +5,16 @@ import (
 	"os"
 	"testing"
 
+	synn "synnergy"
 	"synnergy/core"
 )
 
 // TestSmartContractMarketplaceDeployJSON deploys and trades a contract verifying JSON output.
 func TestSmartContractMarketplaceDeployJSON(t *testing.T) {
-	marketplace = core.NewSmartContractMarketplace(core.NewSimpleVM())
+	ledger = core.NewLedger()
+	marketplace = core.NewSmartContractMarketplace(core.NewSimpleVM(), ledger)
+	gas := synn.GasCost("DeploySmartContract")
+	ledger.Credit("alice", gas*2)
 
 	tmp, err := os.CreateTemp(t.TempDir(), "scm-*.wasm")
 	if err != nil {

--- a/cli/warfare_node_test.go
+++ b/cli/warfare_node_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/hex"
+	"sort"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ func TestParseMetadataDeterministic(t *testing.T) {
 	for k := range m {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	if keys[0] != "priority" {
 		t.Fatalf("expected deterministic ordering, got %v", keys)
 	}

--- a/cmd/synnergy/bootstrap.go
+++ b/cmd/synnergy/bootstrap.go
@@ -95,11 +95,12 @@ func (rt *runtime) Shutdown() {
 
 func (rt *runtime) preloadModules() error {
 	// Shared registries
-	_ = core.NewAuthorityNodeRegistry()
+	validators := core.NewValidatorManager(core.MinStake)
+	_ = core.NewAuthorityNodeRegistry(rt.ledger, validators, 1)
 	_ = core.NewProposalManager()
 	daoMgr := core.NewDAOManager()
-	_ = core.NewDAOStaking(daoMgr)
-	_ = core.NewDAOTokenLedger(daoMgr)
+	_ = core.NewDAOStaking(daoMgr, rt.ledger)
+	_ = core.NewDAOTokenLedger(daoMgr, rt.ledger)
 
 	// Banking and custodial flows use the shared ledger
 	_ = core.NewBankInstitutionalNode("init", "init", rt.ledger)
@@ -113,7 +114,7 @@ func (rt *runtime) preloadModules() error {
 	_ = core.NewCrossChainTxManager(rt.ledger)
 
 	// Contract registry coupled to the bootstrap VM
-	_ = core.NewContractRegistry(rt.vm)
+	_ = core.NewContractRegistry(rt.vm, rt.ledger)
 
 	// Sandbox and security services
 	_ = core.NewSandboxManager()

--- a/cmd/synnergy/main.go
+++ b/cmd/synnergy/main.go
@@ -18,6 +18,8 @@ import (
 	"synnergy/cli"
 	"synnergy/core"
 	"synnergy/internal/config"
+	"synnergy/internal/security"
+	"synnergy/internal/tokens"
 )
 
 func main() {
@@ -56,6 +58,59 @@ func main() {
 	if err := registerEnterpriseGasMetadata(); err != nil {
 		logrus.Fatalf("gas metadata: %v", err)
 	}
+
+	// Preload stage 3 modules so CLI commands can operate without extra setup.
+	_ = core.NewAuthorityNodeRegistry(core.NewLedger(), core.NewValidatorManager(core.MinStake), 1)
+	_ = core.NewBankInstitutionalNode("init", "init", core.NewLedger())
+
+	// Preload stage 8 modules to expose contract and cross-chain managers via CLI.
+	vm := core.NewSimpleVM()
+	_ = vm.Start()
+	_ = core.NewContractRegistry(vm, core.NewLedger())
+	_ = core.NewBridgeRegistry()
+	_ = core.NewBridgeTransferManager()
+	_ = core.NewChainConnectionManager()
+	_ = core.NewProtocolRegistry()
+	_ = core.NewCrossChainTxManager(core.NewLedger())
+
+	// Preload stage 11 modules for VM sandbox management.
+	_ = core.NewSandboxManager()
+
+	// Preload stage 9 modules so DAO-related CLI commands are ready for use.
+	daoMgr := core.NewDAOManager()
+	_ = core.NewProposalManager()
+	daoLedger := core.NewLedger()
+	_ = core.NewDAOStaking(daoMgr, daoLedger)
+	_ = core.NewDAOTokenLedger(daoMgr, daoLedger)
+	_ = core.NewConsensusNetworkManager()
+	_ = core.NewCustodialNode("cli-custodian", "cli-custodian", core.NewLedger())
+
+	// Preload stage 12 modules to expose wallet, warfare, watchtower and data distribution monitoring
+	// functionality via the CLI.
+	if _, err := core.NewWallet(); err != nil {
+		logrus.Debugf("wallet init error: %v", err)
+	}
+	_ = core.NewWarfareNode(core.NewNode("cli-war", "cli-war", core.NewLedger()))
+	_ = core.NewWatchtowerNode("cli-watchtower", nil)
+	// Stage 59 modules for content registry and secrets management
+	_ = core.NewContentNetworkNode("cli-content", "cli")
+	_ = security.NewSecretsManager()
+
+	// Preload stage 13 modules for secure channels and compliance checks.
+	_ = core.NewZeroTrustEngine()
+	_ = core.NewRegulatoryNode("cli-regnode", core.NewRegulatoryManager())
+
+	// Preload stage 20 token extensions for CLI and opcode availability.
+	_ = tokens.NewSYN223Token("cli", "S223", "cli", 0)
+	_ = tokens.NewSYN2700Token()
+	_ = tokens.NewSYN3200Token(1)
+	_ = tokens.NewSYN3600Token()
+	_ = tokens.NewSYN3800Token(0)
+	_ = tokens.NewSYN3900Token()
+	_ = tokens.NewSYN500Token()
+	_ = tokens.NewSYN5000Token()
+	// Preload stage 36 NFT marketplace
+	_ = core.NewNFTMarketplace()
 
 	orch, err := core.NewEnterpriseOrchestrator(ctx)
 	if err != nil {
@@ -133,6 +188,18 @@ func registerEnterpriseGasMetadata() error {
 		logrus.Infof("registered %d stage 78 opcodes", len(inserted))
 	}
 
+	enterpriseSpecialGas := map[string]uint64{
+		"EnterpriseSpecialAttach":    110,
+		"EnterpriseSpecialDetach":    55,
+		"EnterpriseSpecialBroadcast": 145,
+		"EnterpriseSpecialSnapshot":  40,
+		"EnterpriseSpecialLedger":    30,
+	}
+	if inserted, err := synn.EnsureGasSchedule(enterpriseSpecialGas); err != nil {
+		return fmt.Errorf("stage 79 gas sync failed: %w", err)
+	} else if len(inserted) > 0 {
+		logrus.Infof("registered %d enterprise special opcodes", len(inserted))
+	}
 
 	categories := []struct {
 		category    string
@@ -153,107 +220,25 @@ func registerEnterpriseGasMetadata() error {
 		{"monetary", "Stage 40 monetary policy queries", []string{"BlockReward", "CirculatingSupply", "RemainingSupply", "InitialPrice", "AlphaFactor", "MinimumStake"}},
 		{"p2p", "Stage 67 Kademlia routing operations", []string{"KademliaStore", "KademliaGet", "KademliaClosest", "KademliaDistance"}},
 		{"orchestrator", "Stage 78 enterprise orchestrator operations", []string{"EnterpriseBootstrap", "EnterpriseConsensusSync", "EnterpriseWalletSeal", "EnterpriseNodeAudit", "EnterpriseAuthorityElect"}},
+		{"enterprise", "Stage 79 enterprise combined node operations", []string{"EnterpriseSpecialAttach", "EnterpriseSpecialDetach", "EnterpriseSpecialBroadcast", "EnterpriseSpecialSnapshot", "EnterpriseSpecialLedger"}},
 	}
 
-	for _, entry := range categories {
-		for _, name := range entry.names {
-=======
-	enterpriseSpecialGas := map[string]uint64{
-		"EnterpriseSpecialAttach":    110,
-		"EnterpriseSpecialDetach":    55,
-		"EnterpriseSpecialBroadcast": 145,
-		"EnterpriseSpecialSnapshot":  40,
-		"EnterpriseSpecialLedger":    30,
-	}
-	if inserted, err := synn.EnsureGasSchedule(enterpriseSpecialGas); err != nil {
-		logrus.Fatalf("enterprise special gas sync failed: %v", err)
-	} else if len(inserted) > 0 {
-		logrus.Infof("registered %d enterprise special opcodes", len(inserted))
-	}
-	register := func(category, description string, names ...string) {
+	register := func(category, description string, names ...string) error {
 		for _, name := range names {
-
 			cost := synn.GasCost(name)
-			if err := synn.RegisterGasMetadata(name, cost, entry.category, entry.description); err != nil {
+			if err := synn.RegisterGasMetadata(name, cost, category, description); err != nil {
 				return fmt.Errorf("register gas metadata %s: %w", name, err)
 			}
 		}
+		return nil
 	}
 
-	return nil
-=======
-	register("consensus", "Core consensus lifecycle operations", "MineBlock")
-	register("dao", "DAO creation and authority renewal", "CreateDAO", "UpdateMemberRole", "RenewAuthorityTerm")
-	register("cross-chain", "Stage 24 cross-chain operations", "RegisterBridge", "BridgeDeposit", "BridgeClaim", "OpenConnection", "CloseConnection", "LockMint", "BurnRelease")
-	register("node", "Stage 25 node and infrastructure operations", "SetMode", "Stake", "Unstake", "Optimize", "SecureCommand", "TrackLogistics", "ShareTactical", "ReportFork", "Metrics")
-	register("templates", "Stage 29 contract templates", "DeployTokenFaucetTemplate", "DeployStorageMarketTemplate", "DeployDAOGovernanceTemplate", "DeployNFTMintingTemplate", "DeployAIModelMarketTemplate")
-	register("marketplace", "Stage 34 marketplace settlement", "DeploySmartContract", "TradeContract")
-	register("storage", "Stage 35 storage marketplace operations", "CreateListing", "ListListings", "GetListing", "OpenDeal", "CloseDeal", "ListDeals", "GetDeal", "Storage_Pin", "Storage_Retrieve", "IPFS_Add", "IPFS_Get", "IPFS_Unpin")
-	register("nft", "Stage 36 NFT marketplace operations", "MintNFT", "ListNFT", "BuyNFT")
-	register("dex", "Stage 39 liquidity view operations", "Liquidity_Pool", "Liquidity_Pools")
-	register("wallet", "Wallet lifecycle operations", "NewWallet", "Sign", "VerifySignature")
-	register("content", "Stage 59 content registry operations", "RegisterContentNode", "UploadContent", "RetrieveContent", "ListContentNodes")
-	register("monetary", "Stage 40 monetary policy queries", "BlockReward", "CirculatingSupply", "RemainingSupply", "InitialPrice", "AlphaFactor", "MinimumStake")
-	register("p2p", "Stage 67 Kademlia routing operations", "KademliaStore", "KademliaGet", "KademliaClosest", "KademliaDistance")
-	register("orchestrator", "Stage 78 enterprise orchestrator operations", "EnterpriseBootstrap", "EnterpriseConsensusSync", "EnterpriseWalletSeal", "EnterpriseNodeAudit", "EnterpriseAuthorityElect")
-	register("enterprise", "Stage 79 enterprise combined node operations", "EnterpriseSpecialAttach", "EnterpriseSpecialDetach", "EnterpriseSpecialBroadcast", "EnterpriseSpecialSnapshot", "EnterpriseSpecialLedger")
+	for _, entry := range categories {
+		if err := register(entry.category, entry.description, entry.names...); err != nil {
+			return err
+		}
+	}
+
 	logrus.Debug("gas table loaded")
-
-	// Preload stage 3 modules so CLI commands can operate without extra setup.
-	_ = core.NewAuthorityNodeRegistry()
-	_ = core.NewBankInstitutionalNode("init", "init", core.NewLedger())
-
-	// Preload stage 8 modules to expose contract and cross-chain managers via CLI.
-	vm := core.NewSimpleVM()
-	_ = vm.Start()
-	_ = core.NewContractRegistry(vm)
-	_ = core.NewBridgeRegistry()
-	_ = core.NewBridgeTransferManager()
-	_ = core.NewChainConnectionManager()
-	_ = core.NewProtocolRegistry()
-	_ = core.NewCrossChainTxManager(core.NewLedger())
-
-	// Preload stage 11 modules for VM sandbox management.
-	_ = core.NewSandboxManager()
-
-	// Preload stage 9 modules so DAO-related CLI commands are ready for use.
-	daoMgr := core.NewDAOManager()
-	_ = core.NewProposalManager()
-	_ = core.NewDAOStaking(daoMgr)
-	_ = core.NewDAOTokenLedger(daoMgr)
-	_ = core.NewConsensusNetworkManager()
-	_ = core.NewCustodialNode("cli-custodian", "cli-custodian", core.NewLedger())
-
-	// Preload stage 12 modules to expose wallet, warfare, watchtower and data distribution monitoring
-	// functionality via the CLI.
-	if _, err := core.NewWallet(); err != nil {
-		logrus.Debugf("wallet init error: %v", err)
-	}
-	_ = core.NewWarfareNode(core.NewNode("cli-war", "cli-war", core.NewLedger()))
-	_ = core.NewWatchtowerNode("cli-watchtower", nil)
-	// Stage 59 modules for content registry and secrets management
-	_ = core.NewContentNetworkNode("cli-content", "cli")
-	_ = security.NewSecretsManager()
-
-	// Preload stage 13 modules for secure channels and compliance checks.
-	_ = core.NewZeroTrustEngine()
-	_ = core.NewRegulatoryNode("cli-regnode", core.NewRegulatoryManager())
-
-	// Preload stage 20 token extensions for CLI and opcode availability.
-	_ = tokens.NewSYN223Token("cli", "S223", "cli", 0)
-	_ = tokens.NewSYN2700Token()
-	_ = tokens.NewSYN3200Token(1)
-	_ = tokens.NewSYN3600Token()
-	_ = tokens.NewSYN3800Token(0)
-	_ = tokens.NewSYN3900Token()
-	_ = tokens.NewSYN500Token()
-	_ = tokens.NewSYN5000Token()
-	// Preload stage 36 NFT marketplace
-	_ = core.NewNFTMarketplace()
-
-	logrus.Infof("starting Synnergy in %s mode on %s:%d", cfg.Environment, cfg.Server.Host, cfg.Server.Port)
-
-	if err := cli.Execute(); err != nil {
-		logrus.Fatal(err)
-	}
+	return nil
 }

--- a/contract_management_test.go
+++ b/contract_management_test.go
@@ -1,16 +1,25 @@
-package synnergy
+package synnergy_test
 
-import "testing"
+import (
+	"testing"
+
+	synnergy "synnergy"
+	"synnergy/adapters/coreledger"
+	"synnergy/core"
+)
 
 func TestContractManager(t *testing.T) {
-	vm := NewSimpleVM()
+	vm := synnergy.NewSimpleVM()
 	_ = vm.Start()
-	reg := NewContractRegistry(vm)
+	ledger := core.NewLedger()
+	ledger.Credit("owner", 50)
+	ledger.Credit("new", 50)
+	reg := synnergy.NewContractRegistry(vm, coreledger.Wrap(ledger))
 	addr, err := reg.Deploy([]byte{0x01}, "", 5, "owner")
 	if err != nil {
 		t.Fatalf("deploy: %v", err)
 	}
-	mgr := NewContractManager(reg)
+	mgr := synnergy.NewContractManager(reg)
 	if err := mgr.Pause(addr); err != nil {
 		t.Fatalf("pause: %v", err)
 	}

--- a/contracts.go
+++ b/contracts.go
@@ -7,6 +7,27 @@ import (
 	"sync"
 )
 
+// Ledger exposes the minimal ledger operations required by the contract registry.
+type Ledger interface {
+	Transfer(from, to string, amount, fee uint64) error
+	StoreContract(rec LedgerContractRecord)
+	Contracts() []LedgerContractRecord
+}
+
+// LedgerContractRecord mirrors the metadata stored in the ledger for deployed contracts.
+type LedgerContractRecord struct {
+	Address  string
+	Owner    string
+	Manifest string
+	GasLimit uint64
+	WASM     []byte
+}
+
+func contractFeeCollectorAddress() string {
+	sum := sha256.Sum256([]byte("contract_fee_pool"))
+	return hex.EncodeToString(sum[:])
+}
+
 // Contract represents a deployed smart contract. It keeps minimal metadata
 // required by the CLI and other modules to manage and invoke contracts.
 type Contract struct {
@@ -30,17 +51,35 @@ type VirtualMachine interface {
 // ContractRegistry stores deployed contracts and offers helper methods for
 // deployment and invocation. It is safe for concurrent use.
 type ContractRegistry struct {
-	mu        sync.RWMutex
-	contracts map[string]*Contract
-	vm        VirtualMachine
+	mu           sync.RWMutex
+	contracts    map[string]*Contract
+	vm           VirtualMachine
+	ledger       Ledger
+	feeCollector string
 }
 
 // NewContractRegistry initialises an empty registry backed by the provided VM.
-func NewContractRegistry(vm VirtualMachine) *ContractRegistry {
-	return &ContractRegistry{
-		contracts: make(map[string]*Contract),
-		vm:        vm,
+func NewContractRegistry(vm VirtualMachine, ledger Ledger) *ContractRegistry {
+	reg := &ContractRegistry{
+		contracts:    make(map[string]*Contract),
+		vm:           vm,
+		ledger:       ledger,
+		feeCollector: contractFeeCollectorAddress(),
 	}
+	if ledger != nil {
+		for _, rec := range ledger.Contracts() {
+			wasm := make([]byte, len(rec.WASM))
+			copy(wasm, rec.WASM)
+			reg.contracts[rec.Address] = &Contract{
+				Address:  rec.Address,
+				Owner:    rec.Owner,
+				WASM:     wasm,
+				Manifest: rec.Manifest,
+				GasLimit: rec.GasLimit,
+			}
+		}
+	}
+	return reg
 }
 
 // CompileWASM returns the input bytecode and its sha256 hash. In the full
@@ -64,9 +103,23 @@ func (r *ContractRegistry) Deploy(wasm []byte, manifest string, gasLimit uint64,
 	hash := sha256.Sum256(wasm)
 	addr := hex.EncodeToString(hash[:])
 
+	r.mu.RLock()
+	_, exists := r.contracts[addr]
+	r.mu.RUnlock()
+	if exists {
+		return "", errors.New("contract already deployed")
+	}
+	if r.ledger != nil && gasLimit > 0 {
+		if err := r.ledger.Transfer(owner, r.feeCollector, gasLimit, 0); err != nil {
+			return "", err
+		}
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, exists := r.contracts[addr]; exists {
+		if r.ledger != nil && gasLimit > 0 {
+			_ = r.ledger.Transfer(r.feeCollector, owner, gasLimit, 0)
+		}
 		return "", errors.New("contract already deployed")
 	}
 	r.contracts[addr] = &Contract{
@@ -76,12 +129,27 @@ func (r *ContractRegistry) Deploy(wasm []byte, manifest string, gasLimit uint64,
 		Manifest: manifest,
 		GasLimit: gasLimit,
 	}
+	if r.ledger != nil {
+		stored := make([]byte, len(wasm))
+		copy(stored, wasm)
+		r.ledger.StoreContract(LedgerContractRecord{
+			Address:  addr,
+			Owner:    owner,
+			Manifest: manifest,
+			GasLimit: gasLimit,
+			WASM:     stored,
+		})
+	}
 	return addr, nil
 }
 
 // Invoke executes a method on the specified contract via the configured VM.
 // It returns the output bytes and the gas consumed.
 func (r *ContractRegistry) Invoke(addr, method string, args []byte, gasLimit uint64) ([]byte, uint64, error) {
+	return r.InvokeFrom(addr, "", method, args, gasLimit)
+}
+
+func (r *ContractRegistry) InvokeFrom(addr, caller, method string, args []byte, gasLimit uint64) ([]byte, uint64, error) {
 	r.mu.RLock()
 	c, ok := r.contracts[addr]
 	r.mu.RUnlock()
@@ -91,10 +159,31 @@ func (r *ContractRegistry) Invoke(addr, method string, args []byte, gasLimit uin
 	if c.Paused {
 		return nil, 0, errors.New("contract paused")
 	}
-	if gasLimit == 0 || gasLimit > c.GasLimit {
-		gasLimit = c.GasLimit
+	limit := gasLimit
+	if limit == 0 || limit > c.GasLimit {
+		limit = c.GasLimit
 	}
-	return r.vm.Execute(c.WASM, method, args, gasLimit)
+	payer := caller
+	if payer == "" {
+		payer = c.Owner
+	}
+	if r.ledger != nil && limit > 0 {
+		if err := r.ledger.Transfer(payer, r.feeCollector, limit, 0); err != nil {
+			return nil, 0, err
+		}
+	}
+	out, used, err := r.vm.Execute(c.WASM, method, args, limit)
+	if err != nil {
+		if r.ledger != nil && limit > 0 {
+			_ = r.ledger.Transfer(r.feeCollector, payer, limit, 0)
+		}
+	} else if r.ledger != nil && used < limit {
+		refund := limit - used
+		if refund > 0 {
+			_ = r.ledger.Transfer(r.feeCollector, payer, refund, 0)
+		}
+	}
+	return out, used, err
 }
 
 // List returns all deployed contracts.

--- a/contracts_test.go
+++ b/contracts_test.go
@@ -1,13 +1,21 @@
-package synnergy
+package synnergy_test
 
-import "testing"
+import (
+	"testing"
+
+	synnergy "synnergy"
+	"synnergy/adapters/coreledger"
+	"synnergy/core"
+)
 
 func TestContractRegistry(t *testing.T) {
-	vm := NewSimpleVM()
+	vm := synnergy.NewSimpleVM()
 	if err := vm.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	reg := NewContractRegistry(vm)
+	ledger := core.NewLedger()
+	ledger.Credit("owner", 100)
+	reg := synnergy.NewContractRegistry(vm, coreledger.Wrap(ledger))
 	wasm := []byte{0x00, 0x61}
 	addr, err := reg.Deploy(wasm, "", 10, "owner")
 	if err != nil {

--- a/core/ai_enhanced_contract_test.go
+++ b/core/ai_enhanced_contract_test.go
@@ -9,7 +9,9 @@ import (
 func TestAIContractRegistry(t *testing.T) {
 	vm := NewSimpleVM()
 	_ = vm.Start()
-	base := NewContractRegistry(vm)
+	ledger := NewLedger()
+	ledger.Credit("owner", 1_000_000)
+	base := NewContractRegistry(vm, ledger)
 	aiReg := NewAIContractRegistry(base)
 	deployGas := synnergy.GasCost("DeployAIContract")
 	addr, err := aiReg.DeployAIContract([]byte{0x01}, "modelhash", "", deployGas, "owner")

--- a/core/authority_apply_test.go
+++ b/core/authority_apply_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAuthorityApplication(t *testing.T) {
-	reg := NewAuthorityNodeRegistry()
+	reg := NewAuthorityNodeRegistry(nil, NewValidatorManager(MinStake), 0)
 	mgr := NewAuthorityApplicationManager(reg, time.Hour)
 	id := mgr.Submit("cand1", "validator", "test")
 
@@ -30,7 +30,7 @@ func TestAuthorityApplication(t *testing.T) {
 }
 
 func TestAuthorityApplicationJSON(t *testing.T) {
-	reg := NewAuthorityNodeRegistry()
+	reg := NewAuthorityNodeRegistry(nil, NewValidatorManager(MinStake), 0)
 	mgr := NewAuthorityApplicationManager(reg, time.Hour)
 	id := mgr.Submit("cand1", "validator", "test")
 	if id == "" {

--- a/core/authority_nodes_test.go
+++ b/core/authority_nodes_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAuthorityNodeRegistry(t *testing.T) {
-	reg := NewAuthorityNodeRegistry()
+	reg := NewAuthorityNodeRegistry(nil, NewValidatorManager(MinStake), 0)
 	if _, err := reg.Register("addr1", "validator"); err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestAuthorityNodeRegistry(t *testing.T) {
 }
 
 func TestAuthorityNodeJSONAndRemoveVote(t *testing.T) {
-	reg := NewAuthorityNodeRegistry()
+	reg := NewAuthorityNodeRegistry(nil, NewValidatorManager(MinStake), 0)
 	node, err := reg.Register("addr1", "validator")
 	if err != nil {
 		t.Fatalf("register: %v", err)

--- a/core/contract_management_test.go
+++ b/core/contract_management_test.go
@@ -8,7 +8,9 @@ import (
 func TestContractManager(t *testing.T) {
 	vm := NewSimpleVM()
 	_ = vm.Start()
-	reg := NewContractRegistry(vm)
+	ledger := NewLedger()
+	ledger.Credit("owner", 1_000)
+	reg := NewContractRegistry(vm, ledger)
 	addr, err := reg.Deploy([]byte{0x01}, "", 5, "owner")
 	if err != nil {
 		t.Fatalf("deploy: %v", err)

--- a/core/contracts_test.go
+++ b/core/contracts_test.go
@@ -7,7 +7,9 @@ func TestContractRegistry(t *testing.T) {
 	if err := vm.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	reg := NewContractRegistry(vm)
+	ledger := NewLedger()
+	ledger.Credit("owner", 1_000)
+	reg := NewContractRegistry(vm, ledger)
 	wasm := []byte{0x00, 0x61}
 	addr, err := reg.Deploy(wasm, "", 10, "owner")
 	if err != nil {

--- a/core/dao_staking.go
+++ b/core/dao_staking.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"sync"
 )
@@ -8,21 +10,26 @@ import (
 // errInsufficientStake is returned when an unstake exceeds the balance.
 var errInsufficientStake = errors.New("insufficient stake")
 
-// DAOStaking tracks staked tokens for DAO members per DAO instance.
-// It references the DAOManager to enforce membership checks before any
-// staking operation is performed.
+// DAOStaking tracks staked tokens for DAO members per DAO instance.  It wires
+// ledger transfers into the staking flow so that DAO treasuries reflect the
+// locked capital backing governance decisions.
 type DAOStaking struct {
 	mu     sync.RWMutex
 	stakes map[string]map[string]uint64 // daoID -> addr -> amount
 	mgr    *DAOManager
+	ledger *Ledger
 }
 
-// NewDAOStaking creates a new DAOStaking instance bound to a DAOManager.
-func NewDAOStaking(mgr *DAOManager) *DAOStaking {
-	return &DAOStaking{stakes: make(map[string]map[string]uint64), mgr: mgr}
+// NewDAOStaking creates a new DAOStaking instance bound to a DAOManager and
+// optional ledger. When ledger is provided stake and unstake operations will
+// transfer the underlying funds to and from a deterministic DAO treasury
+// address.
+func NewDAOStaking(mgr *DAOManager, ledger *Ledger) *DAOStaking {
+	return &DAOStaking{stakes: make(map[string]map[string]uint64), mgr: mgr, ledger: ledger}
 }
 
-// Stake adds tokens to a member's stake. The caller must be a DAO member.
+// Stake adds tokens to a member's stake. The caller must be a DAO member. When
+// backed by a ledger the staked amount is moved into the DAO treasury.
 func (s *DAOStaking) Stake(daoID, addr string, amount uint64) error {
 	dao, err := s.mgr.Info(daoID)
 	if err != nil {
@@ -30,6 +37,11 @@ func (s *DAOStaking) Stake(daoID, addr string, amount uint64) error {
 	}
 	if !dao.IsMember(addr) {
 		return errUnauthorized
+	}
+	if s.ledger != nil && amount > 0 {
+		if err := s.ledger.Transfer(addr, s.treasuryAddress(daoID), amount, 0); err != nil {
+			return err
+		}
 	}
 	s.mu.Lock()
 	if s.stakes[daoID] == nil {
@@ -41,6 +53,7 @@ func (s *DAOStaking) Stake(daoID, addr string, amount uint64) error {
 }
 
 // Unstake removes tokens from a member's stake. Only DAO members can unstake.
+// Funds are returned from the DAO treasury when a ledger is configured.
 func (s *DAOStaking) Unstake(daoID, addr string, amount uint64) error {
 	dao, err := s.mgr.Info(daoID)
 	if err != nil {
@@ -50,12 +63,25 @@ func (s *DAOStaking) Unstake(daoID, addr string, amount uint64) error {
 		return errUnauthorized
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	bal := s.stakes[daoID][addr]
 	if bal < amount {
+		s.mu.Unlock()
 		return errInsufficientStake
 	}
 	s.stakes[daoID][addr] = bal - amount
+	remaining := s.stakes[daoID][addr]
+	if remaining == 0 {
+		delete(s.stakes[daoID], addr)
+	}
+	s.mu.Unlock()
+	if s.ledger != nil && amount > 0 {
+		if err := s.ledger.Transfer(s.treasuryAddress(daoID), addr, amount, 0); err != nil {
+			s.mu.Lock()
+			s.stakes[daoID][addr] += amount
+			s.mu.Unlock()
+			return err
+		}
+	}
 	return nil
 }
 
@@ -75,4 +101,9 @@ func (s *DAOStaking) TotalStaked(daoID string) uint64 {
 		total += amt
 	}
 	return total
+}
+
+func (s *DAOStaking) treasuryAddress(daoID string) string {
+	sum := sha256.Sum256([]byte("dao_treasury:" + daoID))
+	return hex.EncodeToString(sum[:])
 }

--- a/core/dao_staking_test.go
+++ b/core/dao_staking_test.go
@@ -12,7 +12,9 @@ func TestDAOStaking(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	s := NewDAOStaking(mgr)
+	ledger := NewLedger()
+	ledger.Mint("admin", 20)
+	s := NewDAOStaking(mgr, ledger)
 	if err := s.Stake(dao.ID, "admin", 10); err != nil {
 		t.Fatalf("stake: %v", err)
 	}

--- a/core/dao_token_test.go
+++ b/core/dao_token_test.go
@@ -18,7 +18,9 @@ func TestDAOTokenLedger(t *testing.T) {
 		t.Fatalf("join bob: %v", err)
 	}
 
-	l := NewDAOTokenLedger(mgr)
+	ledger := NewLedger()
+	ledger.Mint("admin", 100)
+	l := NewDAOTokenLedger(mgr, ledger)
 
 	if err := l.Mint(dao.ID, "alice", "alice", 10); err == nil {
 		t.Fatalf("expected unauthorized mint")

--- a/core/enterprise_orchestrator.go
+++ b/core/enterprise_orchestrator.go
@@ -88,12 +88,15 @@ func NewEnterpriseOrchestrator(ctx context.Context, opts ...EnterpriseOption) (*
 		return nil, fmt.Errorf("wallet init: %w", err)
 	}
 
+	ledger := NewLedger()
+	validators := NewValidatorManager(MinStake)
+
 	orchestrator := &EnterpriseOrchestrator{
 		vm:        vm,
 		consensus: NewConsensusNetworkManager(),
 		wallet:    wallet,
-		registry:  NewAuthorityNodeRegistry(),
-		ledger:    NewLedger(),
+		registry:  NewAuthorityNodeRegistry(ledger, validators, 1),
+		ledger:    ledger,
 		gas: map[string]uint64{
 			"EnterpriseBootstrap":      120,
 			"EnterpriseConsensusSync":  95,

--- a/core/smart_contract_marketplace.go
+++ b/core/smart_contract_marketplace.go
@@ -19,13 +19,13 @@ type SmartContractMarketplace struct {
 }
 
 // NewSmartContractMarketplace initialises a marketplace backed by the provided
-// virtual machine. The VM is started if necessary so contracts can be executed
-// immediately after deployment.
-func NewSmartContractMarketplace(vm VirtualMachine) *SmartContractMarketplace {
+// virtual machine and ledger. The VM is started if necessary so contracts can be
+// executed immediately after deployment.
+func NewSmartContractMarketplace(vm VirtualMachine, ledger *Ledger) *SmartContractMarketplace {
 	if !vm.Status() {
 		_ = vm.Start()
 	}
-	reg := NewContractRegistry(vm)
+	reg := NewContractRegistry(vm, ledger)
 	return &SmartContractMarketplace{registry: reg, manager: NewContractManager(reg)}
 }
 

--- a/core/smart_contract_marketplace_test.go
+++ b/core/smart_contract_marketplace_test.go
@@ -14,9 +14,12 @@ func TestSmartContractMarketplaceDeployAndTrade(t *testing.T) {
 	if err := vm.Start(); err != nil {
 		t.Fatalf("vm start: %v", err)
 	}
-	m := NewSmartContractMarketplace(vm)
-
 	gas := synn.GasCost("DeploySmartContract")
+	ledger := NewLedger()
+	ledger.Credit("alice", gas*2)
+
+	m := NewSmartContractMarketplace(vm, ledger)
+
 	addr, err := m.DeployContract(context.Background(), []byte{0x00}, "", gas, "alice")
 	if err != nil {
 		t.Fatalf("deploy: %v", err)

--- a/docs/Whitepaper_detailed/How to setup the blockchain.md
+++ b/docs/Whitepaper_detailed/How to setup the blockchain.md
@@ -109,13 +109,14 @@ Wallet creation and identity attestation are handled by `core/wallet.go` and `id
 Operational scripts such as `scripts/wallet_init.sh`, `scripts/wallet_key_rotation.sh`, `scripts/wallet_multisig_setup.sh` and `scripts/wallet_offline_sign.sh` automate provisioning, key rotation, multisignature coordination and offline signing. For regulated environments `scripts/idwallet_register.sh` captures KYC data and ties wallets to verified identities.
 
 ## 9. Deploy Smart Contracts
-The runtime embeds a virtual machine (`core.NewSNVM`) and contract registry (`core.NewContractRegistry`). Contracts reside under `smart-contracts/` (WebAssembly templates) and `smart-contracts/solidity/` (reference Solidity implementations).  Typical lifecycle:
+The runtime embeds a virtual machine (`core.NewSNVM`) and contract registry (`core.NewContractRegistry` backed by a shared ledger). Contracts reside under `smart-contracts/` (WebAssembly templates) and `smart-contracts/solidity/` (reference Solidity implementations).  Typical lifecycle:
 ```bash
 ./synnergy contracts compile <src.wasm> --out build/          # compile contract
-./synnergy contracts deploy build/src.wasm --from <addr>      # deploy to chain
+./synnergy contracts deploy --wasm build/src.wasm --owner <addr> --gas 200000
 ./synnergy contracts invoke <addr> <method> [args]            # execute entrypoint
 ./synnergy contracts query <addr> <state-key>                 # read contract state
 ```
+Fund the deploying wallet before running `contracts deploy`; the CLI deducts the declared gas limit from the ledger and routes it to the contract fee collector.
 Gas usage is deterministically priced through `synnergy.LoadGasTable()` and `synnergy.RegisterGasCost()` calls executed during start‑up.  Pre‑deployment checks are orchestrated via:
 
 - `scripts/contract_static_analysis.sh` – run `gosec` and `wasm-verify` across sources

--- a/docs/Whitepaper_detailed/How to write a contract.md
+++ b/docs/Whitepaper_detailed/How to write a contract.md
@@ -49,9 +49,12 @@ The returned hash becomes the on‑chain address used in subsequent operations.
 Contracts are registered through the `ContractRegistry`. Deployment requires the WASM bytecode, optional manifest, gas limit and owner address【F:contracts.go†L57-L79】.
 
 ```go
-registry := synnergy.NewContractRegistry(vm)
-addr, err := registry.Deploy(wasm, manifestJSON, gasLimit, owner)
+coreLedger := core.NewLedger()
+ledger := coreledger.Wrap(coreLedger)
+addr, err := synnergy.NewContractRegistry(vm, ledger).Deploy(wasm, manifestJSON, gasLimit, owner)
 ```
+
+Ensure the owner wallet holds at least `gasLimit` units before deployment so the ledger can charge the contract fee. When using the provided adapter (`synnergy/adapters/coreledger`), the registry persists metadata back to the shared core ledger.
 
 For command‑line workflows, the provided script wraps this functionality:
 

--- a/docs/reference/functions_list.md
+++ b/docs/reference/functions_list.md
@@ -106,7 +106,7 @@ This catalogue lists exported functions across the repository for quick navigati
 | `core/syn2900.go` | `43` | `func (p *TokenInsurancePolicy) Claim(now time.Time) (uint64, error) {` |
 | `core/authority_node_index_test.go` | `5` | `func TestAuthorityNodeIndex(t *testing.T) {` |
 | `core/regulatory_management_test.go` | `5` | `func TestRegulatoryManager(t *testing.T) {` |
-| `core/dao_token.go` | `18` | `func NewDAOTokenLedger(mgr *DAOManager) *DAOTokenLedger {` |
+| `core/dao_token.go` | `18` | `func NewDAOTokenLedger(mgr *DAOManager, ledger *Ledger) *DAOTokenLedger {` |
 | `core/dao_token.go` | `23` | `func (l *DAOTokenLedger) Mint(daoID, admin, addr string, amount uint64) error {` |
 | `core/dao_token.go` | `44` | `func (l *DAOTokenLedger) Transfer(daoID, from, to string, amount uint64) error {` |
 | `core/dao_token.go` | `63` | `func (l *DAOTokenLedger) Balance(daoID, addr string) uint64 {` |
@@ -300,7 +300,7 @@ This catalogue lists exported functions across the repository for quick navigati
 | `Tokens/index.go` | `15` | `func (r *Registry) NextID() TokenID {` |
 | `Tokens/index.go` | `21` | `func (r *Registry) Register(t Token) {` |
 | `Tokens/index.go` | `26` | `func (r *Registry) Get(id TokenID) (Token, bool) {` |
-| `core/contracts.go` | `39` | `func NewContractRegistry(vm VirtualMachine) *ContractRegistry {` |
+| `core/contracts.go` | `39` | `func NewContractRegistry(vm VirtualMachine, ledger *Ledger) *ContractRegistry {` |
 | `core/contracts.go` | `49` | `func CompileWASM(src []byte) ([]byte, string, error) {` |
 | `core/contracts.go` | `60` | `func (r *ContractRegistry) Deploy(wasm []byte, manifest string, gasLimit uint64, owner string) (string, error) {` |
 | `core/contracts.go` | `84` | `func (r *ContractRegistry) Invoke(addr, method string, args []byte, gasLimit uint64) ([]byte, uint64, error) {` |
@@ -638,7 +638,7 @@ This catalogue lists exported functions across the repository for quick navigati
 | `core/dao.go` | `51` | `func (m *DAOManager) Leave(id, addr string) error {` |
 | `core/dao.go` | `61` | `func (m *DAOManager) Info(id string) (*DAO, error) {` |
 | `core/dao.go` | `70` | `func (m *DAOManager) List() []*DAO {` |
-| `core/dao_staking.go` | `21` | `func NewDAOStaking(mgr *DAOManager) *DAOStaking {` |
+| `core/dao_staking.go` | `21` | `func NewDAOStaking(mgr *DAOManager, ledger *Ledger) *DAOStaking {` |
 | `core/dao_staking.go` | `26` | `func (s *DAOStaking) Stake(daoID, addr string, amount uint64) error {` |
 | `core/dao_staking.go` | `44` | `func (s *DAOStaking) Unstake(daoID, addr string, amount uint64) error {` |
 | `core/dao_staking.go` | `63` | `func (s *DAOStaking) Balance(daoID, addr string) uint64 {` |
@@ -795,7 +795,7 @@ This catalogue lists exported functions across the repository for quick navigati
 | `core/snvm_test.go` | `21` | `func TestSNVMDivideByZero(t *testing.T) {` |
 | `core/validator_node_test.go` | `5` | `func TestValidatorNode(t *testing.T) {` |
 | `core/identity_verification_test.go` | `5` | `func TestIdentityService(t *testing.T) {` |
-| `core/authority_nodes.go` | `23` | `func NewAuthorityNodeRegistry() *AuthorityNodeRegistry {` |
+| `core/authority_nodes.go` | `23` | `func NewAuthorityNodeRegistry(ledger *Ledger, validators *ValidatorManager, minBalance uint64) *AuthorityNodeRegistry {` |
 | `core/authority_nodes.go` | `28` | `func (r *AuthorityNodeRegistry) Register(addr, role string) (*AuthorityNode, error) {` |
 | `core/authority_nodes.go` | `38` | `func (r *AuthorityNodeRegistry) Vote(voterAddr, candidateAddr string) error {` |
 | `core/authority_nodes.go` | `48` | `func (r *AuthorityNodeRegistry) Electorate(size int) []string {` |

--- a/tests/contracts/faucet_test.go
+++ b/tests/contracts/faucet_test.go
@@ -1,63 +1,66 @@
 package contracts
 
 import (
-        "bytes"
-        "io"
-        "os"
-        "strings"
-        "testing"
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
 
-        synn "synnergy"
-        "synnergy/cli"
+	synn "synnergy"
+	"synnergy/cli"
 )
 
 // execCLI executes the Synnergy CLI command with the given arguments from the
 // repository root and returns combined stdout and stderr.
 func execCLI(t *testing.T, args ...string) (string, error) {
-        t.Helper()
-        wd, err := os.Getwd()
-        if err != nil {
-                t.Fatalf("getwd: %v", err)
-        }
-        defer os.Chdir(wd)
-        if err := os.Chdir("../.." ); err != nil {
-                t.Fatalf("chdir: %v", err)
-        }
-        cmd := cli.RootCmd()
-        buf := new(bytes.Buffer)
-        cmd.SetOut(buf)
-        cmd.SetErr(buf)
-        r, w, _ := os.Pipe()
-        old := os.Stdout
-        os.Stdout = w
-        cmd.SetArgs(args)
-        _, err = cmd.ExecuteC()
-        cmd.SetArgs([]string{})
-        w.Close()
-        os.Stdout = old
-        out, _ := io.ReadAll(r)
-        r.Close()
-        return strings.TrimSpace(buf.String() + string(out)), err
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(wd)
+	if err := os.Chdir("../.."); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	cmd := cli.RootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	cmd.SetArgs(args)
+	_, err = cmd.ExecuteC()
+	cmd.SetArgs([]string{})
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	r.Close()
+	return strings.TrimSpace(buf.String() + string(out)), err
 }
 
 // TestTokenFaucetTemplate deploys the token faucet contract template via the
 // CLI and ensures it is registered.
 func TestTokenFaucetTemplate(t *testing.T) {
-        synn.LoadGasTable()
-        out, err := execCLI(t, "contracts", "deploy-template", "--name", "token_faucet")
-        if err != nil {
-                t.Fatalf("deploy-template: %v", err)
-        }
-        addr := strings.TrimSpace(out)
-        if addr == "" {
-                t.Fatal("empty address returned")
-        }
-        list, err := execCLI(t, "contracts", "list")
-        if err != nil {
-                t.Fatalf("list: %v", err)
-        }
-        if !strings.Contains(list, addr) {
-                t.Fatalf("deployed address %s not listed", addr)
-        }
+	synn.LoadGasTable()
+	owner := "template-owner"
+	if _, err := execCLI(t, "ledger", "mint", owner, "1000000"); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	out, err := execCLI(t, "contracts", "deploy-template", "--name", "token_faucet", "--owner", owner)
+	if err != nil {
+		t.Fatalf("deploy-template: %v", err)
+	}
+	addr := strings.TrimSpace(out)
+	if addr == "" {
+		t.Fatal("empty address returned")
+	}
+	list, err := execCLI(t, "contracts", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(list, addr) {
+		t.Fatalf("deployed address %s not listed", addr)
+	}
 }
-


### PR DESCRIPTION
## Summary
- add an adapters/coreledger helper so the top-level contract registry can operate on the shared core ledger without import cycles
- update CLI contract and AI tooling to require shared ledger instances, validate owners, and adjust tests plus faucet template workflow to fund deployers
- document the new constructor signatures and wire command bootstrap to preload modules after the new gas metadata routine

## Testing
- go test ./... *(fails: genesis bootstrap/unit tests require full chain setup and pre-existing sub-block data)*
- go test ./tests/contracts -run TokenFaucetTemplate -count=1


------
https://chatgpt.com/codex/tasks/task_e_68d0c0c1afa48320a5f78451aec7d3a5