### PR TITLE
Improve sub-block signing and validator registration

### DIFF
--- a/cli/block.go
+++ b/cli/block.go
@@ -38,6 +38,9 @@ func init() {
 			}
 			tx := core.NewTransaction(args[1], args[2], amt, fee, nonce)
 			sb := core.NewSubBlock([]*core.Transaction{tx}, args[0])
+			if err := core.SignSubBlock(sb); err != nil {
+				return fmt.Errorf("sign sub-block: %w", err)
+			}
 			sbList = append(sbList, sb)
 			fmt.Println(sb.PohHash)
 			return nil

--- a/cli/block_test.go
+++ b/cli/block_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"synnergy/core"
 )
 
 // TestBlockCreateAndHeader ensures block creation and header hashing work via CLI.
@@ -10,7 +12,16 @@ func TestBlockCreateAndHeader(t *testing.T) {
 	sbList = nil
 	lastBlock = nil
 
-	if _, err := execCommand("block", "sub-create", "val", "from", "to", "10", "1", "0"); err != nil {
+	wallet, err := core.NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := core.RegisterValidatorWallet(wallet); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	t.Cleanup(func() { core.UnregisterValidator(wallet.Address) })
+
+	if _, err := execCommand("block", "sub-create", wallet.Address, "from", "to", "10", "1", "0"); err != nil {
 		t.Fatalf("sub-create failed: %v", err)
 	}
 

--- a/core/block_test.go
+++ b/core/block_test.go
@@ -11,7 +11,15 @@ import (
 
 func TestSubBlockCreationAndVerification(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "val")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	if err := sb.Validate(); err != nil {
 		t.Fatalf("validate: %v", err)
 	}
@@ -19,7 +27,15 @@ func TestSubBlockCreationAndVerification(t *testing.T) {
 
 func TestBlockHeaderHash(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	b := NewBlock([]*SubBlock{sb}, "prevhash")
 	nonce := uint64(7)
 	got := b.HeaderHash(nonce)
@@ -40,7 +56,15 @@ func TestBlockHeaderHash(t *testing.T) {
 
 func TestSubBlockValidateRejectsDuplicateTransactions(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx, tx}, "val")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx, tx}, w.Address)
 	if err := sb.Validate(); err == nil || !strings.Contains(err.Error(), "duplicate") {
 		t.Fatalf("expected duplicate transaction error, got %v", err)
 	}
@@ -48,7 +72,15 @@ func TestSubBlockValidateRejectsDuplicateTransactions(t *testing.T) {
 
 func TestBlockValidateRejectsFutureTimestamp(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	b := NewBlock([]*SubBlock{sb}, "prevhash")
 	b.Timestamp = time.Now().Add(6 * time.Minute).Unix()
 	b.Nonce = 1
@@ -60,7 +92,15 @@ func TestBlockValidateRejectsFutureTimestamp(t *testing.T) {
 
 func TestBlockValidateRejectsSubBlockAfterBlockTimestamp(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	b := NewBlock([]*SubBlock{sb}, "prevhash")
 	b.Timestamp = sb.Timestamp - 10
 	b.Nonce = 1
@@ -72,7 +112,15 @@ func TestBlockValidateRejectsSubBlockAfterBlockTimestamp(t *testing.T) {
 
 func TestBlockValidateRequiresHash(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	b := NewBlock([]*SubBlock{sb}, "prevhash")
 	b.Nonce = 1
 	if err := b.Validate(); err == nil || !strings.Contains(err.Error(), "hash required") {
@@ -82,7 +130,15 @@ func TestBlockValidateRequiresHash(t *testing.T) {
 
 func TestBlockValidateDetectsHashMismatch(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	b := NewBlock([]*SubBlock{sb}, "prevhash")
 	b.Nonce = 1
 	b.Hash = "bad"

--- a/core/consensus.go
+++ b/core/consensus.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"crypto/sha256"
 	"math/big"
 	"sort"
@@ -42,22 +44,25 @@ type SynnergyConsensus struct {
 	// RegNode performs regulatory checks on transactions during
 	// consensus validation. When nil, regulatory checks are bypassed.
 	RegNode *RegulatoryNode
+
+	validatorPubKeys map[string][]byte
 }
 
 // NewSynnergyConsensus returns a new consensus engine with default parameters
 // derived from the Synnergy specification.
 func NewSynnergyConsensus() *SynnergyConsensus {
 	return &SynnergyConsensus{
-		Weights:      ConsensusWeights{PoW: 0.40, PoS: 0.30, PoH: 0.30},
-		Alpha:        0.5,
-		Beta:         0.5,
-		Gamma:        0.1,
-		Dmax:         1,
-		Smax:         1,
-		PoWAvailable: true,
-		PoSAvailable: true,
-		PoHAvailable: true,
-		PoWRewards:   true,
+		Weights:          ConsensusWeights{PoW: 0.40, PoS: 0.30, PoH: 0.30},
+		Alpha:            0.5,
+		Beta:             0.5,
+		Gamma:            0.1,
+		Dmax:             1,
+		Smax:             1,
+		PoWAvailable:     true,
+		PoSAvailable:     true,
+		PoHAvailable:     true,
+		PoWRewards:       true,
+		validatorPubKeys: make(map[string][]byte),
 	}
 }
 
@@ -66,6 +71,18 @@ func NewSynnergyConsensus() *SynnergyConsensus {
 func (sc *SynnergyConsensus) SetRegulatoryNode(rn *RegulatoryNode) {
 	sc.mu.Lock()
 	sc.RegNode = rn
+	sc.mu.Unlock()
+}
+
+// RegisterValidatorPublicKey records the validator's public key so sub-blocks
+// can be authenticated across the network. The stored key is compared with any
+// key provided in sub-blocks to detect spoofed identities.
+func (sc *SynnergyConsensus) RegisterValidatorPublicKey(addr string, pub *ecdsa.PublicKey) {
+	if addr == "" || pub == nil {
+		return
+	}
+	sc.mu.Lock()
+	sc.validatorPubKeys[addr] = encodePublicKey(pub)
 	sc.mu.Unlock()
 }
 
@@ -236,6 +253,17 @@ func (sc *SynnergyConsensus) ValidateSubBlock(sb *SubBlock) bool {
 	}
 	if err := sb.Validate(); err != nil {
 		return false
+	}
+	if !sb.System {
+		sc.mu.RLock()
+		expected := sc.validatorPubKeys[sb.Validator]
+		sc.mu.RUnlock()
+		if len(expected) == 0 {
+			return false
+		}
+		if !bytes.Equal(expected, sb.ValidatorKey) {
+			return false
+		}
 	}
 	regNode := sc.getRegNode()
 	if regNode == nil {

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -7,6 +7,19 @@ import (
 	"testing"
 )
 
+func registerTestValidator(t *testing.T) *Wallet {
+	t.Helper()
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	t.Cleanup(func() { UnregisterValidator(w.Address) })
+	return w
+}
+
 func TestThreshold(t *testing.T) {
 	sc := NewSynnergyConsensus()
 	if sc.Threshold(2, 3) != sc.Alpha*2+sc.Beta*3 {
@@ -79,18 +92,19 @@ func TestSelectValidatorMajorityStake(t *testing.T) {
 func TestFinalizeBlockRewards(t *testing.T) {
 	sc := NewSynnergyConsensus()
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "v1")
+	w := registerTestValidator(t)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	b := NewBlock([]*SubBlock{sb}, "")
 	vm := NewValidatorManager(1)
-	_ = vm.Add(context.Background(), "v1", 5)
-	votes := map[string]bool{"v1": true, "v2": true, "v3": false}
+	_ = vm.Add(context.Background(), w.Address, 5)
+	votes := map[string]bool{w.Address: true, "v2": true, "v3": false}
 	if !sc.FinalizeBlock(b, votes, vm, 2) {
 		t.Fatalf("expected block to finalize")
 	}
 	if !b.Finalized {
 		t.Fatalf("block not marked finalized")
 	}
-	if vm.Stake("v1") != 7 {
+	if vm.Stake(w.Address) != 7 {
 		t.Fatalf("reward not applied")
 	}
 }
@@ -98,11 +112,13 @@ func TestFinalizeBlockRewards(t *testing.T) {
 func TestValidateSubBlock(t *testing.T) {
 	sc := NewSynnergyConsensus()
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "val")
+	w := registerTestValidator(t)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
+	sc.RegisterValidatorPublicKey(w.Address, &w.PublicKey)
 	if !sc.ValidateSubBlock(sb) {
 		t.Fatalf("expected valid sub-block")
 	}
-	sb.Signature = "bad"
+	sb.Signature = []byte("bad")
 	if sc.ValidateSubBlock(sb) {
 		t.Fatalf("expected invalid sub-block")
 	}
@@ -111,7 +127,9 @@ func TestValidateSubBlock(t *testing.T) {
 func TestValidateBlock(t *testing.T) {
 	sc := NewSynnergyConsensus()
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "val")
+	w := registerTestValidator(t)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
+	sc.RegisterValidatorPublicKey(w.Address, &w.PublicKey)
 	block := NewBlock([]*SubBlock{sb}, "")
 	sc.MineBlock(block, 1)
 	if !sc.ValidateBlock(block) {
@@ -134,12 +152,14 @@ func TestValidateSubBlockRegulatory(t *testing.T) {
 		t.Fatalf("wallet: %v", err)
 	}
 	rn.RegisterWallet(w)
+	validator := registerTestValidator(t)
+	sc.RegisterValidatorPublicKey(validator.Address, &validator.PublicKey)
 
 	tx := NewTransaction(w.Address, "bob", 5, 0, 0)
 	if _, err := w.Sign(tx); err != nil {
 		t.Fatalf("sign: %v", err)
 	}
-	sb := NewSubBlock([]*Transaction{tx}, "val")
+	sb := NewSubBlock([]*Transaction{tx}, validator.Address)
 	if !sc.ValidateSubBlock(sb) {
 		t.Fatalf("expected valid sub-block")
 	}
@@ -148,7 +168,7 @@ func TestValidateSubBlockRegulatory(t *testing.T) {
 	if _, err := w.Sign(tx2); err != nil {
 		t.Fatalf("sign2: %v", err)
 	}
-	sb2 := NewSubBlock([]*Transaction{tx2}, "val")
+	sb2 := NewSubBlock([]*Transaction{tx2}, validator.Address)
 	if sc.ValidateSubBlock(sb2) {
 		t.Fatalf("expected regulatory rejection")
 	}
@@ -160,9 +180,11 @@ func TestValidateSubBlockWithoutRegNode(t *testing.T) {
 	mgr.AddRegulation(Regulation{ID: "r1", MaxAmount: 10})
 	rn := NewRegulatoryNode("rn", mgr)
 	sc.SetRegulatoryNode(rn)
+	validator := registerTestValidator(t)
+	sc.RegisterValidatorPublicKey(validator.Address, &validator.PublicKey)
 
 	tx := NewTransaction("alice", "bob", 20, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "val")
+	sb := NewSubBlock([]*Transaction{tx}, validator.Address)
 	if sc.ValidateSubBlock(sb) {
 		t.Fatalf("expected rejection with regulatory node")
 	}

--- a/core/genesis_block.go
+++ b/core/genesis_block.go
@@ -27,7 +27,7 @@ func (n *Node) InitGenesis(wallets GenesisWallets) (GenesisStats, *Block, error)
 		return GenesisStats{}, nil, err
 	}
 	n.Ledger.Credit(wallets.CreatorWallet, GenesisAllocation)
-	sb := NewSubBlock(nil, wallets.Genesis)
+	sb := NewGenesisSubBlock(wallets.Genesis)
 	block := NewBlock([]*SubBlock{sb}, "")
 	n.Consensus.MineBlock(block, 1)
 	n.Blockchain = append(n.Blockchain, block)

--- a/core/node_test.go
+++ b/core/node_test.go
@@ -9,7 +9,14 @@ func TestMineBlockFeeDistribution(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Credit("alice", 200)
 	node := NewNode("miner", "addr", ledger)
-	validator := "validator1"
+	validatorWallet, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := node.RegisterValidatorWallet(validatorWallet); err != nil {
+		t.Fatalf("register validator: %v", err)
+	}
+	validator := validatorWallet.Address
 	node.SetStake(validator, 2)
 	tx := NewTransaction("alice", "bob", 10, 100, 0)
 	if err := node.AddTransaction(tx); err != nil {

--- a/core/security_test.go
+++ b/core/security_test.go
@@ -53,7 +53,15 @@ func TestEligibleStakesExcludesSlashed(t *testing.T) {
 
 func TestSubBlockSignature(t *testing.T) {
 	tx := NewTransaction("a", "b", 1, 0, 0)
-	sb := NewSubBlock([]*Transaction{tx}, "val")
+	w, err := NewWallet()
+	if err != nil {
+		t.Fatalf("wallet: %v", err)
+	}
+	if err := RegisterValidatorWallet(w); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer UnregisterValidator(w.Address)
+	sb := NewSubBlock([]*Transaction{tx}, w.Address)
 	if !sb.VerifySignature() {
 		t.Fatalf("signature verification failed")
 	}

--- a/core/validator_keys.go
+++ b/core/validator_keys.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"crypto/ecdsa"
+	"errors"
+	"sync"
+)
+
+// validatorKeyStore keeps track of validator signing keys used for sub-block
+// signatures. Keys are registered by nodes when validators join the network so
+// that all components can authenticate sub-blocks without embedding private
+// key material in the structures themselves.
+type validatorKeyStore struct {
+	mu       sync.RWMutex
+	privKeys map[string]*ecdsa.PrivateKey
+	pubKeys  map[string]*ecdsa.PublicKey
+}
+
+var globalValidatorKeys = newValidatorKeyStore()
+
+func newValidatorKeyStore() *validatorKeyStore {
+	return &validatorKeyStore{
+		privKeys: make(map[string]*ecdsa.PrivateKey),
+		pubKeys:  make(map[string]*ecdsa.PublicKey),
+	}
+}
+
+// RegisterValidatorWallet records the wallet keys for the given validator
+// address. The wallet's public key is shared with other components, while the
+// private key is retained only to support local signing helpers used by tests
+// and CLI tooling.
+func RegisterValidatorWallet(w *Wallet) error {
+	if w == nil || w.PrivateKey == nil {
+		return errors.New("wallet private key not initialised")
+	}
+	addr := w.Address
+	if addr == "" {
+		return errors.New("wallet address required")
+	}
+	globalValidatorKeys.mu.Lock()
+	globalValidatorKeys.privKeys[addr] = w.PrivateKey
+	pub := w.PrivateKey.PublicKey
+	globalValidatorKeys.pubKeys[addr] = &pub
+	globalValidatorKeys.mu.Unlock()
+	return nil
+}
+
+// UnregisterValidator removes any stored keys for the provided address. It is
+// primarily used by tests to ensure isolation between cases.
+func UnregisterValidator(addr string) {
+	globalValidatorKeys.mu.Lock()
+	delete(globalValidatorKeys.privKeys, addr)
+	delete(globalValidatorKeys.pubKeys, addr)
+	globalValidatorKeys.mu.Unlock()
+}
+
+func validatorPrivateKey(addr string) *ecdsa.PrivateKey {
+	globalValidatorKeys.mu.RLock()
+	defer globalValidatorKeys.mu.RUnlock()
+	return globalValidatorKeys.privKeys[addr]
+}
+
+func validatorPublicKey(addr string) *ecdsa.PublicKey {
+	globalValidatorKeys.mu.RLock()
+	defer globalValidatorKeys.mu.RUnlock()
+	if pub, ok := globalValidatorKeys.pubKeys[addr]; ok {
+		return pub
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- require sub-blocks to carry real ECDSA signatures and validator public keys, with a system sub-block helper for genesis
- add a validator key store so nodes and consensus can register wallets, enforce public key matching, and expose CLI helpers for mining
- update unit and CLI tests to register validator wallets and validate the hardened signing flow

## Testing
- go test ./core -run 'Test(MineBlockFeeDistribution|ValidateSubBlock|ValidateBlock|SubBlockSignature)' -count=1
- go test ./cli -run TestBlockCreateAndHeader -count=1
- go test ./cli -run TestConsensusMineGas -count=1


------
https://chatgpt.com/codex/tasks/task_e_68d0cc6673f883208869ba39709f999c