### PR TITLE
Add CLI test coverage and test harnesses for watchtower and wallet

### DIFF
--- a/cli/cli_test_helpers_test.go
+++ b/cli/cli_test_helpers_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+        "bytes"
+        "io"
+        "os"
+        "strings"
+        "testing"
+)
+
+// executeCLICommand runs the root command with the provided arguments and
+// captures output from both Cobra's configured writer and direct stdout
+// writes used by some commands.
+func executeCLICommand(t *testing.T, args ...string) (string, error) {
+        t.Helper()
+        cmd := RootCmd()
+        buf := new(bytes.Buffer)
+        cmd.SetOut(buf)
+        cmd.SetErr(buf)
+        cmd.SetArgs(args)
+        defer cmd.SetArgs(nil)
+
+        oldStdout := os.Stdout
+        r, w, err := os.Pipe()
+        if err != nil {
+                t.Fatalf("pipe: %v", err)
+        }
+        os.Stdout = w
+        execErr := cmd.Execute()
+        w.Close()
+        os.Stdout = oldStdout
+        stdoutBytes, _ := io.ReadAll(r)
+        r.Close()
+
+        output := buf.String() + string(stdoutBytes)
+        return strings.TrimSpace(output), execErr
+}

--- a/cli/experimental_node_test.go
+++ b/cli/experimental_node_test.go
@@ -1,7 +1,50 @@
+//go:build experimental
+
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestExperimentalnodePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestExperimentalNodeLifecycle(t *testing.T) {
+	expNode = nil
+	t.Cleanup(func() { expNode = nil })
+
+	out, err := executeCLICommand(t, "experimental", "status")
+	if err != nil {
+		t.Fatalf("status without node: %v", err)
+	}
+	if strings.TrimSpace(out) != "no node" {
+		t.Fatalf("expected 'no node', got %q", out)
+	}
+
+	out, err = executeCLICommand(t, "experimental", "create", "exp1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if strings.TrimSpace(out) != "created" {
+		t.Fatalf("unexpected create output: %q", out)
+	}
+	if expNode == nil {
+		t.Fatalf("expected expNode to be created")
+	}
+
+	if _, err := executeCLICommand(t, "experimental", "start"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !expNode.IsRunning() {
+		t.Fatalf("node should be running")
+	}
+
+	if _, err := executeCLICommand(t, "experimental", "dial", "peer1"); err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	if _, err := executeCLICommand(t, "experimental", "stop"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if expNode.IsRunning() {
+		t.Fatalf("node should be stopped")
+	}
 }

--- a/cli/gateway_test.go
+++ b/cli/gateway_test.go
@@ -1,7 +1,51 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestGatewayPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+	nodes "synnergy/internal/nodes"
+)
+
+func TestGatewayCommands(t *testing.T) {
+	gateway = core.NewGatewayNode(nodes.Address("gw-test"), core.GatewayConfig{})
+	if err := gateway.Start(); err != nil {
+		t.Fatalf("start gateway: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = gateway.Stop()
+		gateway = core.NewGatewayNode(nodes.Address("gw1"), core.GatewayConfig{})
+		_ = gateway.Start()
+	})
+
+	if _, err := executeCLICommand(t, "gateway", "register", "foo"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if endpoints := gateway.Endpoints(); len(endpoints) != 1 || endpoints[0] != "foo" {
+		t.Fatalf("unexpected endpoints: %v", endpoints)
+	}
+
+	out, err := executeCLICommand(t, "gateway", "call", "foo", "payload")
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if strings.TrimSpace(out) != "foo received: payload" {
+		t.Fatalf("unexpected call output: %q", out)
+	}
+
+	out, err = executeCLICommand(t, "gateway", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if strings.TrimSpace(out) != "foo" {
+		t.Fatalf("unexpected list output: %q", out)
+	}
+
+	if _, err := executeCLICommand(t, "gateway", "remove", "foo"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if len(gateway.Endpoints()) != 0 {
+		t.Fatalf("expected no endpoints after removal")
+	}
 }

--- a/cli/optimization_node_test.go
+++ b/cli/optimization_node_test.go
@@ -1,7 +1,23 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestOptimizationnodePlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	on "synnergy/internal/nodes/optimization_nodes"
+)
+
+func TestOptimizationFeeOrdering(t *testing.T) {
+	feeOpt = on.FeeOptimizer{}
+
+	out, err := executeCLICommand(t, "optimize", "fee", "tx1:10:2", "tx2:9:1")
+	if err != nil {
+		t.Fatalf("fee optimize: %v", err)
+	}
+	if !strings.Contains(out, "Hash:tx2") || !strings.Contains(out, "Hash:tx1") {
+		t.Fatalf("unexpected optimize output: %q", out)
+	}
+	if strings.Index(out, "Hash:tx2") > strings.Index(out, "Hash:tx1") {
+		t.Fatalf("expected tx2 before tx1, got %q", out)
+	}
 }

--- a/cli/plasma_management_test.go
+++ b/cli/plasma_management_test.go
@@ -1,7 +1,51 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestPlasmamanagementPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestPlasmaManagementCommands(t *testing.T) {
+	plasmaBridge = core.NewPlasmaBridge()
+	plasmaJSON = false
+	t.Cleanup(func() {
+		plasmaBridge = core.NewPlasmaBridge()
+		plasmaJSON = false
+	})
+
+	out, err := executeCLICommand(t, "plasma-mgmt", "pause")
+	if err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if !strings.Contains(out, "gas:") {
+		t.Fatalf("expected gas output, got %q", out)
+	}
+	if !plasmaBridge.IsPaused() {
+		t.Fatalf("bridge should be paused")
+	}
+
+	out, err = executeCLICommand(t, "plasma-mgmt", "status")
+	if err != nil {
+		t.Fatalf("status after pause: %v", err)
+	}
+	if strings.TrimSpace(out) != "true" {
+		t.Fatalf("expected paused status, got %q", out)
+	}
+
+	if _, err = executeCLICommand(t, "plasma-mgmt", "resume"); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if plasmaBridge.IsPaused() {
+		t.Fatalf("bridge should be resumed")
+	}
+
+	out, err = executeCLICommand(t, "plasma-mgmt", "status")
+	if err != nil {
+		t.Fatalf("status after resume: %v", err)
+	}
+	if strings.TrimSpace(out) != "false" {
+		t.Fatalf("expected resumed status, got %q", out)
+	}
 }

--- a/cli/plasma_operations_test.go
+++ b/cli/plasma_operations_test.go
@@ -1,7 +1,32 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestPlasmaoperationsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestPlasmaOperationsCommands(t *testing.T) {
+	plasmaBridge = core.NewPlasmaBridge()
+	t.Cleanup(func() { plasmaBridge = core.NewPlasmaBridge() })
+
+	if _, err := executeCLICommand(t, "plasma-ops", "deposit", "alice", "token", "10"); err != nil {
+		t.Fatalf("deposit: %v", err)
+	}
+	out, err := executeCLICommand(t, "plasma-ops", "exit", "alice", "token", "5")
+	if err != nil || strings.TrimSpace(out) != "1" {
+		t.Fatalf("unexpected exit output: %q err=%v", out, err)
+	}
+	if _, err := executeCLICommand(t, "plasma-ops", "finalize", "1"); err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	out, err = executeCLICommand(t, "plasma-ops", "get", "1")
+	if err != nil || !strings.Contains(out, "Nonce:1") {
+		t.Fatalf("unexpected get output: %q err=%v", out, err)
+	}
+	out, err = executeCLICommand(t, "plasma-ops", "list")
+	if err != nil || !strings.Contains(out, "Finalized:true") {
+		t.Fatalf("unexpected list output: %q err=%v", out, err)
+	}
 }

--- a/cli/plasma_test.go
+++ b/cli/plasma_test.go
@@ -1,7 +1,31 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
 
-func TestPlasmaPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestPlasmaStatusJSON(t *testing.T) {
+	plasmaBridge = core.NewPlasmaBridge()
+	plasmaJSON = false
+	jsonOutput = false
+	t.Cleanup(func() {
+		plasmaBridge = core.NewPlasmaBridge()
+		plasmaJSON = false
+		jsonOutput = false
+	})
+
+	out, err := executeCLICommand(t, "plasma", "--json", "plasma-mgmt", "status")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	var payload map[string]bool
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if v, ok := payload["paused"]; !ok || v {
+		t.Fatalf("expected paused=false, got %v (map: %v)", payload["paused"], payload)
+	}
 }

--- a/cli/private_transactions_test.go
+++ b/cli/private_transactions_test.go
@@ -1,7 +1,64 @@
 package cli
 
-import "testing"
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
 
-func TestPrivatetransactionsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestPrivateTransactionsCommands(t *testing.T) {
+	privTxMgr = core.NewPrivateTxManager()
+	t.Cleanup(func() { privTxMgr = core.NewPrivateTxManager() })
+
+	key := "0123456789abcdef0123456789abcdef"
+	plaintext := "secret"
+	out, err := executeCLICommand(t, "private-tx", "encrypt", key, plaintext)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	cipher, err := hex.DecodeString(out)
+	if err != nil {
+		t.Fatalf("decode cipher: %v", err)
+	}
+	if len(cipher) <= len(plaintext) {
+		t.Fatalf("ciphertext too short: %d", len(cipher))
+	}
+
+	generated, err := core.Encrypt([]byte(key), []byte(plaintext))
+	if err != nil {
+		t.Fatalf("encrypt fixture: %v", err)
+	}
+	decoded, err := executeCLICommand(t, "private-tx", "decrypt", key, hex.EncodeToString(generated))
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if decoded != plaintext {
+		t.Fatalf("expected plaintext %q, got %q", plaintext, decoded)
+	}
+
+	payload := hex.EncodeToString([]byte{0x01, 0x02})
+	nonce := hex.EncodeToString([]byte{0x03, 0x04})
+	body, err := json.Marshal(map[string]string{"payload": payload, "nonce": nonce})
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tx.json")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, err := executeCLICommand(t, "private-tx", "send", path); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	txs := privTxMgr.List()
+	if len(txs) != 1 {
+		t.Fatalf("expected 1 tx, got %d", len(txs))
+	}
+	if hex.EncodeToString(txs[0].Payload) != payload || hex.EncodeToString(txs[0].Nonce) != nonce {
+		t.Fatalf("unexpected stored tx: %+v", txs[0])
+	}
 }

--- a/cli/rpc_webrtc_test.go
+++ b/cli/rpc_webrtc_test.go
@@ -1,7 +1,55 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestRpcwebrtcPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestRPCWebRTCCommands(t *testing.T) {
+	webrtcRPC = core.NewWebRTCRPC()
+	peerChans = map[string]<-chan []byte{}
+	t.Cleanup(func() {
+		webrtcRPC = core.NewWebRTCRPC()
+		peerChans = map[string]<-chan []byte{}
+	})
+
+	if _, err := executeCLICommand(t, "rpcwebrtc", "connect", "p1"); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if len(webrtcRPC.Peers()) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(webrtcRPC.Peers()))
+	}
+
+	out, err := executeCLICommand(t, "rpcwebrtc", "send", "p1", "hello")
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if strings.TrimSpace(out) != "sent" {
+		t.Fatalf("unexpected send output: %q", out)
+	}
+
+	out, err = executeCLICommand(t, "rpcwebrtc", "recv", "p1")
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if strings.TrimSpace(out) != "hello" {
+		t.Fatalf("unexpected recv output: %q", out)
+	}
+
+	out, err = executeCLICommand(t, "rpcwebrtc", "recv", "p1")
+	if err != nil {
+		t.Fatalf("recv empty: %v", err)
+	}
+	if strings.TrimSpace(out) != "no message" {
+		t.Fatalf("expected no message, got %q", out)
+	}
+
+	if _, err := executeCLICommand(t, "rpcwebrtc", "disconnect", "p1"); err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	if len(webrtcRPC.Peers()) != 0 {
+		t.Fatalf("expected no peers after disconnect, got %d", len(webrtcRPC.Peers()))
+	}
 }

--- a/cli/sidechain_ops_test.go
+++ b/cli/sidechain_ops_test.go
@@ -1,7 +1,43 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestSidechainopsPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestSidechainOpsCommands(t *testing.T) {
+	sideReg = core.NewSidechainRegistry()
+	sideOps = core.NewSidechainOps(sideReg)
+	t.Cleanup(func() {
+		sideReg = core.NewSidechainRegistry()
+		sideOps = core.NewSidechainOps(sideReg)
+	})
+
+	if _, err := sideReg.Register("chain1", "meta", nil); err != nil {
+		t.Fatalf("register chain: %v", err)
+	}
+
+	if _, err := executeCLICommand(t, "sidechainops", "deposit", "chain1", "alice", "40"); err != nil {
+		t.Fatalf("deposit: %v", err)
+	}
+	out, err := executeCLICommand(t, "sidechainops", "balance", "chain1", "alice")
+	if err != nil {
+		t.Fatalf("balance: %v", err)
+	}
+	if strings.TrimSpace(out) != "40" {
+		t.Fatalf("expected balance 40, got %q", out)
+	}
+
+	if _, err := executeCLICommand(t, "sidechainops", "withdraw", "chain1", "alice", "10", "proof"); err != nil {
+		t.Fatalf("withdraw: %v", err)
+	}
+	out, err = executeCLICommand(t, "sidechainops", "balance", "chain1", "alice")
+	if err != nil {
+		t.Fatalf("balance after withdraw: %v", err)
+	}
+	if strings.TrimSpace(out) != "30" {
+		t.Fatalf("expected balance 30, got %q", out)
+	}
 }

--- a/cli/synchronization_test.go
+++ b/cli/synchronization_test.go
@@ -1,7 +1,61 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
 
-func TestSynchronizationPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestSynchronizationCommands(t *testing.T) {
+	syncMgr = core.NewSyncManager(ledger)
+	syncJSON = false
+	t.Cleanup(func() {
+		syncMgr = core.NewSyncManager(ledger)
+		syncJSON = false
+	})
+
+	out, err := executeCLICommand(t, "synchronization", "status")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(out, "running: false") {
+		t.Fatalf("unexpected status output: %q", out)
+	}
+
+	if _, err := executeCLICommand(t, "synchronization", "once"); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("expected not running error, got %v", err)
+	}
+
+	if _, err := executeCLICommand(t, "synchronization", "start"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if _, err := executeCLICommand(t, "synchronization", "once"); err != nil {
+		t.Fatalf("once: %v", err)
+	}
+
+	out, err = executeCLICommand(t, "synchronization", "status")
+	if err != nil {
+		t.Fatalf("status running: %v", err)
+	}
+	if !strings.Contains(out, "running: true") {
+		t.Fatalf("expected running true, got %q", out)
+	}
+
+	out, err = executeCLICommand(t, "synchronization", "--json", "status")
+	if err != nil {
+		t.Fatalf("status json: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if payload["running"] != true {
+		t.Fatalf("expected running true in json, got %v", payload["running"])
+	}
+
+	if _, err := executeCLICommand(t, "synchronization", "stop"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
 }

--- a/cli/system_health_logging_test.go
+++ b/cli/system_health_logging_test.go
@@ -1,7 +1,32 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func TestSystemhealthloggingPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	"synnergy/core"
+)
+
+func TestSystemHealthLoggingCommands(t *testing.T) {
+	sysLogger = core.NewSystemHealthLogger()
+	sysLogs = nil
+	t.Cleanup(func() {
+		sysLogger = core.NewSystemHealthLogger()
+		sysLogs = nil
+	})
+
+	out, err := executeCLICommand(t, "system_health", "snapshot")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if !strings.Contains(out, "\"CPUUsage\"") {
+		t.Fatalf("expected CPUUsage in output, got %q", out)
+	}
+
+	if _, err := executeCLICommand(t, "system_health", "log", "warn", "check"); err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	if len(sysLogs) != 1 || sysLogs[0] != "warn: check" {
+		t.Fatalf("unexpected sysLogs: %v", sysLogs)
+	}
 }

--- a/cmd/watchtower/main_test.go
+++ b/cmd/watchtower/main_test.go
@@ -1,7 +1,37 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+	"syscall"
+	"testing"
+	"time"
 
-func TestMainPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+	synnergy "synnergy"
+)
+
+func TestRunHandlesSignal(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	node := synnergy.NewWatchtowerNode("test", logger)
+	signals := make(chan os.Signal, 1)
+
+	result := make(chan error, 1)
+	go func() {
+		result <- run(context.Background(), node, logger, signals, 100*time.Millisecond)
+	}()
+
+	signals <- syscall.SIGINT
+
+	if err := <-result; err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	if err := node.Start(context.Background()); err != nil {
+		t.Fatalf("node should restart after run: %v", err)
+	}
+	if err := node.Stop(); err != nil {
+		t.Fatalf("stop after restart: %v", err)
+	}
 }

--- a/tests/formal/contracts_verification_test.go
+++ b/tests/formal/contracts_verification_test.go
@@ -1,7 +1,45 @@
 package formal
 
-import "testing"
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"testing/quick"
+
+	synnergy "synnergy"
+)
+
+type noopVM struct{}
+
+func (noopVM) Execute([]byte, string, []byte, uint64) ([]byte, uint64, error) { return nil, 0, nil }
+func (noopVM) Start() error                                                   { return nil }
+func (noopVM) Stop() error                                                    { return nil }
+func (noopVM) Status() bool                                                   { return true }
 
 func TestContractsFormalVerification(t *testing.T) {
-	t.Skip("formal verification not implemented")
+	vm := noopVM{}
+	cfg := &quick.Config{MaxCount: 50}
+	property := func(data []byte) bool {
+		if len(data) == 0 {
+			return true
+		}
+		reg := synnergy.NewContractRegistry(vm, nil)
+		addr, err := reg.Deploy(data, `{"name":"contract"}`, 1, "owner")
+		if err != nil {
+			return false
+		}
+		sum := sha256.Sum256(data)
+		if addr != hex.EncodeToString(sum[:]) {
+			return false
+		}
+		c, ok := reg.Get(addr)
+		if !ok {
+			return false
+		}
+		return bytes.Equal(c.WASM, data)
+	}
+	if err := quick.Check(property, cfg); err != nil {
+		t.Fatalf("contract registry invariant violated: %v", err)
+	}
 }

--- a/walletserver/main.go
+++ b/walletserver/main.go
@@ -6,14 +6,18 @@ import (
 	"synnergy/internal/log"
 )
 
-func main() {
-	srv := newServer()
-	http.HandleFunc("/health", srv.healthHandler)
-	http.HandleFunc("/wallet/new", srv.newWalletHandler)
+var httpListenAndServe = http.ListenAndServe
 
-	addr := ":8080"
+func run(addr string, srv *server) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", srv.healthHandler)
+	mux.HandleFunc("/wallet/new", srv.newWalletHandler)
 	log.Info("wallet server listening", "addr", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	return httpListenAndServe(addr, mux)
+}
+
+func main() {
+	if err := run(":8080", newServer()); err != nil {
 		log.Error("server shutdown", "err", err)
 	}
 }

--- a/walletserver/main_test.go
+++ b/walletserver/main_test.go
@@ -1,7 +1,63 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
-func TestMainPlaceholder(t *testing.T) {
-	t.Skip("TODO: implement test")
+func TestRunRegistersHandlers(t *testing.T) {
+	oldListen := httpListenAndServe
+	defer func() { httpListenAndServe = oldListen }()
+
+	var capturedAddr string
+	var handler http.Handler
+	httpListenAndServe = func(addr string, h http.Handler) error {
+		capturedAddr = addr
+		handler = h
+		return nil
+	}
+
+	if err := run(":9999", newServer()); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if capturedAddr != ":9999" {
+		t.Fatalf("expected addr :9999, got %s", capturedAddr)
+	}
+	if handler == nil {
+		t.Fatal("expected handler to be registered")
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("health status: %d", rr.Code)
+	}
+	var health map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &health); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if health["status"] != "ok" {
+		t.Fatalf("unexpected health response: %v", health)
+	}
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/wallet/new", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected method not allowed, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/wallet/new", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("wallet new status: %d", rr.Code)
+	}
+	var wallet map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &wallet); err != nil {
+		t.Fatalf("decode wallet: %v", err)
+	}
+	if wallet["address"] == "" {
+		t.Fatalf("expected non-empty address: %v", wallet)
+	}
 }


### PR DESCRIPTION
## Summary
- add a reusable executeCLICommand helper and replace the remaining placeholder CLI tests (plasma management/operations, gateway, optimization, private tx, RPC WebRTC, sidechain ops, synchronization)
- scope the experimental node test under the experimental build tag and implement it along with a property-based formal verification test
- expose run helpers for the watchtower binary and wallet server so their mains can be exercised by real unit tests

## Testing
- go test ./... *(fails: repository currently has numerous pre-existing build errors outside this change, see execution log)*

------
https://chatgpt.com/codex/tasks/task_e_68d15d44bbdc83209a54fab325b18b01